### PR TITLE
docs(theorycloud): align publishable docs with staged subtree layout

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @aron23 @dumpsterfire513
+*       @aron23 @dumpsterfire513 @paytheory

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @aron23 @dumpsterfire513

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ Thumbs.db
 
 # Cursor AI specific
 .cursor/
+.codex/
 
 # Project specific
 /docs/development/notes/

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,15 +2,16 @@
 
 <!-- AI Training: This is the documentation index for TableTheory -->
 
-**New to TableTheory?** Start with the getting-started guide for your language:
-[Go](./getting-started.md) | [TypeScript](../ts/docs/getting-started.md) | [Python](../py/docs/getting-started.md)
+**New to TableTheory?** Start with the [Go getting-started guide](./getting-started.md). TypeScript and Python
+runtime-specific package docs are staged alongside this surface as sibling package entrypoints in the shared
+TheoryCloud TableTheory subtree.
 
 | | |
 |---|---|
-| **API Reference** | [Go](./api-reference.md) &#124; [TypeScript](../ts/docs/api-reference.md) &#124; [Python](../py/docs/api-reference.md) |
-| **Core Guides** | [Core Patterns](./core-patterns.md) &#124; [Testing](./testing-guide.md) &#124; [Troubleshooting](./troubleshooting.md) |
-| **Schema** | [DMS v0.1 Spec](./development/planning/theorydb-spec-dms-v0.1.md) &#124; [Struct Definition Guide](./struct-definition-guide.md) |
-| **CDK** | [CDK Integration](./cdk/README.md) &#124; [Multi-lang Demo](../examples/cdk-multilang/README.md) |
+| **Go Guides** | [Getting Started](./getting-started.md) &#124; [API Reference](./api-reference.md) &#124; [Core Patterns](./core-patterns.md) &#124; [Testing](./testing-guide.md) &#124; [Troubleshooting](./troubleshooting.md) |
+| **Schema** | [Struct Definition Guide](./struct-definition-guide.md) &#124; DMS v0.1 remains a repo-local planning document and is not published to TheoryCloud |
+| **FaceTheory** | [ISR Cache Schema](./facetheory/isr-cache-schema.md) &#124; [ISR Transaction Recipes](./facetheory/isr-transaction-recipes.md) &#124; [TTL Cache Patterns](./facetheory/ttl-cache-patterns.md) &#124; [ISR Idempotency](./facetheory/isr-idempotency.md) |
+| **CDK** | [CDK Integration](./cdk/README.md) |
 | **Migration** | [Migration Guide](./migration-guide.md) |
 
 ---
@@ -22,8 +23,10 @@
 ### Multi-language SDKs
 
 - **Go (this folder):** [Getting Started](./getting-started.md), [Core Patterns](./core-patterns.md), [API Reference](./api-reference.md)
-- **TypeScript:** [ts/docs](../ts/docs/README.md)
-- **Python:** [py/docs](../py/docs/README.md)
+- **TypeScript:** package docs are authored under `ts/docs/` and published as a runtime-specific package surface
+  alongside the canonical Go docs.
+- **Python:** package docs are authored under `py/docs/` and published as a runtime-specific package surface
+  alongside the canonical Go docs.
 
 ### 🚀 Getting Started
 
@@ -37,7 +40,6 @@
 - [FaceTheory ISR Transaction Recipes](./facetheory/isr-transaction-recipes.md) – Correctness-first patterns for publishing metadata under lease
 - [FaceTheory TTL Cache Patterns](./facetheory/ttl-cache-patterns.md) – Freshness vs expiry, TTL lag, and operational guidance for ISR tables
 - [FaceTheory ISR Idempotency Patterns](./facetheory/isr-idempotency.md) – Request-id driven regeneration guidance and replay safety
-- [Development Guidelines](./development-guidelines.md) – Repo-wide coding standards (Go + TS + Python)
 - [Testing Guide](./testing-guide.md) – Repo-wide testing strategy (Go + TS + Python)
 - [Troubleshooting (Go)](./troubleshooting.md) – Go SDK troubleshooting (TypeScript/Python have their own)
 - [Struct Definition Guide (Go)](./struct-definition-guide.md) – Canonical guide for defining DynamoDB models in Go
@@ -53,11 +55,10 @@
 
 - [CDK Integration Guide](./cdk/README.md) – How to define tables in CDK for TableTheory models
 
-### 📝 Development Artifacts
+### 📝 Repo-local Maintainer Artifacts
 
-- [Development Notes](../hgm-infra/planning/theorydb-session-notes-template.md) – Session notes and progress tracking template
-- [Architectural Decisions](./development/decisions/template-decision.md) – Architectural choices and rationale templates
-- [Clarification Requests](./development/clarifications/template-clarification.md) – Templates for documenting questions and ambiguities
+- Planning, decision, and clarification templates live under `docs/development/**` and `hgm-infra/planning/**`.
+- These maintainer artifacts are intentionally excluded from the TheoryCloud user-facing TableTheory subtree.
 
 ## Audience
 
@@ -69,7 +70,8 @@
 
 ## Document Map
 
-- **Start here:** choose your SDK documentation: [Go](./getting-started.md), [TypeScript](../ts/docs/getting-started.md), [Python](../py/docs/getting-started.md).
+- **Start here:** begin with the [Go getting-started guide](./getting-started.md). TypeScript and Python package
+  guides are staged alongside this surface as runtime-specific package entrypoints.
 - **Use [Core Patterns](./core-patterns.md)** for copy-pasteable recipes in Go.
 - **Use [API Reference](./api-reference.md)** when you need detailed signature information for Go public methods.
 - **Use [Troubleshooting](./troubleshooting.md)** when encountering errors like `ValidationException` or `ResourceNotFoundException`.
@@ -84,7 +86,8 @@
 
 ## Contributing
 
-- Follow the conventions in [PAY_THEORY_DOCUMENTATION_GUIDE.md](./PAY_THEORY_DOCUMENTATION_GUIDE.md)
+- Maintainer authoring standards live in repo-local `docs/PAY_THEORY_DOCUMENTATION_GUIDE.md` and are intentionally
+  excluded from the TheoryCloud user-facing surface.
 - Validate examples against live code
 - Include CORRECT/INCORRECT blocks for integration snippets
 - Update troubleshooting alongside code changes

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,10 +4,8 @@
 
 **This document provides the official technical specification for the public **Go** TableTheory interfaces, functions, and types.**
 
-Multi-language API references:
-
-- TypeScript: [TypeScript API Reference](../ts/docs/api-reference.md)
-- Python: [Python API Reference](../py/docs/api-reference.md)
+TypeScript and Python ship their own runtime-specific API references as sibling package surfaces in the shared
+TheoryCloud TableTheory subtree. This page is the Go API reference.
 
 ## Table of Contents
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -2,10 +2,8 @@
 
 This guide documents canonical usage patterns for the **Go** TableTheory SDK, designed to be copy-pasted into your application.
 
-Multi-language core patterns:
-
-- TypeScript: [ts/docs/core-patterns.md](../ts/docs/core-patterns.md)
-- Python: [py/docs/core-patterns.md](../py/docs/core-patterns.md)
+TypeScript and Python ship their own runtime-specific core-pattern guides as sibling package surfaces in the shared
+TheoryCloud TableTheory subtree. This page is the Go patterns guide.
 
 ## Lambda Optimization
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -2,10 +2,8 @@
 
 This guide assists in migrating existing Go applications to use TableTheory, focusing on transitions from raw AWS SDK calls or other ORMs.
 
-Multi-language migration guides:
-
-- TypeScript: [ts/docs/migration-guide.md](../ts/docs/migration-guide.md)
-- Python: [py/docs/migration-guide.md](../py/docs/migration-guide.md)
+TypeScript and Python ship their own runtime-specific migration guides as sibling package surfaces in the shared
+TheoryCloud TableTheory subtree. This page is the Go migration guide.
 
 ## From Raw AWS SDK for Go (v2)
 

--- a/docs/struct-definition-guide.md
+++ b/docs/struct-definition-guide.md
@@ -194,6 +194,8 @@ type User struct {
 
 ## Next references
 
-- `docs/development-guidelines.md` (coding standards and tag expectations)
+- [Documentation Index](./README.md)
 - `docs/core-patterns.md` (canonical usage patterns)
 - `docs/api-reference.md` (full API surface)
+- Repo-local coding standards live in `docs/development-guidelines.md` and are intentionally excluded from the
+  TheoryCloud user-facing surface.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -5,8 +5,8 @@ This guide explains how to write unit and integration tests for applications usi
 ## Quick Links (by SDK)
 
 - Go: this document (mocks in `pkg/mocks`)
-- TypeScript: [TypeScript Testing Guide](../ts/docs/testing-guide.md)
-- Python: [Python Testing Guide](../py/docs/testing-guide.md)
+- TypeScript: runtime-specific testing guide is staged alongside this document in the shared TableTheory subtree
+- Python: runtime-specific testing guide is staged alongside this document in the shared TableTheory subtree
 
 ## Unit Testing with Mocks
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,10 +2,8 @@
 
 This guide provides solutions to common issues with verified fixes, categorized by the type of error you might encounter.
 
-Multi-language troubleshooting:
-
-- TypeScript: [ts/docs/troubleshooting.md](../ts/docs/troubleshooting.md)
-- Python: [py/docs/troubleshooting.md](../py/docs/troubleshooting.md)
+TypeScript and Python ship their own runtime-specific troubleshooting guides as sibling package surfaces in the shared
+TheoryCloud TableTheory subtree. This page is the Go troubleshooting guide.
 
 ## Quick Diagnosis
 

--- a/py/docs/README.md
+++ b/py/docs/README.md
@@ -11,7 +11,6 @@
 ### 📚 Core Documentation
 - [API Reference](./api-reference.md) – Public API (`ModelDefinition`, `Table`, query, batch, transactions, encryption, streams)
 - [Core Patterns](./core-patterns.md) – Canonical recipes (CRUD, pagination, batch, transactions, streams, encryption)
-- [Development Guidelines](./development-guidelines.md) – Python 3.14, mypy/ruff, formatting and typing conventions
 - [Testing Guide](./testing-guide.md) – Unit tests with strict fakes, integration tests with DynamoDB Local
 - [Troubleshooting](./troubleshooting.md) – Verified fixes for common runtime and configuration errors
 - [Migration Guide](./migration-guide.md) – Migrating from raw boto3 DynamoDB usage
@@ -41,6 +40,8 @@
 5. **Machine Parsable** – the YAML triad stays in sync with the code and tests.
 
 ## Contributing
-- Follow the conventions in [Pay Theory Documentation Guide](../../docs/PAY_THEORY_DOCUMENTATION_GUIDE.md).
+- Package maintainer guidance lives in repo-local `py/docs/development-guidelines.md` and is intentionally excluded
+  from the TheoryCloud user-facing surface.
+- Follow the repo-local maintainer standards in `docs/PAY_THEORY_DOCUMENTATION_GUIDE.md`.
 - Update `_concepts.yaml`, `_patterns.yaml`, and `_decisions.yaml` when behavior changes.
 - Keep examples aligned with `py/examples/` and contract tests.

--- a/ts/docs/README.md
+++ b/ts/docs/README.md
@@ -14,7 +14,6 @@
 
 - [API Reference](./api-reference.md) – Public exports (`defineModel`, `TheorydbClient`, queries, transactions, encryption)
 - [Core Patterns](./core-patterns.md) – Canonical recipes (CRUD, query/cursor, batch, transactions, streams, encryption)
-- [Development Guidelines](./development-guidelines.md) – Node.js 24, TypeScript config, linting/formatting conventions
 - [Testing Guide](./testing-guide.md) – Unit tests with `testkit`, integration tests with DynamoDB Local
 - [Troubleshooting](./troubleshooting.md) – Verified fixes for common runtime and configuration errors
 - [Migration Guide](./migration-guide.md) – Migrating from raw AWS SDK v3 usage
@@ -49,6 +48,8 @@
 
 ## Contributing
 
-- Follow the conventions in [Pay Theory Documentation Guide](../../docs/PAY_THEORY_DOCUMENTATION_GUIDE.md).
+- Package maintainer guidance lives in repo-local `ts/docs/development-guidelines.md` and is intentionally excluded
+  from the TheoryCloud user-facing surface.
+- Follow the repo-local maintainer standards in `docs/PAY_THEORY_DOCUMENTATION_GUIDE.md`.
 - Update `_concepts.yaml`, `_patterns.yaml`, and `_decisions.yaml` when behavior changes.
 - Keep examples aligned with `ts/examples/` and contract tests.


### PR DESCRIPTION
## Milestone
`tt-surface-clean` — make the publishable Go/TS/Py docs surface self-contained and free of links to excluded or out-of-bundle content.

## Linear
Project: https://linear.app/theorycloud/project/tt-129-theorycloud-subtree-publishing-for-tabletheory-docs-f89163fc0ae6
Milestone: `tt-surface-clean`
Issue: THE-101

## Affected runtimes
none (docs / CI surface only)

## Contract impact
docs-only

## Backward compatibility
additive

## Tasks
- [x] THE-101 Align publishable docs with the staged subtree contract

## Validation
- [x] `bash scripts/verify-doc-integrity.sh`
- [x] `make test-unit`
- [x] included-doc-link-scan for staged-theorycloud exclusions

## Cross-repo coordination
none
