### PR TITLE
fix(marshal): restore anonymous embed custom hook handling

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -203,6 +203,9 @@ Updates specific fields of the item used in `Model()`. If `fields` is empty, upd
 - **Opt-in flat helper writes (Go)**: If you explicitly want flat promoted-field helper encoding, provide
   `Query.WithConverter(pkgtypes.NewConverter().WithFlatAnonymousEmbedEncoding())`. The default helper write shape does
   not change unless you opt in.
+- **Anonymous-embed hook precedence (Go)**: If an anonymous embedded field has a registered custom converter or a
+  `MarshalDynamoDBAttributeValue()` hook, Go helper writes apply that hook to the embedded container before any
+  promoted-field traversal or flat anonymous-embed encoding is considered.
 
 #### `Delete() error`
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -222,6 +222,9 @@ helper decoders looked only for a nested anonymous-container map such as `BaseOb
   resolve promoted fields that live on exported anonymous embedded structs.
 - **Default write compatibility**: Historical helper paths that encoded anonymous embedded structs under a container such as
   `BaseObject` continue to do so by default. This repair does not silently flatten helper write output.
+- **Anonymous-embed hook precedence**: When an anonymous embedded field has a registered custom converter or a
+  `MarshalDynamoDBAttributeValue()` hook, Go helper write paths marshal that embedded container through the hook before
+  any promoted-field traversal or flat anonymous-embed encoding is applied.
 
 ### Opting in to flat helper writes
 

--- a/internal/expr/builder.go
+++ b/internal/expr/builder.go
@@ -771,6 +771,15 @@ func (b *Builder) addValueSecure(value any) (string, error) {
 			return placeholder, nil
 		}
 
+		if av, ok, err := attributeValueFromMarshalerHook(value); ok {
+			if err != nil {
+				return "", fmt.Errorf("custom marshaler failed for %T: %w", value, err)
+			}
+			placeholder := b.newValuePlaceholder()
+			b.values[placeholder] = av
+			return placeholder, nil
+		}
+
 		if converterRequestsFlatAnonymousEmbeds(b.converter) {
 			if err := validation.ValidateValue(value); err != nil {
 				return "", fmt.Errorf("security validation failed: %w", err)
@@ -794,6 +803,28 @@ func (b *Builder) addValueSecure(value any) (string, error) {
 	placeholder := b.newValuePlaceholder()
 	b.values[placeholder] = av
 	return placeholder, nil
+}
+
+func attributeValueFromMarshalerHook(value any) (types.AttributeValue, bool, error) {
+	if value == nil {
+		return nil, false, nil
+	}
+
+	if marshaler, ok := value.(Marshaler); ok {
+		av, err := marshaler.MarshalDynamoDBAttributeValue()
+		return av, true, err
+	}
+
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return nil, false, nil
+	}
+	if marshaler, ok := addressableMarshaler(rv); ok {
+		av, err := marshaler.MarshalDynamoDBAttributeValue()
+		return av, true, err
+	}
+
+	return nil, false, nil
 }
 
 // convertToSliceSecure converts various slice types to []any with validation

--- a/internal/expr/converter.go
+++ b/internal/expr/converter.go
@@ -55,6 +55,12 @@ func prepareValueForConversion(v reflect.Value) (reflect.Value, types.AttributeV
 				return reflect.Value{}, av, true, err
 			}
 		}
+		if v.Kind() != reflect.Ptr {
+			if marshaler, ok := addressableMarshaler(v); ok {
+				av, err := marshaler.MarshalDynamoDBAttributeValue()
+				return reflect.Value{}, av, true, err
+			}
+		}
 
 		if v.Kind() != reflect.Interface && v.Kind() != reflect.Ptr {
 			return v, nil, false, nil
@@ -64,6 +70,22 @@ func prepareValueForConversion(v reflect.Value) (reflect.Value, types.AttributeV
 		}
 		v = v.Elem()
 	}
+}
+
+func addressableMarshaler(v reflect.Value) (Marshaler, bool) {
+	if !v.IsValid() || v.Kind() == reflect.Ptr {
+		return nil, false
+	}
+
+	if v.CanAddr() {
+		marshaler, ok := v.Addr().Interface().(Marshaler)
+		return marshaler, ok
+	}
+
+	copyValue := reflect.New(v.Type()).Elem()
+	copyValue.Set(v)
+	marshaler, ok := copyValue.Addr().Interface().(Marshaler)
+	return marshaler, ok
 }
 
 func convertConcreteValueToAttributeValue(v reflect.Value, inheritedConvention naming.Convention, inheritNaming bool, opts ConvertOptions) (types.AttributeValue, error) {
@@ -135,7 +157,7 @@ func convertStructToAttributeValueWithConvention(v reflect.Value, inheritedConve
 	t := v.Type()
 	convention, _ := resolveStructNaming(t, inheritedConvention, inheritNaming)
 
-	fieldPlans, err := reflectutil.BuildVisibleFieldPlan(t, nil)
+	fieldPlans, err := BuildMarshalVisibleFieldPlan(t, nil, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/expr/converter_test.go
+++ b/internal/expr/converter_test.go
@@ -382,6 +382,54 @@ func TestConvertToAttributeValueWithOptions_PromotedAnonymousEmbeds_FlatShape(t 
 	require.ElementsMatch(t, []string{"acct:one", "acct:two"}, exprStringListValues(t, activityAV.Value["to"]))
 }
 
+type ExprHookedSecret struct {
+	Value string
+}
+
+func (s *ExprHookedSecret) MarshalDynamoDBAttributeValue() (types.AttributeValue, error) {
+	return &types.AttributeValueMemberS{Value: "HOOK:" + s.Value}, nil
+}
+
+func TestBuildMarshalVisibleFieldPlan_AnonymousEmbeddedMarshalerFieldIsTerminal(t *testing.T) {
+	//nolint:govet // Field order mirrors the anonymous-embed hook contract under test.
+	type Payload struct {
+		ExprHookedSecret
+		Mode string
+	}
+
+	plans, err := BuildMarshalVisibleFieldPlan(reflect.TypeOf(Payload{}), nil, true)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(plans))
+	for _, plan := range plans {
+		names = append(names, plan.Field.Name)
+	}
+
+	require.Contains(t, names, "ExprHookedSecret")
+	require.Contains(t, names, "Mode")
+	require.NotContains(t, names, "Value")
+}
+
+func TestBuildMarshalVisibleFieldPlan_AnonymousEmbeddedMarshalerFieldIsTerminal_Flat(t *testing.T) {
+	//nolint:govet // Field order mirrors the anonymous-embed hook contract under test.
+	type Payload struct {
+		ExprHookedSecret
+		Mode string
+	}
+
+	plans, err := BuildMarshalVisibleFieldPlan(reflect.TypeOf(Payload{}), nil, true)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(plans))
+	for _, plan := range plans {
+		names = append(names, plan.Field.Name)
+	}
+
+	require.Contains(t, names, "ExprHookedSecret")
+	require.Contains(t, names, "Mode")
+	require.NotContains(t, names, "Value")
+}
+
 func TestConvertFromAttributeValue_PromotedAnonymousEmbeds(t *testing.T) {
 	type BaseObject struct {
 		ID   string

--- a/internal/expr/cov7_add_value_secure_test.go
+++ b/internal/expr/cov7_add_value_secure_test.go
@@ -35,6 +35,14 @@ func (c *cov7Converter) FlatAnonymousEmbedEncodingEnabled() bool {
 
 type cov7CustomType string
 
+type cov7MarshalerValue struct {
+	Value string
+}
+
+func (v cov7MarshalerValue) MarshalDynamoDBAttributeValue() (types.AttributeValue, error) {
+	return &types.AttributeValueMemberS{Value: "HOOK:" + v.Value}, nil
+}
+
 func TestBuilder_addValueSecure_CustomConverterAndValidationPaths_COV7(t *testing.T) {
 	t.Run("CustomConverterSuccess", func(t *testing.T) {
 		converter := &cov7Converter{
@@ -107,6 +115,21 @@ func TestBuilder_addValueSecure_CustomConverterAndValidationPaths_COV7(t *testin
 		require.True(t, converter.toCalled)
 		_, ok := b.values[ref].(*types.AttributeValueMemberM)
 		require.True(t, ok)
+	})
+
+	t.Run("FlatAnonymousEmbedEncodingStillHonorsMarshalerHooks", func(t *testing.T) {
+		converter := &cov7Converter{flat: true}
+		b := NewBuilderWithConverter(converter)
+
+		ref, err := b.addValueSecure(cov7MarshalerValue{Value: "plaintext"})
+		require.NoError(t, err)
+		require.Equal(t, ":v1", ref)
+		require.True(t, converter.hasCalled)
+		require.False(t, converter.toCalled)
+
+		av, ok := b.values[ref].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.Equal(t, "HOOK:plaintext", av.Value)
 	})
 }
 

--- a/internal/expr/marshal_field_plan.go
+++ b/internal/expr/marshal_field_plan.go
@@ -1,0 +1,180 @@
+package expr
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/theory-cloud/tabletheory/internal/reflectutil"
+)
+
+type marshalFieldConverterLookup interface {
+	HasCustomConverter(typ reflect.Type) bool
+}
+
+var marshalerInterfaceType = reflect.TypeOf((*Marshaler)(nil)).Elem()
+
+// BuildMarshalVisibleFieldPlan enumerates the exported fields that helper
+// marshaling should visit for a struct. Unlike reflectutil.BuildVisibleFieldPlan,
+// this helper can preserve anonymous embedded struct containers as terminal
+// fields when they carry custom converter or Marshaler hooks so those hooks run
+// before promoted-field traversal would otherwise bypass them.
+func BuildMarshalVisibleFieldPlan(modelType reflect.Type, converter any, honorMarshalers bool) ([]reflectutil.VisibleFieldPlan, error) {
+	structType, err := resolveMarshalStructType(modelType)
+	if err != nil {
+		return nil, err
+	}
+
+	visibleFields := reflect.VisibleFields(structType)
+	plans := make([]reflectutil.VisibleFieldPlan, 0, len(visibleFields))
+	terminalPrefixes := make([][]int, 0, len(visibleFields))
+
+	for _, field := range visibleFields {
+		if !field.IsExported() {
+			continue
+		}
+		if indexHasTerminalPrefix(field.Index, terminalPrefixes) {
+			continue
+		}
+
+		if isMarshalTerminalAnonymousEmbed(field, converter, honorMarshalers) {
+			plans = append(plans, reflectutil.VisibleFieldPlan{
+				Field:     field,
+				IndexPath: cloneMarshalIndexPath(field.Index),
+			})
+			terminalPrefixes = append(terminalPrefixes, cloneMarshalIndexPath(field.Index))
+			continue
+		}
+
+		if isMarshalAnonymousStructContainer(field) {
+			continue
+		}
+
+		include, err := includeMarshalVisibleField(structType, field.Index)
+		if err != nil {
+			return nil, err
+		}
+		if !include {
+			continue
+		}
+
+		plans = append(plans, reflectutil.VisibleFieldPlan{
+			Field:     field,
+			IndexPath: cloneMarshalIndexPath(field.Index),
+		})
+	}
+
+	return plans, nil
+}
+
+func resolveMarshalStructType(modelType reflect.Type) (reflect.Type, error) {
+	if modelType == nil {
+		return nil, fmt.Errorf("model type cannot be nil")
+	}
+
+	for modelType.Kind() == reflect.Ptr {
+		modelType = modelType.Elem()
+	}
+
+	if modelType.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("model type must be a struct or pointer to struct, got %s", modelType)
+	}
+
+	return modelType, nil
+}
+
+func isMarshalTerminalAnonymousEmbed(field reflect.StructField, converter any, honorMarshalers bool) bool {
+	if !field.Anonymous {
+		return false
+	}
+
+	fieldType := field.Type
+	if fieldType.Kind() == reflect.Ptr {
+		if fieldType.Elem().Kind() != reflect.Struct {
+			return false
+		}
+	} else if fieldType.Kind() != reflect.Struct {
+		return false
+	}
+
+	if honorMarshalers {
+		if fieldType.Implements(marshalerInterfaceType) {
+			return true
+		}
+		if fieldType.Kind() != reflect.Ptr && reflect.PointerTo(fieldType).Implements(marshalerInterfaceType) {
+			return true
+		}
+	}
+
+	lookup, ok := converter.(marshalFieldConverterLookup)
+	if !ok || isNilMarshalFieldLookup(converter) {
+		return false
+	}
+	if lookup.HasCustomConverter(fieldType) {
+		return true
+	}
+	if fieldType.Kind() != reflect.Ptr && lookup.HasCustomConverter(reflect.PointerTo(fieldType)) {
+		return true
+	}
+	return false
+}
+
+func isNilMarshalFieldLookup(converter any) bool {
+	if converter == nil {
+		return true
+	}
+
+	rv := reflect.ValueOf(converter)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+func isMarshalAnonymousStructContainer(field reflect.StructField) bool {
+	return field.Anonymous && field.Type.Kind() == reflect.Struct
+}
+
+func includeMarshalVisibleField(modelType reflect.Type, indexPath []int) (bool, error) {
+	if len(indexPath) <= 1 {
+		return true, nil
+	}
+
+	for depth := 1; depth < len(indexPath); depth++ {
+		containerField := modelType.FieldByIndex(indexPath[:depth])
+		if !containerField.Anonymous {
+			return false, nil
+		}
+		if !containerField.IsExported() {
+			return false, nil
+		}
+		if containerField.Type.Kind() != reflect.Struct {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func indexHasTerminalPrefix(indexPath []int, terminalPrefixes [][]int) bool {
+	for _, prefix := range terminalPrefixes {
+		if len(prefix) == 0 || len(prefix) >= len(indexPath) {
+			continue
+		}
+		if reflect.DeepEqual(indexPath[:len(prefix)], prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneMarshalIndexPath(indexPath []int) []int {
+	if len(indexPath) == 0 {
+		return nil
+	}
+
+	cloned := make([]int, len(indexPath))
+	copy(cloned, indexPath)
+	return cloned
+}

--- a/internal/theorydb/theorydb_custom_converter_update_test.go
+++ b/internal/theorydb/theorydb_custom_converter_update_test.go
@@ -125,6 +125,22 @@ type TestModelWithCustomID struct {
 	CustomID TestCustomID `theorydb:"attr:custom_id"`
 }
 
+// TestAnonymousPayloadEnvelope exercises a nested struct that anonymously embeds
+// a custom-converted type. The nested helper marshaling path must run the
+// embedded converter before promoted-field traversal.
+//
+//nolint:govet // Field order mirrors the anonymous-embed hook contract under test.
+type TestAnonymousPayloadEnvelope struct {
+	TestPayloadJSON
+	Kind string `theorydb:"attr:kind"`
+}
+
+type TestModelWithAnonymousEmbeddedPayload struct {
+	ID      string                       `theorydb:"pk"`
+	Entity  string                       `theorydb:"sk"`
+	Payload TestAnonymousPayloadEnvelope `theorydb:"attr:payload"`
+}
+
 func setupPayloadConverterTestDB(t *testing.T) (*DB, *capturingHTTPClient) {
 	client := newCapturingHTTPClient(nil)
 	stubSessionConfigLoad(t, func(ctx context.Context, opts ...func(*config.LoadOptions) error) (aws.Config, error) {
@@ -564,4 +580,40 @@ func TestCustomConverterRegressionGuard(t *testing.T) {
 		}
 		assert.True(t, found, "Update should marshal custom_id via converter")
 	})
+}
+
+func TestCustomConverter_NestedAnonymousEmbedUsesHook(t *testing.T) {
+	db, _ := setupPayloadConverterTestDB(t)
+
+	record := &TestModelWithAnonymousEmbeddedPayload{
+		ID:     "nested-1",
+		Entity: "PAYLOAD",
+		Payload: TestAnonymousPayloadEnvelope{
+			TestPayloadJSON: TestPayloadJSON{
+				Data: map[string]interface{}{
+					"secret": "plaintext",
+					"count":  2,
+				},
+			},
+			Kind: "task",
+		},
+	}
+
+	require.NoError(t, db.registry.Register(&TestModelWithAnonymousEmbeddedPayload{}))
+	metadata, err := db.registry.GetMetadata(&TestModelWithAnonymousEmbeddedPayload{})
+	require.NoError(t, err)
+
+	item, err := db.marshaler.MarshalItem(record, metadata)
+	require.NoError(t, err)
+
+	payloadAV, ok := item["payload"].(*types.AttributeValueMemberM)
+	require.True(t, ok)
+	require.NotContains(t, payloadAV.Value, "data")
+	kindAV, ok := payloadAV.Value["kind"].(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	require.Equal(t, "task", kindAV.Value)
+
+	embeddedAV, ok := payloadAV.Value["testPayloadJSON"].(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	require.JSONEq(t, mustJSON(t, record.Payload.Data), embeddedAV.Value)
 }

--- a/pkg/marshal/cov7_anonymous_embed_custom_hook_test.go
+++ b/pkg/marshal/cov7_anonymous_embed_custom_hook_test.go
@@ -1,0 +1,73 @@
+package marshal
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+
+	pkgTypes "github.com/theory-cloud/tabletheory/pkg/types"
+)
+
+type Cov7AnonymousEmbedSecret struct {
+	Value string
+}
+
+type cov7AnonymousEmbedSecretConverter struct{}
+
+func (cov7AnonymousEmbedSecretConverter) ToAttributeValue(value any) (types.AttributeValue, error) {
+	secret, ok := value.(Cov7AnonymousEmbedSecret)
+	if !ok {
+		return nil, nil
+	}
+	return &types.AttributeValueMemberS{Value: "HOOK:" + secret.Value}, nil
+}
+
+func (cov7AnonymousEmbedSecretConverter) FromAttributeValue(types.AttributeValue, any) error {
+	return nil
+}
+
+func TestMarshaler_AnonymousEmbeddedCustomConverterUsesHook_COV7(t *testing.T) {
+	//nolint:govet // Field order mirrors the anonymous-embed hook contract under test.
+	type Activity struct {
+		Cov7AnonymousEmbedSecret
+		Actor string
+	}
+
+	converter := pkgTypes.NewConverter()
+	converter.RegisterConverter(reflect.TypeOf(Cov7AnonymousEmbedSecret{}), cov7AnonymousEmbedSecretConverter{})
+
+	av, err := New(converter).marshalStructAsMap(reflect.ValueOf(Activity{
+		Cov7AnonymousEmbedSecret: Cov7AnonymousEmbedSecret{Value: "plaintext"},
+		Actor:                    "acct:actor",
+	}))
+	require.NoError(t, err)
+
+	activityAV := requireAVM(t, av).Value
+	require.Equal(t, "HOOK:plaintext", requireAVS(t, activityAV["cov7AnonymousEmbedSecret"]).Value)
+	require.Equal(t, "acct:actor", requireAVS(t, activityAV["actor"]).Value)
+	require.NotContains(t, activityAV, "value")
+}
+
+func TestSafeMarshaler_AnonymousEmbeddedCustomConverterUsesHook_COV7(t *testing.T) {
+	//nolint:govet // Field order mirrors the anonymous-embed hook contract under test.
+	type Activity struct {
+		Cov7AnonymousEmbedSecret
+		Actor string
+	}
+
+	converter := pkgTypes.NewConverter()
+	converter.RegisterConverter(reflect.TypeOf(Cov7AnonymousEmbedSecret{}), cov7AnonymousEmbedSecretConverter{})
+
+	av, err := NewSafeMarshalerWithConverter(converter).marshalStruct(reflect.ValueOf(Activity{
+		Cov7AnonymousEmbedSecret: Cov7AnonymousEmbedSecret{Value: "plaintext"},
+		Actor:                    "acct:actor",
+	}), &safeFieldMarshaler{})
+	require.NoError(t, err)
+
+	activityAV := requireAVM(t, av).Value
+	require.Equal(t, "HOOK:plaintext", requireAVS(t, activityAV["cov7AnonymousEmbedSecret"]).Value)
+	require.Equal(t, "acct:actor", requireAVS(t, activityAV["actor"]).Value)
+	require.NotContains(t, activityAV, "value")
+}

--- a/pkg/marshal/marshaler.go
+++ b/pkg/marshal/marshaler.go
@@ -523,7 +523,7 @@ func (m *Marshaler) marshalStructComplex(v reflect.Value) (types.AttributeValue,
 func (m *Marshaler) marshalStructAsMap(v reflect.Value) (types.AttributeValue, error) {
 	typ := v.Type()
 	flattenAnonymousEmbeds := converterRequestsFlatAnonymousEmbeds(m.converter)
-	fieldPlans, err := buildMarshalVisibleFieldPlans(typ)
+	fieldPlans, err := buildMarshalVisibleFieldPlans(typ, m.converter)
 	if err != nil {
 		return nil, err
 	}
@@ -563,8 +563,8 @@ func (m *Marshaler) marshalStructAsMap(v reflect.Value) (types.AttributeValue, e
 	return &types.AttributeValueMemberM{Value: structMap}, nil
 }
 
-func buildMarshalVisibleFieldPlans(typ reflect.Type) ([]reflectutil.VisibleFieldPlan, error) {
-	return reflectutil.BuildVisibleFieldPlan(typ, nil)
+func buildMarshalVisibleFieldPlans(typ reflect.Type, converter *pkgTypes.Converter) ([]reflectutil.VisibleFieldPlan, error) {
+	return expr.BuildMarshalVisibleFieldPlan(typ, converter, false)
 }
 
 func resolveMarshalStructFieldName(field reflect.StructField, convention naming.Convention) (string, bool) {

--- a/pkg/marshal/safe_marshaler.go
+++ b/pkg/marshal/safe_marshaler.go
@@ -366,7 +366,7 @@ func (m *SafeMarshaler) marshalStruct(v reflect.Value, fieldMeta *safeFieldMarsh
 	typ := v.Type()
 	convention := resolveNestedNamingConvention(typ, fieldMeta)
 	flattenAnonymousEmbeds := converterRequestsFlatAnonymousEmbeds(m.converter)
-	fieldPlans, err := buildMarshalVisibleFieldPlans(typ)
+	fieldPlans, err := buildMarshalVisibleFieldPlans(typ, m.converter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query/cov7_anonymous_embed_custom_hook_test.go
+++ b/pkg/query/cov7_anonymous_embed_custom_hook_test.go
@@ -1,0 +1,120 @@
+package query
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/internal/expr"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	pkgtypes "github.com/theory-cloud/tabletheory/pkg/types"
+)
+
+type Cov7TaggedSecret struct {
+	Value string
+}
+
+type cov7TaggedSecretConverter struct{}
+
+func (cov7TaggedSecretConverter) ToAttributeValue(value any) (types.AttributeValue, error) {
+	secret, ok := value.(Cov7TaggedSecret)
+	if !ok {
+		return nil, nil
+	}
+	return &types.AttributeValueMemberS{Value: "HOOK:" + secret.Value}, nil
+}
+
+func (cov7TaggedSecretConverter) FromAttributeValue(types.AttributeValue, any) error { return nil }
+
+type Cov7TaggedMarshalerSecret struct {
+	Value string
+}
+
+func (s Cov7TaggedMarshalerSecret) MarshalDynamoDBAttributeValue() (types.AttributeValue, error) {
+	return &types.AttributeValueMemberS{Value: "HOOK:" + s.Value}, nil
+}
+
+func TestQuery_FlatTaggedHelpers_AnonymousEmbeddedCustomConverterWins_COV7(t *testing.T) {
+	//nolint:govet // Field order mirrors the anonymous-embed hook contract under test.
+	type item struct {
+		Cov7TaggedSecret
+		ID     string `theorydb:"pk"`
+		Status string `theorydb:"attr:status"`
+	}
+
+	converter := pkgtypes.NewConverter()
+	converter.RegisterConverter(reflect.TypeOf(Cov7TaggedSecret{}), cov7TaggedSecretConverter{})
+	converter.WithFlatAnonymousEmbedEncoding()
+
+	q := New(&item{}, &cov4Metadata{
+		table: "tbl",
+		pk:    core.KeySchema{PartitionKey: "ID"},
+		attrs: map[string]string{
+			"Status": "status",
+		},
+	}, &cov4Executor{}).WithConverter(converter)
+
+	modelValue := reflect.ValueOf(item{
+		Cov7TaggedSecret: Cov7TaggedSecret{Value: "plaintext"},
+		ID:               "id-1",
+		Status:           "ready",
+	})
+
+	out, err := q.marshalItemTaggedFlat(modelValue)
+	require.NoError(t, err)
+
+	secretAV, ok := out["Cov7TaggedSecret"]
+	require.True(t, ok, "expected anonymous embedded custom converter field to be preserved as a terminal field")
+	secretString, ok := secretAV.(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	require.Equal(t, "HOOK:plaintext", secretString.Value)
+	require.Contains(t, out, "Status")
+	require.NotContains(t, out, "Value")
+
+	builder := expr.NewBuilderWithConverter(q.converter)
+	require.NoError(t, q.buildUpdateExpressionFromTaggedVisibleFields(builder, modelValue, q.metadata.PrimaryKey()))
+
+	components := builder.Build()
+	require.NotEmpty(t, components.UpdateExpression)
+
+	foundHook := false
+	for _, av := range components.ExpressionAttributeValues {
+		if strAV, ok := av.(*types.AttributeValueMemberS); ok && strAV.Value == "HOOK:plaintext" {
+			foundHook = true
+		}
+	}
+	require.True(t, foundHook, "expected update expression values to use the anonymous embedded custom converter output")
+
+	for _, name := range components.ExpressionAttributeNames {
+		require.NotEqual(t, "Value", name)
+	}
+}
+
+func TestQuery_FlatTaggedHelpers_AnonymousEmbeddedMarshalerWins_COV7(t *testing.T) {
+	//nolint:govet // Field order mirrors the anonymous-embed hook contract under test.
+	type item struct {
+		Cov7TaggedMarshalerSecret
+		ID     string `theorydb:"pk"`
+		Status string `theorydb:"attr:status"`
+	}
+
+	converter := pkgtypes.NewConverter().WithFlatAnonymousEmbedEncoding()
+	q := New(&item{}, &cov4Metadata{
+		table: "tbl",
+		pk:    core.KeySchema{PartitionKey: "ID"},
+	}, &cov4Executor{}).WithConverter(converter)
+
+	out, err := q.marshalItemTaggedFlat(reflect.ValueOf(item{
+		Cov7TaggedMarshalerSecret: Cov7TaggedMarshalerSecret{Value: "plaintext"},
+		ID:                        "id-1",
+		Status:                    "ready",
+	}))
+	require.NoError(t, err)
+
+	secretAV, ok := out["Cov7TaggedMarshalerSecret"].(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	require.Equal(t, "HOOK:plaintext", secretAV.Value)
+	require.NotContains(t, out, "Value")
+}

--- a/pkg/query/tagged_encode_helpers.go
+++ b/pkg/query/tagged_encode_helpers.go
@@ -9,12 +9,11 @@ import (
 
 	"github.com/theory-cloud/tabletheory/internal/expr"
 	"github.com/theory-cloud/tabletheory/internal/fieldcodec"
-	"github.com/theory-cloud/tabletheory/internal/reflectutil"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 )
 
 func (q *Query) marshalItemTaggedFlat(modelValue reflect.Value) (map[string]types.AttributeValue, error) {
-	fieldPlans, err := reflectutil.BuildVisibleFieldPlan(modelValue.Type(), nil)
+	fieldPlans, err := expr.BuildMarshalVisibleFieldPlan(modelValue.Type(), q.converter, true)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +49,7 @@ func (q *Query) buildUpdateExpressionFromTaggedVisibleFields(
 	modelValue reflect.Value,
 	primaryKey core.KeySchema,
 ) error {
-	fieldPlans, err := reflectutil.BuildVisibleFieldPlan(modelValue.Type(), nil)
+	fieldPlans, err := expr.BuildMarshalVisibleFieldPlan(modelValue.Type(), q.converter, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/query/visible_field_helpers.go
+++ b/pkg/query/visible_field_helpers.go
@@ -39,6 +39,12 @@ func (q *Query) marshalTaggedFieldAttributeValue(field reflect.StructField, fiel
 			return nil, fmt.Errorf("failed to convert field %s: %w", field.Name, err)
 		}
 		return av, nil
+	case taggedValueUsesExprMarshaler(valueToConvert):
+		av, err := expr.ConvertToAttributeValue(valueToConvert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert field %s: %w", field.Name, err)
+		}
+		return av, nil
 	case q != nil && q.converter != nil:
 		av, err := q.converter.ToAttributeValue(valueToConvert)
 		if err != nil {
@@ -52,6 +58,35 @@ func (q *Query) marshalTaggedFieldAttributeValue(field reflect.StructField, fiel
 		}
 		return av, nil
 	}
+}
+
+func taggedValueUsesExprMarshaler(value any) bool {
+	if value == nil {
+		return false
+	}
+	if _, ok := value.(expr.Marshaler); ok {
+		return true
+	}
+
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return false
+	}
+	if rv.Kind() == reflect.Ptr {
+		return false
+	}
+
+	var candidate reflect.Value
+	if rv.CanAddr() {
+		candidate = rv.Addr()
+	} else {
+		copyValue := reflect.New(rv.Type()).Elem()
+		copyValue.Set(rv)
+		candidate = copyValue.Addr()
+	}
+
+	_, ok := candidate.Interface().(expr.Marshaler)
+	return ok
 }
 
 func (q *Query) findVisibleFieldByNames(modelValue reflect.Value, names ...string) (reflect.Value, reflect.StructField, bool) {


### PR DESCRIPTION
## Milestone
`tt-go-anonymous-embed-hook-restoration` — restore anonymous-embed custom converter and marshaler hook handling before promoted-field traversal in Go marshal / expr / helper write paths.

## Linear
Project: TT-144 Security hardening for encrypted update paths and filter isolation
Issue: THE-388 — https://linear.app/theorycloud/issue/THE-388/fixmarshal-restore-anonymous-embed-custom-hook-handling
Milestone: `tt-go-anonymous-embed-hook-restoration`

## Affected runtimes
- go

## Contract impact
- additive-runtime
- Restores anonymous embedded values that carry custom converters or `MarshalDynamoDBAttributeValue()` hooks as terminal helper-marshaled fields before promoted-field traversal in Go marshal, expr, and tagged helper update paths.

## Backward compatibility
- behavior-restoring
- Preserved-shape note: helper writes now prefer the anonymous embedded field hook output again instead of promoted child fields when a custom converter / marshaler hook is present.

## Tasks
- [x] THE-388 — fix(marshal): restore anonymous embed custom hook handling

## Validation
- [x] `go test ./internal/expr ./pkg/marshal ./pkg/query ./internal/theorydb`
- [x] `make test-unit`
- [x] `make rubric`

## Cross-repo coordination
- none
