### PR TITLE
fix(ci): add theorycloud subtree sync and publish commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # TableTheory Makefile
 
-.PHONY: all build test test-unit unit-cover clean lint fmt fmt-check docker-up docker-down docker-clean integration benchmark stress test-all verify-coverage verify-go-modules verify-ci-toolchain verify-planning-docs sec rubric stage-theorycloud-tabletheory-subtree verify-theorycloud-tabletheory-subtree
+.PHONY: all build test test-unit unit-cover clean lint fmt fmt-check docker-up docker-down docker-clean integration benchmark stress test-all verify-coverage verify-go-modules verify-ci-toolchain verify-planning-docs sec rubric stage-theorycloud-tabletheory-subtree verify-theorycloud-tabletheory-subtree sync-theorycloud-tabletheory-subtree trigger-theorycloud-publish
 
 # Variables
 GOMOD := github.com/theory-cloud/tabletheory
@@ -193,6 +193,12 @@ stage-theorycloud-tabletheory-subtree:
 verify-theorycloud-tabletheory-subtree:
 	@bash ./scripts/verify-theorycloud-tabletheory-subtree.sh "$${THEORYCLOUD_TABLETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/theorycloud-tabletheory-source}"
 
+sync-theorycloud-tabletheory-subtree:
+	@bash ./scripts/sync_theorycloud_tabletheory_subtree.sh --output "$${THEORYCLOUD_TABLETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/theorycloud-tabletheory-source}"
+
+trigger-theorycloud-publish:
+	@bash ./scripts/trigger_theorycloud_publish.sh
+
 # Show test coverage in browser
 coverage: test
 	@echo "Generating coverage report..."
@@ -250,6 +256,8 @@ help:
 	@echo "  make rubric      - Run full rubric gate set"
 	@echo "  make stage-theorycloud-tabletheory-subtree - Stage the theorycloud/tabletheory subtree locally"
 	@echo "  make verify-theorycloud-tabletheory-subtree - Verify the staged theorycloud/tabletheory subtree"
+	@echo "  make sync-theorycloud-tabletheory-subtree - Sync the staged theorycloud/tabletheory subtree to the configured stage prefix"
+	@echo "  make trigger-theorycloud-publish - Trigger the shared theorycloud publish endpoint for the configured stage"
 	@echo ""
 	@echo "Docker/DynamoDB:"
 	@echo "  make docker-up   - Start DynamoDB Local"

--- a/scripts/sync_theorycloud_tabletheory_subtree.sh
+++ b/scripts/sync_theorycloud_tabletheory_subtree.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+  cat <<EOF_USAGE
+Usage:
+  bash scripts/sync_theorycloud_tabletheory_subtree.sh [--stage STAGE] [--source-s3-uri URI] [--output DIR]
+
+Environment:
+  THEORYCLOUD_STAGE                           Stage name or branch name. Accepts: lab, live, premain, main
+  THEORYCLOUD_TABLETHEORY_SUBTREE_OUTPUT_DIR  Staging root directory. Default: /tmp/theorycloud-tabletheory-source
+  THEORYCLOUD_TABLETHEORY_SOURCE_S3_URI       Optional override for the subtree destination S3 URI
+  KT_SOURCE_S3_URI                            Alternate override for the subtree destination S3 URI
+  THEORYCLOUD_S3_SYNC_DELETE                  Default: true. When true, prune objects under theorycloud/tabletheory/
+  THEORYCLOUD_S3_SYNC_DRY_RUN                 Default: false. When true, print the sync plan without calling AWS
+EOF_USAGE
+}
+
+fail() {
+  echo "sync-theorycloud-tabletheory-subtree: FAIL ($*)" >&2
+  exit 1
+}
+
+normalize_stage() {
+  local value="${1:-}"
+  value="${value,,}"
+  case "${value}" in
+    lab|live)
+      printf '%s\n' "${value}"
+      ;;
+    premain|refs/heads/premain)
+      printf '%s\n' 'lab'
+      ;;
+    main|refs/heads/main)
+      printf '%s\n' 'live'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+current_ref_name() {
+  if [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    printf '%s\n' "${GITHUB_REF_NAME}"
+    return 0
+  fi
+  if [[ -n "${GITHUB_REF:-}" ]]; then
+    printf '%s\n' "${GITHUB_REF#refs/heads/}"
+    return 0
+  fi
+  git -C "${REPO_ROOT}" branch --show-current 2>/dev/null || true
+}
+
+resolve_stage() {
+  local input="${1:-}"
+  local resolved=""
+
+  if [[ -n "${input}" ]]; then
+    resolved="$(normalize_stage "${input}" || true)"
+    if [[ -z "${resolved}" ]]; then
+      fail "unsupported stage or branch '${input}'; expected lab|live or premain|main"
+    fi
+    printf '%s\n' "${resolved}"
+    return 0
+  fi
+
+  local ref_name
+  ref_name="$(current_ref_name)"
+  resolved="$(normalize_stage "${ref_name}" || true)"
+  if [[ -z "${resolved}" ]]; then
+    fail "unable to resolve stage from current ref '${ref_name:-<empty>}'; set THEORYCLOUD_STAGE to lab|live or run on premain/main"
+  fi
+  printf '%s\n' "${resolved}"
+}
+
+default_source_s3_uri_for_stage() {
+  local stage="$1"
+  case "${stage}" in
+    lab) printf '%s\n' 's3://kt-sources-lab-787107040121/theorycloud/tabletheory/' ;;
+    live) printf '%s\n' 's3://kt-sources-live-787107040121/theorycloud/tabletheory/' ;;
+    *) return 1 ;;
+  esac
+}
+
+require_source_s3_uri() {
+  local value="$1"
+  local label="$2"
+  if [[ -z "${value}" ]]; then
+    fail "missing ${label}"
+  fi
+  if [[ ! "${value}" =~ ^s3://[^/]+/theorycloud/tabletheory/?$ ]]; then
+    fail "${label} must point exactly to s3://<bucket>/theorycloud/tabletheory/: ${value}"
+  fi
+}
+
+STAGE_INPUT="${THEORYCLOUD_STAGE:-}"
+OUTPUT_DIR="${THEORYCLOUD_TABLETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/theorycloud-tabletheory-source}"
+SOURCE_S3_URI="${THEORYCLOUD_TABLETHEORY_SOURCE_S3_URI:-${KT_SOURCE_S3_URI:-}}"
+SYNC_DELETE="${THEORYCLOUD_S3_SYNC_DELETE:-true}"
+SYNC_DRY_RUN="${THEORYCLOUD_S3_SYNC_DRY_RUN:-false}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stage)
+      STAGE_INPUT="$2"
+      shift 2
+      ;;
+    --source-s3-uri)
+      SOURCE_S3_URI="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+STAGE="$(resolve_stage "${STAGE_INPUT}")"
+if [[ -z "${SOURCE_S3_URI}" ]]; then
+  SOURCE_S3_URI="$(default_source_s3_uri_for_stage "${STAGE}" || true)"
+fi
+require_source_s3_uri "${SOURCE_S3_URI}" "THEORYCLOUD_TABLETHEORY_SOURCE_S3_URI"
+SOURCE_S3_URI="${SOURCE_S3_URI%/}/"
+
+bash "${SCRIPT_DIR}/stage_theorycloud_tabletheory_subtree.sh" --output "${OUTPUT_DIR}"
+
+SUBTREE_DIR="${OUTPUT_DIR%/}/tabletheory"
+if [[ ! -d "${SUBTREE_DIR}" ]]; then
+  fail "missing staged subtree at ${SUBTREE_DIR}; staging helper did not produce tabletheory/"
+fi
+if [[ ! -f "${SUBTREE_DIR}/source-manifest.json" ]]; then
+  fail "missing staged provenance manifest at ${SUBTREE_DIR}/source-manifest.json"
+fi
+
+sync_flags=()
+if [[ "${SYNC_DELETE,,}" == "true" ]]; then
+  sync_flags+=(--delete)
+fi
+
+if [[ "${SYNC_DRY_RUN,,}" == "true" ]]; then
+  echo "sync-theorycloud-tabletheory-subtree: DRY RUN"
+  echo "stage=${STAGE}"
+  echo "source=${SUBTREE_DIR}/"
+  echo "destination=${SOURCE_S3_URI}"
+  if [[ "${SYNC_DELETE,,}" == "true" ]]; then
+    echo "delete=true"
+  else
+    echo "delete=false"
+  fi
+  echo "command=aws s3 sync ${SUBTREE_DIR}/ ${SOURCE_S3_URI} ${sync_flags[*]:-}"
+  echo "sync-theorycloud-tabletheory-subtree: PASS (dry-run; target=${SOURCE_S3_URI})"
+  exit 0
+fi
+
+command -v aws >/dev/null 2>&1 || fail "aws CLI is required"
+
+echo "syncing TableTheory subtree to ${SOURCE_S3_URI}"
+if ! aws s3 sync "${SUBTREE_DIR}/" "${SOURCE_S3_URI}" "${sync_flags[@]}"; then
+  fail "aws s3 sync failed for ${SOURCE_S3_URI}"
+fi
+
+echo "sync-theorycloud-tabletheory-subtree: PASS (target=${SOURCE_S3_URI})"

--- a/scripts/trigger_theorycloud_publish.sh
+++ b/scripts/trigger_theorycloud_publish.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+  cat <<EOF_USAGE
+Usage:
+  bash scripts/trigger_theorycloud_publish.sh [--stage STAGE] [--publish-url URL] [--source-revision SHA] [--idempotency-key KEY] [--reason TEXT] [--force]
+
+Environment:
+  THEORYCLOUD_STAGE           Stage name or branch name. Accepts: lab, live, premain, main
+  THEORYCLOUD_PUBLISH_URL     Optional override for the publish endpoint URL
+  KT_PUBLISH_URL              Alternate override for the publish endpoint URL
+  THEORYCLOUD_PUBLISH_DRY_RUN Default: false. When true, print the request instead of invoking KT
+  THEORYCLOUD_PUBLISH_REASON  Default: docs sync complete
+  THEORYCLOUD_PUBLISH_FORCE   Default: false
+  SOURCE_REVISION             Optional source revision override
+  AWS_REGION                  Default: us-east-1
+EOF_USAGE
+}
+
+fail() {
+  echo "trigger-theorycloud-publish: FAIL ($*)" >&2
+  exit 1
+}
+
+normalize_stage() {
+  local value="${1:-}"
+  value="${value,,}"
+  case "${value}" in
+    lab|live)
+      printf '%s\n' "${value}"
+      ;;
+    premain|refs/heads/premain)
+      printf '%s\n' 'lab'
+      ;;
+    main|refs/heads/main)
+      printf '%s\n' 'live'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+current_ref_name() {
+  if [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    printf '%s\n' "${GITHUB_REF_NAME}"
+    return 0
+  fi
+  if [[ -n "${GITHUB_REF:-}" ]]; then
+    printf '%s\n' "${GITHUB_REF#refs/heads/}"
+    return 0
+  fi
+  git -C "${REPO_ROOT}" branch --show-current 2>/dev/null || true
+}
+
+resolve_stage() {
+  local input="${1:-}"
+  local resolved=""
+
+  if [[ -n "${input}" ]]; then
+    resolved="$(normalize_stage "${input}" || true)"
+    if [[ -z "${resolved}" ]]; then
+      fail "unsupported stage or branch '${input}'; expected lab|live or premain|main"
+    fi
+    printf '%s\n' "${resolved}"
+    return 0
+  fi
+
+  local ref_name
+  ref_name="$(current_ref_name)"
+  resolved="$(normalize_stage "${ref_name}" || true)"
+  if [[ -z "${resolved}" ]]; then
+    fail "unable to resolve stage from current ref '${ref_name:-<empty>}'; set THEORYCLOUD_STAGE to lab|live or run on premain/main"
+  fi
+  printf '%s\n' "${resolved}"
+}
+
+default_publish_url_for_stage() {
+  local stage="$1"
+  case "${stage}" in
+    lab) printf '%s\n' 'https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud' ;;
+    live) printf '%s\n' 'https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud' ;;
+    *) return 1 ;;
+  esac
+}
+
+require_publish_url() {
+  local value="$1"
+  if [[ -z "${value}" ]]; then
+    fail "missing THEORYCLOUD_PUBLISH_URL"
+  fi
+  if [[ ! "${value}" =~ ^https://[^[:space:]]+/v1/internal/publish/theorycloud/?$ ]]; then
+    fail "publish URL must point exactly to https://<host>/v1/internal/publish/theorycloud: ${value}"
+  fi
+}
+
+STAGE_INPUT="${THEORYCLOUD_STAGE:-}"
+PUBLISH_URL="${THEORYCLOUD_PUBLISH_URL:-${KT_PUBLISH_URL:-}}"
+SOURCE_REVISION="${SOURCE_REVISION:-}"
+IDEMPOTENCY_KEY=""
+REASON="${THEORYCLOUD_PUBLISH_REASON:-docs sync complete}"
+FORCE="${THEORYCLOUD_PUBLISH_FORCE:-false}"
+PUBLISH_DRY_RUN="${THEORYCLOUD_PUBLISH_DRY_RUN:-false}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stage)
+      STAGE_INPUT="$2"
+      shift 2
+      ;;
+    --publish-url)
+      PUBLISH_URL="$2"
+      shift 2
+      ;;
+    --source-revision)
+      SOURCE_REVISION="$2"
+      shift 2
+      ;;
+    --idempotency-key)
+      IDEMPOTENCY_KEY="$2"
+      shift 2
+      ;;
+    --reason)
+      REASON="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+STAGE="$(resolve_stage "${STAGE_INPUT}")"
+if [[ -z "${PUBLISH_URL}" ]]; then
+  PUBLISH_URL="$(default_publish_url_for_stage "${STAGE}" || true)"
+fi
+PUBLISH_URL="${PUBLISH_URL%/}"
+require_publish_url "${PUBLISH_URL}"
+
+if [[ -z "${SOURCE_REVISION}" ]]; then
+  SOURCE_REVISION="$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || true)"
+fi
+if [[ -z "${SOURCE_REVISION}" ]]; then
+  fail "missing source revision"
+fi
+
+short_sha="${SOURCE_REVISION:0:12}"
+if [[ -z "${IDEMPOTENCY_KEY}" ]]; then
+  if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+    IDEMPOTENCY_KEY="github-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-1}-${short_sha}"
+  else
+    IDEMPOTENCY_KEY="manual-${short_sha}"
+  fi
+fi
+
+PAYLOAD="$(SOURCE_REVISION="${SOURCE_REVISION}" IDEMPOTENCY_KEY="${IDEMPOTENCY_KEY}" REASON="${REASON}" FORCE="${FORCE}" python3 - <<'PY'
+import json
+import os
+
+payload = {
+    'source_revision': os.environ['SOURCE_REVISION'],
+    'idempotency_key': os.environ['IDEMPOTENCY_KEY'],
+    'reason': os.environ['REASON'],
+    'force': os.environ['FORCE'].strip().lower() == 'true',
+}
+print(json.dumps(payload, separators=(',', ':')))
+PY
+)"
+
+if [[ "${PUBLISH_DRY_RUN,,}" == "true" ]]; then
+  echo "trigger-theorycloud-publish: DRY RUN"
+  echo "stage=${STAGE}"
+  echo "url=${PUBLISH_URL}"
+  echo "payload=${PAYLOAD}"
+  echo "command=awscurl --service execute-api --region ${AWS_REGION} -X POST -H content-type:application/json --data ${PAYLOAD} ${PUBLISH_URL}"
+  echo "trigger-theorycloud-publish: PASS (dry-run; url=${PUBLISH_URL})"
+  exit 0
+fi
+
+command -v awscurl >/dev/null 2>&1 || fail "awscurl is required for publish invocation"
+
+response_file="$(mktemp)"
+http_code="$(awscurl --service execute-api --region "${AWS_REGION}" -X POST -H 'content-type: application/json' --data "${PAYLOAD}" -o "${response_file}" -w '%{http_code}' "${PUBLISH_URL}")" || {
+  status=$?
+  rm -f "${response_file}"
+  fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status})"
+}
+
+if [[ ! "${http_code}" =~ ^2 ]]; then
+  body="$(cat "${response_file}")"
+  rm -f "${response_file}"
+  fail "publish returned HTTP ${http_code}: ${body}"
+fi
+
+body="$(cat "${response_file}")"
+rm -f "${response_file}"
+echo "trigger-theorycloud-publish: PASS (url=${PUBLISH_URL}; http=${http_code})"
+printf '%s\n' "${body}"


### PR DESCRIPTION
## Milestone
tt-subtree-sync — add stage-aware subtree sync and shared publish trigger commands

## Linear
TT-129 TheoryCloud subtree publishing for TableTheory docs / THE-104

## Affected runtimes
none (docs / CI only)

## Contract impact
internal only; no contract scenarios or DMS changes

## Backward compatibility
additive

## Tasks
- [x] THE-104 Add stage-aware subtree sync and shared publish trigger commands

## Validation
- `bash -n scripts/sync_theorycloud_tabletheory_subtree.sh scripts/trigger_theorycloud_publish.sh`
- `THEORYCLOUD_STAGE=lab THEORYCLOUD_S3_SYNC_DRY_RUN=true bash scripts/sync_theorycloud_tabletheory_subtree.sh`
- `THEORYCLOUD_S3_SYNC_DRY_RUN=true bash scripts/sync_theorycloud_tabletheory_subtree.sh --stage premain`
- `THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --stage main --source-revision abc123def456 --idempotency-key test-live`
- `GITHUB_REF_NAME=main THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --source-revision abc123def456 --idempotency-key test-ref`
- `bash scripts/trigger_theorycloud_publish.sh --help`
- `make test-unit`
- `make rubric`

## Cross-repo coordination
none for this milestone; workflow wiring and stage-specific IAM/vars remain in THE-105
