### PR TITLE
[codex] fix(go): harden named updates and grouped filters

### DIFF
--- a/contract-tests/runners/ts/package-lock.json
+++ b/contract-tests/runners/ts/package-lock.json
@@ -1109,6 +1109,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
@@ -1752,9 +1764,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -1767,9 +1779,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -1778,9 +1790,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -1830,9 +1843,9 @@
       "license": "MIT"
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -1855,9 +1868,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/contract-tests/runners/ts/package.json
+++ b/contract-tests/runners/ts/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-dynamodb": "^3.1002.0"
   },
   "overrides": {
-    "fast-xml-parser": "^5.5.7"
+    "fast-xml-parser": "5.7.1"
   },
   "devDependencies": {
     "tsx": "^4.21.0",

--- a/internal/expr/builder.go
+++ b/internal/expr/builder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -206,20 +207,90 @@ func (b *Builder) AddFilterCondition(logicalOp, field, operator string, value an
 
 // AddGroupFilter adds a grouped filter expression
 func (b *Builder) AddGroupFilter(logicalOp string, components ExpressionComponents) {
+	nameRemaps := make(map[string]string)
 	for ph, name := range components.ExpressionAttributeNames {
-		b.names[ph] = name
+		targetPlaceholder := ph
+		if existingName, exists := b.names[ph]; exists && existingName != name {
+			targetPlaceholder = b.newNamePlaceholder()
+			nameRemaps[ph] = targetPlaceholder
+		}
+		b.names[targetPlaceholder] = name
 	}
+
+	valueRemaps := make(map[string]string)
 	for ph, val := range components.ExpressionAttributeValues {
-		b.values[ph] = val
+		targetPlaceholder := ph
+		if _, exists := b.values[ph]; exists {
+			targetPlaceholder = b.newValuePlaceholder()
+			valueRemaps[ph] = targetPlaceholder
+		}
+		b.values[targetPlaceholder] = val
 	}
 
 	if components.FilterExpression != "" {
-		groupExpr := "(" + components.FilterExpression + ")"
+		groupExpr := components.FilterExpression
+		if len(nameRemaps) > 0 || len(valueRemaps) > 0 {
+			groupExpr = remapPlaceholders(groupExpr, nameRemaps, valueRemaps)
+		}
+		groupExpr = "(" + groupExpr + ")"
 		b.filterConditions = append(b.filterConditions, groupExpr)
 		if len(b.filterConditions) > 1 {
 			b.filterOperators = append(b.filterOperators, logicalOp)
 		}
 	}
+}
+
+func (b *Builder) newNamePlaceholder() string {
+	for {
+		b.nameCounter++
+		placeholder := fmt.Sprintf("#n%d", b.nameCounter)
+		if _, exists := b.names[placeholder]; !exists {
+			return placeholder
+		}
+	}
+}
+
+func (b *Builder) newValuePlaceholder() string {
+	for {
+		b.valueCounter++
+		placeholder := fmt.Sprintf(":v%d", b.valueCounter)
+		if _, exists := b.values[placeholder]; !exists {
+			return placeholder
+		}
+	}
+}
+
+func remapPlaceholders(expr string, nameRemaps, valueRemaps map[string]string) string {
+	if expr == "" {
+		return ""
+	}
+
+	type replacement struct {
+		from string
+		to   string
+	}
+
+	replacements := make([]replacement, 0, len(nameRemaps)+len(valueRemaps))
+	for from, to := range nameRemaps {
+		replacements = append(replacements, replacement{from: from, to: to})
+	}
+	for from, to := range valueRemaps {
+		replacements = append(replacements, replacement{from: from, to: to})
+	}
+
+	slices.SortFunc(replacements, func(a, b replacement) int {
+		if len(a.from) == len(b.from) {
+			return strings.Compare(a.from, b.from)
+		}
+		return len(b.from) - len(a.from)
+	})
+
+	replacementPairs := make([]string, 0, len(replacements)*2)
+	for _, replacement := range replacements {
+		replacementPairs = append(replacementPairs, replacement.from, replacement.to)
+	}
+
+	return strings.NewReplacer(replacementPairs...).Replace(expr)
 }
 
 // AddProjection adds fields to the projection expression
@@ -654,8 +725,7 @@ func (b *Builder) addNameSecure(name string) string {
 				processedParts[i] = placeholder
 			} else {
 				// Use placeholder for consistency and security
-				b.nameCounter++
-				placeholder := fmt.Sprintf("#n%d", b.nameCounter)
+				placeholder := b.newNamePlaceholder()
 				b.names[placeholder] = part
 				processedParts[i] = placeholder
 			}
@@ -673,8 +743,7 @@ func (b *Builder) addNameSecure(name string) string {
 	}
 
 	// Generate new placeholder for non-reserved words (for consistency)
-	b.nameCounter++
-	placeholder := fmt.Sprintf("#n%d", b.nameCounter)
+	placeholder := b.newNamePlaceholder()
 	b.names[placeholder] = name
 	return placeholder
 }
@@ -697,8 +766,7 @@ func (b *Builder) addValueSecure(value any) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("custom converter failed for %T: %w", value, err)
 			}
-			b.valueCounter++
-			placeholder := fmt.Sprintf(":v%d", b.valueCounter)
+			placeholder := b.newValuePlaceholder()
 			b.values[placeholder] = av
 			return placeholder, nil
 		}
@@ -712,8 +780,7 @@ func (b *Builder) addValueSecure(value any) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("flat anonymous-embed encoding failed for %T: %w", value, err)
 			}
-			b.valueCounter++
-			placeholder := fmt.Sprintf(":v%d", b.valueCounter)
+			placeholder := b.newValuePlaceholder()
 			b.values[placeholder] = av
 			return placeholder, nil
 		}
@@ -724,8 +791,7 @@ func (b *Builder) addValueSecure(value any) (string, error) {
 		return "", fmt.Errorf("failed to convert value type %T: %w", value, err)
 	}
 
-	b.valueCounter++
-	placeholder := fmt.Sprintf(":v%d", b.valueCounter)
+	placeholder := b.newValuePlaceholder()
 	b.values[placeholder] = av
 	return placeholder, nil
 }
@@ -902,8 +968,7 @@ func (b *Builder) addValueAsSet(value any) (string, error) {
 		return "", err
 	}
 
-	b.valueCounter++
-	placeholder := fmt.Sprintf(":v%d", b.valueCounter)
+	placeholder := b.newValuePlaceholder()
 	b.values[placeholder] = av
 	return placeholder, nil
 }

--- a/internal/expr/builder_test.go
+++ b/internal/expr/builder_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -389,7 +390,33 @@ func TestAddGroupFilter(t *testing.T) {
 	assert.Contains(t, components.FilterExpression, "(")
 	assert.Contains(t, components.FilterExpression, ")")
 	assert.Contains(t, components.FilterExpression, "#STATUS = :v1")
-	assert.Contains(t, components.FilterExpression, "#n2 = :v2") // verified - corrected placeholder
+	assert.Contains(t, components.FilterExpression, "#n2 = :v4")
+}
+
+func TestAddGroupFilter_DoesNotOverrideExistingPlaceholders(t *testing.T) {
+	mainBuilder := expr.NewBuilder()
+	require.NoError(t, mainBuilder.AddFilterCondition("AND", "tenant_id", "=", "tenant-a"))
+
+	subBuilder := expr.NewBuilder()
+	require.NoError(t, subBuilder.AddFilterCondition("AND", "status", "=", "public"))
+
+	mainBuilder.AddGroupFilter("AND", subBuilder.Build())
+
+	components := mainBuilder.Build()
+
+	assert.Equal(t, "tenant_id", components.ExpressionAttributeNames["#n1"])
+	assert.Equal(t, "status", components.ExpressionAttributeNames["#STATUS"])
+
+	tenantValue, ok := components.ExpressionAttributeValues[":v1"].(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	assert.Equal(t, "tenant-a", tenantValue.Value)
+
+	statusValue, ok := components.ExpressionAttributeValues[":v2"].(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	assert.Equal(t, "public", statusValue.Value)
+
+	assert.Contains(t, components.FilterExpression, "#n1 = :v1")
+	assert.Contains(t, components.FilterExpression, "(#STATUS = :v2)")
 }
 
 func TestConvertToSlice(t *testing.T) {

--- a/internal/theorydb/theorydb_encryption_tag_write_test.go
+++ b/internal/theorydb/theorydb_encryption_tag_write_test.go
@@ -104,6 +104,21 @@ func TestEncryptedTag_WriteTimeEncryption(t *testing.T) {
 		require.Contains(t, envelope, "ct")
 	})
 
+	t.Run("Update rejects modifier lookup names on metadata path", func(t *testing.T) {
+		httpClient.mu.Lock()
+		httpClient.requests = nil
+		httpClient.callCount = make(map[string]int)
+		httpClient.mu.Unlock()
+
+		err := db.Model(&encryptedTagWriteModel{
+			PK:     "pk2b",
+			SK:     "sk2b",
+			Secret: "new-secret",
+		}).Update("encrypted")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field 'encrypted' not found in model metadata")
+	})
+
 	t.Run("UpdateBuilder encrypts expression attribute values", func(t *testing.T) {
 		httpClient.mu.Lock()
 		httpClient.requests = nil

--- a/pkg/query/cov4_query_methods_test.go
+++ b/pkg/query/cov4_query_methods_test.go
@@ -214,6 +214,44 @@ func TestQuery_Update_PromotedAnonymousEmbeddedKeyAndFieldFallback(t *testing.T)
 	require.True(t, foundStatus, "expected status placeholder to be emitted for promoted embedded field")
 }
 
+func TestQuery_Update_UsesCanonicalAttributeNameForTheoryDBModifierLookup(t *testing.T) {
+	type updateItem struct {
+		PK     string `theorydb:"pk"`
+		Secret string `theorydb:"encrypted,attr:secret"`
+	}
+
+	metadata := &cov4Metadata{
+		table: "tbl",
+		pk:    core.KeySchema{PartitionKey: "pk"},
+	}
+
+	executor := &cov4Executor{}
+	item := &updateItem{
+		PK:     "id-1",
+		Secret: "top-secret",
+	}
+
+	q := New(item, metadata, executor)
+
+	require.NoError(t, q.Update("encrypted"))
+	require.NotNil(t, executor.lastUpdate)
+	require.NotEmpty(t, executor.lastUpdate.UpdateExpression)
+
+	foundSecret := false
+	foundEncrypted := false
+	for _, name := range executor.lastUpdate.ExpressionAttributeNames {
+		if name == "secret" {
+			foundSecret = true
+		}
+		if name == "encrypted" {
+			foundEncrypted = true
+		}
+	}
+
+	require.True(t, foundSecret, "expected canonical attribute name to be used for encrypted field")
+	require.False(t, foundEncrypted, "modifier token must not become a DynamoDB attribute name")
+}
+
 func TestQuery_buildUpdateExpressionFromTags_PromotedAnonymousEmbeds_PreservesLegacyContainer(t *testing.T) {
 	type BaseObject struct {
 		ID   string

--- a/pkg/query/cov5_query_methods_test.go
+++ b/pkg/query/cov5_query_methods_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/theory-cloud/tabletheory/pkg/core"
@@ -135,4 +136,35 @@ func TestQuery_OrFilterGroup_CoversGroupedOrFilters_COV5(t *testing.T) {
 
 	var out []struct{}
 	require.NoError(t, q.All(&out))
+}
+
+func TestQuery_FilterGroup_PreservesEarlierFilterPlaceholders_COV5(t *testing.T) {
+	exec := &cov5QueryExecutor{}
+
+	q := New(&struct{}{}, cov5Metadata{
+		table:      "tbl",
+		primaryKey: core.KeySchema{PartitionKey: "pk"},
+	}, exec)
+
+	q.Filter("tenant_id", "=", "tenant-a")
+	q.FilterGroup(func(sub core.Query) {
+		sub.Filter("status", "=", "public")
+	})
+
+	var out []struct{}
+	require.NoError(t, q.All(&out))
+	require.NotNil(t, exec.lastScan)
+	require.Contains(t, exec.lastScan.FilterExpression, "#n1 = :v1")
+	require.Contains(t, exec.lastScan.FilterExpression, "(#STATUS = :v2)")
+
+	require.Equal(t, "tenant_id", exec.lastScan.ExpressionAttributeNames["#n1"])
+	require.Equal(t, "status", exec.lastScan.ExpressionAttributeNames["#STATUS"])
+
+	tenantValue, ok := exec.lastScan.ExpressionAttributeValues[":v1"].(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	require.Equal(t, "tenant-a", tenantValue.Value)
+
+	statusValue, ok := exec.lastScan.ExpressionAttributeValues[":v2"].(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	require.Equal(t, "public", statusValue.Value)
 }

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -1092,7 +1092,8 @@ func (q *Query) buildUpdateExpressionFromNamedFields(builder *expr.Builder, mode
 			}
 			valueToSet = normalized
 		}
-		if err := builder.AddUpdateSet(q.resolveAttributeName(field), valueToSet); err != nil {
+		attrName := q.resolveMatchedFieldAttributeName(fieldStruct)
+		if err := builder.AddUpdateSet(attrName, valueToSet); err != nil {
 			return fmt.Errorf("failed to build update for %s: %w", field, err)
 		}
 	}

--- a/pkg/query/visible_field_helpers.go
+++ b/pkg/query/visible_field_helpers.go
@@ -161,6 +161,37 @@ func appendQueryLookupName(names []string, name string) []string {
 	return append(names, name)
 }
 
+func (q *Query) resolveMatchedFieldAttributeName(field reflect.StructField) string {
+	if q != nil {
+		if meta := q.attributeMetadata(field.Name); meta != nil {
+			if meta.DynamoDBName != "" && meta.DynamoDBName != field.Name {
+				return meta.DynamoDBName
+			}
+			if meta.Name != "" && meta.Name != field.Name {
+				return meta.Name
+			}
+		}
+	}
+
+	if dynamodbName := parseAttributeName(field.Tag.Get("dynamodb")); dynamodbName != "" && dynamodbName != "-" {
+		return dynamodbName
+	}
+
+	for _, token := range strings.Split(field.Tag.Get("theorydb"), ",") {
+		token = strings.TrimSpace(token)
+		if !strings.HasPrefix(token, "attr:") {
+			continue
+		}
+
+		name := strings.TrimSpace(strings.TrimPrefix(token, "attr:"))
+		if name != "" && name != "-" {
+			return name
+		}
+	}
+
+	return field.Name
+}
+
 func normalizeTaggedFieldValue(field reflect.StructField, fieldValue reflect.Value) (any, error) {
 	if !fieldcodec.HasJSONModifier(field.Tag.Get("theorydb")) {
 		return fieldValue.Interface(), nil

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1391,6 +1391,18 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
@@ -2623,9 +2635,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -2638,9 +2650,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -2649,9 +2661,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2997,9 +3010,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -3117,9 +3130,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/ts/package.json
+++ b/ts/package.json
@@ -38,7 +38,7 @@
     "yaml": "^2.8.3"
   },
   "overrides": {
-    "fast-xml-parser": "^5.5.7",
+    "fast-xml-parser": "5.7.1",
     "flatted": "^3.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Milestone
`tt-go-update-filter-hardening` — Canonicalize Go named update attribute resolution and isolate grouped-filter placeholders so query helpers cannot leak encrypted values or rewrite earlier enforced filters.

## Linear
Project: TT-144 Security hardening for encrypted update paths and filter isolation
Milestone: `tt-go-update-filter-hardening`
Issues: THE-391, THE-384, THE-385

## Affected runtimes
Go, with a TypeScript lockfile prerequisite to restore the baseline SEC-2 rubric gate.

## Contract impact
No DMS or contract-test scenario changes. This milestone is additive runtime hardening only.

## Backward compatibility
Additive hardening.

## Tasks
- [x] THE-391 — fix(ts): raise fast-xml-parser override for audit baseline
- [x] THE-384 — fix(go): bind named updates to matched attribute names
- [x] THE-385 — fix(expr): remap grouped filter placeholders on merge

## Validation
Completed during this milestone:
- `go test ./pkg/query ./internal/theorydb`
- `go test ./internal/expr ./pkg/query`
- `make test-unit`
- `cd ts && npm run lint && npm run typecheck && npm run test:unit` (`check` script not defined in `ts/package.json`)
- `bash scripts/sec-npm-audit.sh`
- `make rubric`

## Cross-repo coordination
none
