### PR TITLE
[codex] fix(ts): guard encrypted transaction updates

### DIFF
--- a/pkg/query/cov7_update_builder_ci_test.go
+++ b/pkg/query/cov7_update_builder_ci_test.go
@@ -1,0 +1,118 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+func TestUpdateBuilder_JSONNormalizationErrors_COV7(t *testing.T) {
+	q := &Query{
+		metadata: cov5Metadata{
+			attributes: map[string]*core.AttributeMetadata{
+				"payload": {
+					Name:         "Payload",
+					DynamoDBName: "payload",
+					Tags:         map[string]string{"json": ""},
+				},
+			},
+		},
+	}
+
+	invalidJSONCarrier := make(chan int)
+	tests := []struct {
+		name      string
+		apply     func(*UpdateBuilder)
+		wantError string
+	}{
+		{
+			name: "Set",
+			apply: func(ub *UpdateBuilder) {
+				ub.Set("payload", invalidJSONCarrier)
+			},
+			wantError: "Set(payload)",
+		},
+		{
+			name: "SetIfNotExists",
+			apply: func(ub *UpdateBuilder) {
+				ub.SetIfNotExists("payload", nil, invalidJSONCarrier)
+			},
+			wantError: "SetIfNotExists(payload)",
+		},
+		{
+			name: "AppendToList",
+			apply: func(ub *UpdateBuilder) {
+				ub.AppendToList("payload", invalidJSONCarrier)
+			},
+			wantError: "AppendToList(payload)",
+		},
+		{
+			name: "PrependToList",
+			apply: func(ub *UpdateBuilder) {
+				ub.PrependToList("payload", invalidJSONCarrier)
+			},
+			wantError: "PrependToList(payload)",
+		},
+		{
+			name: "SetListElement",
+			apply: func(ub *UpdateBuilder) {
+				ub.SetListElement("payload", 1, invalidJSONCarrier)
+			},
+			wantError: "SetListElement(payload)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ub := NewUpdateBuilder(q).(*UpdateBuilder)
+			tt.apply(ub)
+			require.Error(t, ub.buildErr)
+			require.Contains(t, ub.buildErr.Error(), tt.wantError)
+		})
+	}
+}
+
+func TestUpdateBuilder_EncryptedConditionGuardsAndVersionField_COV7(t *testing.T) {
+	q := &Query{
+		metadata: cov5Metadata{
+			attributes: map[string]*core.AttributeMetadata{
+				"secret": {
+					Name:         "Secret",
+					DynamoDBName: "secret",
+					Tags:         map[string]string{"encrypted": ""},
+				},
+			},
+			versionField: "Revision",
+		},
+	}
+
+	t.Run("Condition rejects encrypted fields", func(t *testing.T) {
+		ub := NewUpdateBuilder(q).(*UpdateBuilder)
+		ub.Condition("secret", "=", "top-secret")
+
+		require.ErrorIs(t, ub.buildErr, theorydbErrors.ErrEncryptedFieldNotQueryable)
+		require.Contains(t, ub.buildErr.Error(), "Secret")
+	})
+
+	t.Run("OrCondition rejects encrypted fields", func(t *testing.T) {
+		ub := NewUpdateBuilder(q).(*UpdateBuilder)
+		ub.OrCondition("secret", "=", "top-secret")
+
+		require.ErrorIs(t, ub.buildErr, theorydbErrors.ErrEncryptedFieldNotQueryable)
+		require.Contains(t, ub.buildErr.Error(), "Secret")
+	})
+
+	t.Run("ConditionVersion uses metadata version field", func(t *testing.T) {
+		ub := NewUpdateBuilder(q).(*UpdateBuilder)
+		ub.ConditionVersion(7)
+
+		require.NoError(t, ub.buildErr)
+		require.Len(t, ub.conditions, 1)
+		require.Equal(t, "Revision", ub.conditions[0].field)
+		require.Equal(t, "=", ub.conditions[0].operator)
+		require.EqualValues(t, 7, ub.conditions[0].value)
+	})
+}

--- a/ts/docs/api-reference.md
+++ b/ts/docs/api-reference.md
@@ -74,6 +74,10 @@ const next = page.cursor
 - `batchWrite(modelName, { puts, deletes }, options?)`
 - `transactWrite(ops, options?)`
 
+For models with encrypted attributes, transaction `update` actions must use
+`updateFn`. Raw `updateExpression` transaction updates are rejected because they
+would bypass `UpdateBuilder` encryption and validation.
+
 ## Streams
 
 - `unmarshalStreamRecord(model, record, options?)`

--- a/ts/docs/core-patterns.md
+++ b/ts/docs/core-patterns.md
@@ -82,17 +82,18 @@ await db.transactWrite([
     kind: 'update',
     model: 'User',
     key: { PK: 'U#1', SK: 'TX' },
-    updateExpression: 'SET #ws = if_not_exists(#ws, :ws) ADD #count :inc',
-    conditionExpression: 'attribute_not_exists(#count) OR #count < :maxAllowed',
-    expressionAttributeNames: { '#ws': 'WindowStart', '#count': 'Count' },
-    expressionAttributeValues: {
-      ':ws': { S: '2026-01-23T00:00:00Z' },
-      ':inc': { N: '1' },
-      ':maxAllowed': { N: '100' },
+    updateFn: (u) => {
+      u.setIfNotExists('WindowStart', undefined, '2026-01-23T00:00:00Z');
+      u.add('Count', 1);
+      u.conditionNotExists('Count').orCondition('Count', '<', 100);
     },
   },
 ]);
 ```
+
+For models with encrypted attributes, transaction updates **must** use `updateFn`.
+Raw `updateExpression` transaction updates are only supported for models without
+encrypted attributes.
 
 ## Pattern: Streams unmarshalling
 

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -497,6 +497,12 @@ export class TheorydbClient {
             update.ExpressionAttributeNames = built.expressionAttributeNames;
             update.ExpressionAttributeValues = built.expressionAttributeValues;
           } else {
+            if (provider) {
+              throw new TheorydbError(
+                'ErrInvalidModel',
+                `Encrypted transaction updates for model ${model.name} must use updateFn`,
+              );
+            }
             update.UpdateExpression = a.updateExpression;
             update.ConditionExpression = a.conditionExpression;
             update.ExpressionAttributeNames = a.expressionAttributeNames;

--- a/ts/src/transaction.ts
+++ b/ts/src/transaction.ts
@@ -2,6 +2,11 @@ import type { AttributeValue } from '@aws-sdk/client-dynamodb';
 
 import type { UpdateBuilder } from './update-builder.js';
 
+/**
+ * Raw transaction updates bypass UpdateBuilder encryption/validation and are
+ * therefore only valid for models without encrypted attributes. Encrypted
+ * models must use `updateFn`.
+ */
 type TransactUpdateRaw = {
   kind: 'update';
   model: string;

--- a/ts/test/integration/batch-tx.test.ts
+++ b/ts/test/integration/batch-tx.test.ts
@@ -11,6 +11,7 @@ import {
 import { TheorydbClient } from '../../src/client.js';
 import { TheorydbError } from '../../src/errors.js';
 import { defineModel } from '../../src/model.js';
+import { createDeterministicEncryptionProvider } from '../../src/testkit/index.js';
 
 const endpoint = process.env.DYNAMODB_ENDPOINT ?? 'http://localhost:8000';
 const skipIntegration =
@@ -67,7 +68,38 @@ try {
     ],
   });
 
+  const encryptedUser = defineModel({
+    name: 'EncryptedUser',
+    table: { name: 'users_contract' },
+    naming: { convention: 'camelCase' },
+    keys: {
+      partition: { attribute: 'PK', type: 'S' },
+      sort: { attribute: 'SK', type: 'S' },
+    },
+    attributes: [
+      { attribute: 'PK', type: 'S', required: true, roles: ['pk'] },
+      { attribute: 'SK', type: 'S', required: true, roles: ['sk'] },
+      {
+        attribute: 'createdAt',
+        type: 'S',
+        format: 'rfc3339nano',
+        roles: ['created_at'],
+      },
+      {
+        attribute: 'updatedAt',
+        type: 'S',
+        format: 'rfc3339nano',
+        roles: ['updated_at'],
+      },
+      { attribute: 'version', type: 'N', format: 'int', roles: ['version'] },
+      { attribute: 'secret', type: 'S', encryption: { v: 1 }, optional: true },
+    ],
+  });
+
   const theorydb = new TheorydbClient(ddb).register(user);
+  const encryptedTheorydb = new TheorydbClient(ddb, {
+    encryption: createDeterministicEncryptionProvider('integration-seed'),
+  }).register(encryptedUser);
 
   const pk = `USER#batch-${Date.now()}`;
   const keys = [
@@ -131,6 +163,44 @@ try {
       ]),
     (err) => err instanceof TheorydbError && err.code === 'ErrConditionFailed',
   );
+
+  const encryptedKey = { PK: `${pk}#enc`, SK: 'PROFILE' };
+  await encryptedTheorydb.create('EncryptedUser', {
+    ...encryptedKey,
+    secret: 'before',
+  });
+
+  await assert.rejects(
+    () =>
+      encryptedTheorydb.transactWrite([
+        {
+          kind: 'update',
+          model: 'EncryptedUser',
+          key: encryptedKey,
+          updateExpression: 'SET #secret = :secret',
+          expressionAttributeNames: { '#secret': 'secret' },
+          expressionAttributeValues: { ':secret': { S: 'plaintext' } },
+        },
+      ]),
+    (err) => err instanceof TheorydbError && err.code === 'ErrInvalidModel',
+  );
+
+  await encryptedTheorydb.transactWrite([
+    {
+      kind: 'update',
+      model: 'EncryptedUser',
+      key: encryptedKey,
+      updateFn: (u) => {
+        u.set('secret', 'after');
+      },
+    },
+  ]);
+
+  const encryptedGot = await encryptedTheorydb.get(
+    'EncryptedUser',
+    encryptedKey,
+  );
+  assert.equal(encryptedGot.secret, 'after');
 } finally {
   ddb.destroy();
 }

--- a/ts/test/unit/client.test.ts
+++ b/ts/test/unit/client.test.ts
@@ -17,6 +17,7 @@ import {
 import { TheorydbClient } from '../../src/client.js';
 import { TheorydbError } from '../../src/errors.js';
 import { defineModel } from '../../src/model.js';
+import { createDeterministicEncryptionProvider } from '../../src/testkit/index.js';
 import type { TransactAction } from '../../src/transaction.js';
 
 const User = defineModel({
@@ -33,6 +34,20 @@ const User = defineModel({
     { attribute: 'createdAt', type: 'S', roles: ['created_at'] },
     { attribute: 'updatedAt', type: 'S', roles: ['updated_at'] },
     { attribute: 'version', type: 'N', roles: ['version'] },
+  ],
+});
+
+const EncryptedUser = defineModel({
+  name: 'EncryptedUser',
+  table: { name: 'users_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort: { attribute: 'SK', type: 'S' },
+  },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'SK', type: 'S', roles: ['sk'] },
+    { attribute: 'secret', type: 'S', encryption: { v: 1 } },
   ],
 });
 
@@ -303,6 +318,67 @@ class StubDdb {
   assert.ok(update?.UpdateExpression?.includes('if_not_exists'));
   assert.ok(update?.ConditionExpression?.includes('attribute_not_exists'));
   assert.ok(update?.ConditionExpression?.includes('<'));
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof TransactWriteItemsCommand) return {};
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient, {
+    encryption: createDeterministicEncryptionProvider('seed'),
+  }).register(EncryptedUser);
+
+  await assert.rejects(
+    () =>
+      client.transactWrite([
+        {
+          kind: 'update',
+          model: 'EncryptedUser',
+          key: { PK: 'A', SK: '1' },
+          updateExpression: 'SET #s = :s',
+          expressionAttributeNames: { '#s': 'secret' },
+          expressionAttributeValues: { ':s': { S: 'plaintext' } },
+        },
+      ]),
+    (e) =>
+      e instanceof TheorydbError &&
+      e.code === 'ErrInvalidModel' &&
+      e.message.includes('must use updateFn'),
+  );
+  assert.equal(ddb.sent.length, 0);
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof TransactWriteItemsCommand) return {};
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient, {
+    encryption: createDeterministicEncryptionProvider('seed'),
+  }).register(EncryptedUser);
+
+  await client.transactWrite([
+    {
+      kind: 'update',
+      model: 'EncryptedUser',
+      key: { PK: 'A', SK: '1' },
+      updateFn: (u) => {
+        u.set('secret', 'cipher-me');
+      },
+    },
+  ]);
+
+  const cmd = ddb.sent[0];
+  assert.ok(cmd instanceof TransactWriteItemsCommand);
+  const update = cmd.input.TransactItems?.[0]?.Update;
+  assert.equal(update?.UpdateExpression, 'SET #u1 = :u1');
+  assert.deepEqual(update?.ExpressionAttributeNames, { '#u1': 'secret' });
+  const encrypted = update?.ExpressionAttributeValues?.[':u1'];
+  assert.ok(encrypted && 'M' in encrypted);
+  assert.ok(encrypted.M?.ct);
+  assert.ok(encrypted.M?.nonce);
+  assert.ok(encrypted.M?.edk);
 }
 
 {


### PR DESCRIPTION
## Milestone
`tt-ts-transaction-update-guardrails` — Reject raw transaction update expressions for encrypted models so transaction writes cannot bypass UpdateBuilder encryption and validation.

## Linear
Project: TT-144 Security hardening for encrypted update paths and filter isolation
Milestone: `tt-ts-transaction-update-guardrails`
Issues: THE-386

## Affected runtimes
TypeScript

## Contract impact
No DMS or contract-test scenario changes. This milestone is additive runtime hardening only.

## Backward compatibility
Behavior tightening. Downstream review is required for encrypted-model callers that currently use raw transaction update expressions.

## Tasks
- [x] THE-386 — fix(ts): reject raw transact updates on encrypted models

## Validation
- `make test-unit` (baseline preflight on `origin/staging` `00e66ae`)
- `cd ts && npm run lint && npm run typecheck && npm run test:unit`
- `cd ts && npx tsx test/integration/batch-tx.test.ts`
- `make rubric`

## Cross-repo coordination
Potential downstream review for consumers using raw transaction update expressions on encrypted models; no in-repo coordinated changes required in this milestone.
