### PR TITLE
fix(ci): finalize theorycloud publish workflow against KT lab contract

### DIFF
--- a/.github/workflows/theorycloud-tabletheory-publish.yml
+++ b/.github/workflows/theorycloud-tabletheory-publish.yml
@@ -59,9 +59,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      AWS_REGION: us-east-1
       THEORYCLOUD_STAGE: ${{ github.ref_name == 'premain' && 'lab' || github.ref_name == 'main' && 'live' || '' }}
-      AWS_ROLE_ARN: ${{ github.ref_name == 'premain' && vars.THEORYCLOUD_AWS_ROLE_ARN_LAB || github.ref_name == 'main' && vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE || '' }}
+      AWS_ROLE_ARN: ${{ github.ref_name == 'premain' && 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-TableTheory-lab-Publisher' || github.ref_name == 'main' && 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-TableTheory-live-Publisher' || '' }}
       THEORYCLOUD_TABLETHEORY_SUBTREE_OUTPUT_DIR: /tmp/theorycloud-tabletheory-source
       THEORYCLOUD_PUBLISH_REASON: ${{ format('github:{0}:{1}', github.repository, github.ref_name) }}
     steps:
@@ -74,9 +74,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          : "${AWS_REGION:?missing vars.AWS_REGION (or default)}"
+          : "${AWS_REGION:?missing literal AWS_REGION}"
           : "${THEORYCLOUD_STAGE:?missing stage resolution}"
-          : "${AWS_ROLE_ARN:?missing stage-scoped AWS role ARN}"
+          : "${AWS_ROLE_ARN:?missing stage-scoped AWS role ARN literal}"
 
           case "${THEORYCLOUD_STAGE}" in
             lab|live) ;;

--- a/scripts/trigger_theorycloud_publish.sh
+++ b/scripts/trigger_theorycloud_publish.sh
@@ -187,7 +187,7 @@ if [[ "${PUBLISH_DRY_RUN,,}" == "true" ]]; then
   echo "stage=${STAGE}"
   echo "url=${PUBLISH_URL}"
   echo "payload=${PAYLOAD}"
-  echo "command=awscurl --service execute-api --region ${AWS_REGION} -X POST -H content-type:application/json --data ${PAYLOAD} ${PUBLISH_URL}"
+  echo "command=awscurl --service execute-api --region ${AWS_REGION} --fail-with-body -X POST -H content-type:application/json --data ${PAYLOAD} -o <response_file> ${PUBLISH_URL}"
   echo "trigger-theorycloud-publish: PASS (dry-run; url=${PUBLISH_URL})"
   exit 0
 fi
@@ -195,19 +195,17 @@ fi
 command -v awscurl >/dev/null 2>&1 || fail "awscurl is required for publish invocation"
 
 response_file="$(mktemp)"
-http_code="$(awscurl --service execute-api --region "${AWS_REGION}" -X POST -H 'content-type: application/json' --data "${PAYLOAD}" -o "${response_file}" -w '%{http_code}' "${PUBLISH_URL}")" || {
+if ! awscurl --service execute-api --region "${AWS_REGION}" --fail-with-body -X POST -H 'content-type: application/json' --data "${PAYLOAD}" -o "${response_file}" "${PUBLISH_URL}" >/dev/null; then
   status=$?
+  body="$(cat "${response_file}" 2>/dev/null || true)"
   rm -f "${response_file}"
-  fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status})"
-}
-
-if [[ ! "${http_code}" =~ ^2 ]]; then
-  body="$(cat "${response_file}")"
-  rm -f "${response_file}"
-  fail "publish returned HTTP ${http_code}: ${body}"
+  if [[ -n "${body}" ]]; then
+    fail "publish invocation failed for ${PUBLISH_URL} (exit ${status}): ${body}"
+  fi
+  fail "publish invocation failed for ${PUBLISH_URL} (exit ${status})"
 fi
 
 body="$(cat "${response_file}")"
 rm -f "${response_file}"
-echo "trigger-theorycloud-publish: PASS (url=${PUBLISH_URL}; http=${http_code})"
+echo "trigger-theorycloud-publish: PASS (url=${PUBLISH_URL})"
 printf '%s\n' "${body}"


### PR DESCRIPTION
## Summary
- switch the TheoryCloud subtree publish workflow to the settled KT no-vars contract
- encode the stable TableTheory lab/live publisher role ARNs directly in the workflow
- make the shared publish helper awscurl-compatible by removing curl-only `-w` usage and using `--fail-with-body`
- keep the post-merge protected-branch push trigger and existing subtree-only sync/publish flow intact

## Issue
Closes #135

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/theorycloud-tabletheory-publish.yml"); puts "yaml: PASS"'`
- `rg -n "THEORYCLOUD_AWS_ROLE_ARN_LAB|THEORYCLOUD_AWS_ROLE_ARN_LIVE|vars\\.THEORYCLOUD_AWS_ROLE_ARN|vars\\.AWS_REGION" .github/workflows/theorycloud-tabletheory-publish.yml || true`
- `bash -n scripts/trigger_theorycloud_publish.sh`
- `THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --stage lab --source-revision abc123def456 --idempotency-key test-lab`
- `bash scripts/verify-theorycloud-tabletheory-subtree.sh`
- `make rubric`

## Note
A real lab run still depends on promoting `staging -> premain`, because the workflow only executes on post-merge pushes to `premain` and `main`.
