### PR TITLE
fix(ci): stop release-please release PR loops

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -1,0 +1,28 @@
+name: Prerelease PR (premain)
+
+on:
+  push:
+    branches: ["premain"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    # Don't open a "next prerelease" PR while the prerelease commit's workflow is still
+    # building assets and publishing the draft prerelease (immutable releases).
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message || '', 'chore(premain): release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Please (PR only)
+        id: release
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          target-branch: premain
+          config-file: release-please-config.premain.json
+          manifest-file: .release-please-manifest.premain.json
+          skip-github-release: true

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,6 +22,9 @@ jobs:
           target-branch: premain
           config-file: release-please-config.premain.json
           manifest-file: .release-please-manifest.premain.json
+          # Prevent release-please from opening the *next* prerelease PR on release commits.
+          # PR generation runs in prerelease-pr.yml.
+          skip-github-pull-request: true
 
       - name: Checkout (for release assets)
         if: steps.release.outputs.release_created == 'true'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,28 @@
+name: Release PR (main)
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    # Don't open a "next release" PR while the release commit's workflow is still
+    # building assets and publishing the draft release (immutable releases).
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message || '', 'chore(main): release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Please (PR only)
+        id: release
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          target-branch: main
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Prevent release-please from opening the *next* release PR on release commits.
+          # PR generation runs in release-pr.yml.
+          skip-github-pull-request: true
 
       - name: Checkout (for release assets)
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
Stops the release-please “next release PR” loop that happens because this repo uses **draft** GitHub Releases (immutable releases require draft → upload assets → publish).

Changes:
- `.github/workflows/release.yml`: add `skip-github-pull-request: true` so this workflow only publishes releases.
- `.github/workflows/prerelease.yml`: add `skip-github-pull-request: true` so this workflow only publishes prereleases.
- Add `.github/workflows/release-pr.yml`: generates release PRs only (`skip-github-release: true`) and skips release commits (`chore(main): release ...`).
- Add `.github/workflows/prerelease-pr.yml`: generates prerelease PRs only (`skip-github-release: true`) and skips release commits (`chore(premain): release ...`).

Result:
- No more auto-opening a follow-on release PR/version during the same release run.
- Still fully automated release-please PRs + automated GitHub releases with assets + publish-to-immutable.
