### PR TITLE
fix: remove unreachable json null branch return

### DIFF
--- a/py/src/theorydb_py/attr_types.py
+++ b/py/src/theorydb_py/attr_types.py
@@ -217,7 +217,6 @@ def _validate_json_value_matches_storage(value: Any, *, storage_type: str, field
     if storage_type == "NULL":
         if value is not None:
             raise ValidationError(f"json field {field_name} requires null")
-        return
 
     if storage_type == "L":
         if not isinstance(value, list):


### PR DESCRIPTION
Addresses github-code-quality review comment on PR #124.

Change:
- remove the unreachable `return` in `_validate_json_value_matches_storage()` for the `"NULL"` storage-type branch

Validation:
- `./py/.venv/bin/pytest py/tests/unit/test_attr_types.py`
- `./py/.venv/bin/ruff check py/src/theorydb_py/attr_types.py py/tests/unit/test_attr_types.py`
- `make lint`