### PR TITLE
fix(ci): prevent release-please PR loops

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -3,6 +3,12 @@ name: Prerelease PR (premain)
 on:
   push:
     branches: ["premain"]
+    paths-ignore:
+      - ".release-please-manifest.premain.json"
+      - "CHANGELOG.md"
+      - "py/src/theorydb_py/version.json"
+      - "ts/package.json"
+      - "ts/package-lock.json"
   workflow_dispatch: {}
 
 permissions:
@@ -12,9 +18,6 @@ permissions:
 
 jobs:
   release-please:
-    # Don't open a "next prerelease" PR while the prerelease commit's workflow is still
-    # building assets and publishing the draft prerelease (immutable releases).
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(premain): release')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Release Please (PR only)

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -3,6 +3,12 @@ name: Release PR (main)
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - ".release-please-manifest.json"
+      - "CHANGELOG.md"
+      - "py/src/theorydb_py/version.json"
+      - "ts/package.json"
+      - "ts/package-lock.json"
   workflow_dispatch: {}
 
 permissions:
@@ -12,9 +18,6 @@ permissions:
 
 jobs:
   release-please:
-    # Don't open a "next release" PR while the release commit's workflow is still
-    # building assets and publishing the draft release (immutable releases).
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(main): release')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Release Please (PR only)


### PR DESCRIPTION
Fixes the PR-only workflows (.github/workflows/release-pr.yml, .github/workflows/prerelease-pr.yml) so they don’t run on release commits.

Approach:
- Use `paths-ignore` to skip commits that touch release-managed files (manifest/changelog + TS/PY version files).
- Remove the job-level `if:` expression that GitHub Actions was rejecting (workflow file parse failure).

This prevents the cascade of follow-on release PRs/versions while we’re publishing draft releases for immutability.
