### PR TITLE
fix(ci): make release-pr workflows valid

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -14,7 +14,7 @@ jobs:
   release-please:
     # Don't open a "next prerelease" PR while the prerelease commit's workflow is still
     # building assets and publishing the draft prerelease (immutable releases).
-    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message || '', 'chore(premain): release')
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(premain): release')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Release Please (PR only)

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -14,7 +14,7 @@ jobs:
   release-please:
     # Don't open a "next release" PR while the release commit's workflow is still
     # building assets and publishing the draft release (immutable releases).
-    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message || '', 'chore(main): release')
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(main): release')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Release Please (PR only)


### PR DESCRIPTION
Fixes `.github/workflows/release-pr.yml` and `.github/workflows/prerelease-pr.yml` parse errors by switching the job-level `if:` to explicit expression form (`${{ ... }}`) and avoiding null `head_commit` access.

This unblocks release-please PR automation while keeping release publishing in `.github/workflows/release.yml` / `.github/workflows/prerelease.yml`.
