### PR TITLE
fix(ci): automate theorycloud subtree publishing for tabletheory

### DIFF
--- a/.github/workflows/theorycloud-tabletheory-publish.yml
+++ b/.github/workflows/theorycloud-tabletheory-publish.yml
@@ -1,0 +1,126 @@
+name: TableTheory TheoryCloud subtree publish
+
+on:
+  push:
+    branches:
+      - premain
+      - main
+    paths:
+      - "docs/README.md"
+      - "docs/_concepts.yaml"
+      - "docs/_decisions.yaml"
+      - "docs/_patterns.yaml"
+      - "docs/api-reference.md"
+      - "docs/architecture-patterns.md"
+      - "docs/core-patterns.md"
+      - "docs/getting-started.md"
+      - "docs/migration-guide.md"
+      - "docs/struct-definition-guide.md"
+      - "docs/testing-guide.md"
+      - "docs/troubleshooting.md"
+      - "docs/cdk/**"
+      - "docs/facetheory/**"
+      - "docs/llm-faq/**"
+      - "ts/docs/README.md"
+      - "ts/docs/_concepts.yaml"
+      - "ts/docs/_decisions.yaml"
+      - "ts/docs/_patterns.yaml"
+      - "ts/docs/api-reference.md"
+      - "ts/docs/core-patterns.md"
+      - "ts/docs/getting-started.md"
+      - "ts/docs/migration-guide.md"
+      - "ts/docs/testing-guide.md"
+      - "ts/docs/troubleshooting.md"
+      - "py/docs/README.md"
+      - "py/docs/_concepts.yaml"
+      - "py/docs/_decisions.yaml"
+      - "py/docs/_patterns.yaml"
+      - "py/docs/api-reference.md"
+      - "py/docs/core-patterns.md"
+      - "py/docs/getting-started.md"
+      - "py/docs/migration-guide.md"
+      - "py/docs/testing-guide.md"
+      - "py/docs/troubleshooting.md"
+      - "scripts/stage_theorycloud_tabletheory_subtree.sh"
+      - "scripts/verify-theorycloud-tabletheory-subtree.sh"
+      - "scripts/sync_theorycloud_tabletheory_subtree.sh"
+      - "scripts/trigger_theorycloud_publish.sh"
+      - ".github/workflows/theorycloud-tabletheory-publish.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: tabletheory-theorycloud-subtree-publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      THEORYCLOUD_STAGE: ${{ github.ref_name == 'premain' && 'lab' || github.ref_name == 'main' && 'live' || '' }}
+      AWS_ROLE_ARN: ${{ github.ref_name == 'premain' && vars.THEORYCLOUD_AWS_ROLE_ARN_LAB || github.ref_name == 'main' && vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE || '' }}
+      THEORYCLOUD_TABLETHEORY_SUBTREE_OUTPUT_DIR: /tmp/theorycloud-tabletheory-source
+      THEORYCLOUD_PUBLISH_REASON: ${{ format('github:{0}:{1}', github.repository, github.ref_name) }}
+    steps:
+      - name: Checkout protected branch head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate publish workflow configuration
+        run: |
+          set -euo pipefail
+
+          : "${AWS_REGION:?missing vars.AWS_REGION (or default)}"
+          : "${THEORYCLOUD_STAGE:?missing stage resolution}"
+          : "${AWS_ROLE_ARN:?missing stage-scoped AWS role ARN}"
+
+          case "${THEORYCLOUD_STAGE}" in
+            lab|live) ;;
+            *)
+              echo "unsupported theorycloud stage: ${THEORYCLOUD_STAGE}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Assume stage-scoped theorycloud publish role
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: tabletheory-${{ github.ref_name }}-${{ github.run_id }}
+
+      - name: Install awscurl
+        run: |
+          set -euo pipefail
+
+          python3 -m pip install --user --upgrade pip
+          python3 -m pip install --user awscurl
+          printf '%s\n' "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Verify staged TableTheory subtree contract
+        run: |
+          set -euo pipefail
+
+          bash scripts/verify-theorycloud-tabletheory-subtree.sh "${THEORYCLOUD_TABLETHEORY_SUBTREE_OUTPUT_DIR}"
+
+      - name: Sync TableTheory subtree into shared theorycloud source state
+        run: |
+          set -euo pipefail
+
+          bash scripts/sync_theorycloud_tabletheory_subtree.sh \
+            --stage "${THEORYCLOUD_STAGE}" \
+            --output "${THEORYCLOUD_TABLETHEORY_SUBTREE_OUTPUT_DIR}"
+
+      - name: Trigger shared theorycloud publish
+        env:
+          SOURCE_REVISION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          bash scripts/trigger_theorycloud_publish.sh \
+            --stage "${THEORYCLOUD_STAGE}" \
+            --source-revision "${SOURCE_REVISION}"


### PR DESCRIPTION
## Milestone
tt-postmerge-publish — automate post-merge subtree publishing for TableTheory docs

## Linear
TT-129 TheoryCloud subtree publishing for TableTheory docs / THE-105

## Affected runtimes
none (docs / CI only)

## Contract impact
internal only; no contract scenarios or DMS changes

## Backward compatibility
additive

## Tasks
- [x] THE-105 Automate post-merge subtree publishing for TableTheory docs

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/theorycloud-tabletheory-publish.yml"); puts "yaml: PASS"'`
- `bash scripts/verify-theorycloud-tabletheory-subtree.sh`
- `make test-unit`
- `make rubric`

## Cross-repo coordination
- Requires stage-scoped repo vars `THEORYCLOUD_AWS_ROLE_ARN_LAB` and `THEORYCLOUD_AWS_ROLE_ARN_LIVE`
- Workflow filename `.github/workflows/theorycloud-tabletheory-publish.yml` is load-bearing for OIDC trust pinning
