### PR TITLE
fix(scripts): reject symlinks in subtree staging

### DIFF
--- a/pkg/query/batch_operations_test.go
+++ b/pkg/query/batch_operations_test.go
@@ -814,62 +814,69 @@ func TestBatchDeleteWithOptions(t *testing.T) {
 }
 
 func TestExecuteBatchesParallel(t *testing.T) {
-	// Test concurrent execution
 	items := make([][]any, 10)
 	for i := 0; i < 10; i++ {
 		items[i] = []any{TestItem{ID: fmt.Sprintf("%d", i)}}
 	}
 
 	var mu sync.Mutex
-	var executionOrder []int
+	const expectedConcurrency = 3
+	currentConcurrency := 0
+	maxConcurrency := 0
+	handlerCalls := 0
+	concurrencyReached := make(chan struct{})
+	releaseHandlers := make(chan struct{})
+	var reachOnce sync.Once
 
 	q := &Query{
 		metadata: &TestMetadata{},
 		ctx:      context.Background(),
-		// Mock the execution to track order
 	}
 
-	// Monkey patch the executeUpdateBatch method for testing
-	// In real tests, we'd use dependency injection
 	processed := 0
 	total := 10
 
 	opts := &BatchUpdateOptions{
 		Parallel:       true,
-		MaxConcurrency: 3,
+		MaxConcurrency: expectedConcurrency,
 		ErrorHandler: func(item any, err error) error {
-			// Track execution order
-			if batch, ok := item.([]any); ok && len(batch) > 0 {
-				if testItem, ok := batch[0].(TestItem); ok {
-					mu.Lock()
-					for i, id := range []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"} {
-						if testItem.ID == id {
-							executionOrder = append(executionOrder, i)
-							break
-						}
-					}
-					mu.Unlock()
+			mu.Lock()
+			handlerCalls++
+			currentConcurrency++
+			if currentConcurrency > maxConcurrency {
+				maxConcurrency = currentConcurrency
+				if maxConcurrency == expectedConcurrency {
+					reachOnce.Do(func() {
+						close(concurrencyReached)
+					})
 				}
 			}
+			mu.Unlock()
+
+			<-releaseHandlers
+
+			mu.Lock()
+			currentConcurrency--
+			mu.Unlock()
 			return nil
 		},
 	}
 
-	err := q.executeBatchesParallel(items, opts, []string{"Name"}, &processed, total)
-	assert.NoError(t, err)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- q.executeBatchesParallel(items, opts, []string{"Name"}, &processed, total)
+	}()
 
-	// Verify all batches were attempted
-	assert.Len(t, executionOrder, 10)
-
-	// Verify they didn't all execute sequentially (some parallelism occurred)
-	// This is a weak test but better than nothing
-	isSequential := true
-	for i := 1; i < len(executionOrder); i++ {
-		if executionOrder[i] < executionOrder[i-1] {
-			isSequential = false
-			break
-		}
+	select {
+	case <-concurrencyReached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for parallel batch handlers to overlap")
 	}
-	// With parallel execution, we expect some out-of-order execution
-	assert.False(t, isSequential, "Expected some parallel execution")
+
+	close(releaseHandlers)
+
+	err := <-errCh
+	assert.NoError(t, err)
+	assert.Equal(t, total, handlerCalls)
+	assert.Equal(t, expectedConcurrency, maxConcurrency, "expected handlers to overlap up to the configured concurrency")
 }

--- a/scripts/stage_theorycloud_tabletheory_subtree.sh
+++ b/scripts/stage_theorycloud_tabletheory_subtree.sh
@@ -123,23 +123,58 @@ def stage_rel_path(stage_prefix: str, rel_path: str) -> str:
     return f"{stage_prefix}/{rel_path}"
 
 
+def resolve_within_repo(repo_root: Path, path: Path, label: str) -> Path:
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError:
+        fail(f"{label} {path} does not exist")
+    except OSError as exc:
+        fail(f"unable to resolve {label} {path}: {exc}")
+
+    try:
+        resolved.relative_to(repo_root)
+    except ValueError:
+        fail(f"{label} {path} resolves outside repo root: {resolved}")
+
+    return resolved
+
+
 def collect_surface(repo_root: Path, root: str, stage_prefix: str, exclusions: tuple[str, ...]) -> tuple[list[tuple[Path, str]], list[str]]:
-    surface_root = (repo_root / root).resolve()
+    surface_root = repo_root / root
     if not surface_root.is_dir():
         fail(f"docs root {surface_root} does not exist")
+    if surface_root.is_symlink():
+        fail(f"docs root {surface_root} must not be a symlink")
+
+    surface_root = resolve_within_repo(repo_root, surface_root, "docs root")
 
     included: list[tuple[Path, str]] = []
     excluded: list[str] = []
 
-    for path in sorted(surface_root.rglob("*")):
-        if not path.is_file():
-            continue
-        rel_path = path.relative_to(surface_root).as_posix()
-        staged_path = stage_rel_path(stage_prefix, rel_path)
-        if is_excluded(rel_path, exclusions):
-            excluded.append(staged_path)
-            continue
-        included.append((path, staged_path))
+    for current_root, dirnames, filenames in os.walk(surface_root, topdown=True, followlinks=False):
+        current_path = Path(current_root)
+
+        safe_dirnames: list[str] = []
+        for dirname in sorted(dirnames):
+            dir_path = current_path / dirname
+            if dir_path.is_symlink():
+                fail(f"symlinked docs input {dir_path.relative_to(repo_root)} is not allowed")
+            resolve_within_repo(repo_root, dir_path, "docs directory")
+            safe_dirnames.append(dirname)
+        dirnames[:] = safe_dirnames
+
+        for filename in sorted(filenames):
+            path = current_path / filename
+            if path.is_symlink():
+                fail(f"symlinked docs input {path.relative_to(repo_root)} is not allowed")
+
+            resolved_path = resolve_within_repo(repo_root, path, "docs input")
+            rel_path = path.relative_to(surface_root).as_posix()
+            staged_path = stage_rel_path(stage_prefix, rel_path)
+            if is_excluded(rel_path, exclusions):
+                excluded.append(staged_path)
+                continue
+            included.append((resolved_path, staged_path))
 
     return included, excluded
 
@@ -200,7 +235,7 @@ def main() -> None:
     for source_path, staged_rel in included:
         destination_path = subtree_root / staged_rel
         destination_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source_path, destination_path)
+        shutil.copy2(source_path, destination_path, follow_symlinks=False)
 
     manifest = OrderedDict(
         [

--- a/scripts/sync_theorycloud_tabletheory_subtree.sh
+++ b/scripts/sync_theorycloud_tabletheory_subtree.sh
@@ -147,6 +147,7 @@ if [[ ! -f "${SUBTREE_DIR}/source-manifest.json" ]]; then
 fi
 
 sync_flags=()
+sync_flags+=(--no-follow-symlinks)
 if [[ "${SYNC_DELETE,,}" == "true" ]]; then
   sync_flags+=(--delete)
 fi

--- a/scripts/verify-theorycloud-tabletheory-subtree.sh
+++ b/scripts/verify-theorycloud-tabletheory-subtree.sh
@@ -149,23 +149,58 @@ def stage_rel_path(stage_prefix: str, rel_path: str) -> str:
     return f"{stage_prefix}/{rel_path}"
 
 
+def resolve_within_repo(repo_root: Path, path: Path, label: str) -> Path:
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError:
+        fail(f"{label} {path} does not exist")
+    except OSError as exc:
+        fail(f"unable to resolve {label} {path}: {exc}")
+
+    try:
+        resolved.relative_to(repo_root)
+    except ValueError:
+        fail(f"{label} {path} resolves outside repo root: {resolved}")
+
+    return resolved
+
+
 def collect_expected(repo_root: Path) -> tuple[list[str], list[str]]:
     included: list[str] = []
     excluded: list[str] = []
 
     for surface in SURFACES:
-        surface_root = (repo_root / surface["root"]).resolve()
+        surface_root = repo_root / surface["root"]
         if not surface_root.is_dir():
             fail(f"missing docs root {surface_root}")
-        for path in sorted(surface_root.rglob("*")):
-            if not path.is_file():
-                continue
-            rel_path = path.relative_to(surface_root).as_posix()
-            staged_rel = stage_rel_path(surface["stage_prefix"], rel_path)
-            if is_excluded(rel_path, surface["exclusions"]):
-                excluded.append(staged_rel)
-            else:
-                included.append(staged_rel)
+        if surface_root.is_symlink():
+            fail(f"docs root {surface_root} must not be a symlink")
+
+        surface_root = resolve_within_repo(repo_root, surface_root, "docs root")
+        for current_root, dirnames, filenames in os.walk(surface_root, topdown=True, followlinks=False):
+            current_path = Path(current_root)
+
+            safe_dirnames: list[str] = []
+            for dirname in sorted(dirnames):
+                dir_path = current_path / dirname
+                if dir_path.is_symlink():
+                    fail(f"symlinked docs input {dir_path.relative_to(repo_root)} is not allowed")
+                resolve_within_repo(repo_root, dir_path, "docs directory")
+                safe_dirnames.append(dirname)
+            dirnames[:] = safe_dirnames
+
+            for filename in sorted(filenames):
+                path = current_path / filename
+                if path.is_symlink():
+                    fail(f"symlinked docs input {path.relative_to(repo_root)} is not allowed")
+
+                resolve_within_repo(repo_root, path, "docs input")
+                rel_path = path.relative_to(surface_root).as_posix()
+                staged_rel = stage_rel_path(surface["stage_prefix"], rel_path)
+                if is_excluded(rel_path, surface["exclusions"]):
+                    excluded.append(staged_rel)
+                else:
+                    included.append(staged_rel)
 
     return sorted(dict.fromkeys(included)), sorted(dict.fromkeys(excluded))
 
@@ -270,6 +305,31 @@ def verify_doc_links(subtree_root: Path) -> None:
                     fail(f"{md.relative_to(subtree_root)} has broken link fragment {raw}")
 
 
+def collect_staged_files(subtree_root: Path) -> list[str]:
+    actual_rel_paths: list[str] = []
+
+    for current_root, dirnames, filenames in os.walk(subtree_root, topdown=True, followlinks=False):
+        current_path = Path(current_root)
+
+        safe_dirnames: list[str] = []
+        for dirname in sorted(dirnames):
+            dir_path = current_path / dirname
+            if dir_path.is_symlink():
+                fail(f"staged subtree contains symlinked directory {dir_path.relative_to(subtree_root)}")
+            safe_dirnames.append(dirname)
+        dirnames[:] = safe_dirnames
+
+        for filename in sorted(filenames):
+            path = current_path / filename
+            if path.is_symlink():
+                fail(f"staged subtree contains symlinked file {path.relative_to(subtree_root)}")
+            if path.name == "source-manifest.json":
+                continue
+            actual_rel_paths.append(path.relative_to(subtree_root).as_posix())
+
+    return sorted(actual_rel_paths)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -301,11 +361,7 @@ def main() -> None:
         fail(f"unexpected docs wrapper at {subtree_root / 'docs'}")
 
     expected_included, expected_excluded = collect_expected(repo_root)
-    actual_rel_paths = sorted(
-        path.relative_to(subtree_root).as_posix()
-        for path in subtree_root.rglob("*")
-        if path.is_file() and path.name != "source-manifest.json"
-    )
+    actual_rel_paths = collect_staged_files(subtree_root)
 
     missing = sorted(set(expected_included) - set(actual_rel_paths))
     extra = sorted(set(actual_rel_paths) - set(expected_included))


### PR DESCRIPTION
## Milestone
`tt-tooling-runtime-cleanup` — fail closed on symlinked subtree staging inputs and close the remaining Python aggregate report as false positive under the supported Python 3.14 toolchain.

## Linear
Project: TT-144 Security hardening for encrypted update paths and filter isolation
Milestone: `tt-tooling-runtime-cleanup`
- THE-389 — https://linear.app/theorycloud/issue/THE-389/fixscripts-reject-symlinks-in-subtree-staging
- THE-390 — https://linear.app/theorycloud/issue/THE-390/fixpy-repair-aggregates-exception-syntax

## Affected runtimes
- none (tooling only)

## Contract impact
- internal
- Hardens the docs subtree staging/sync helpers so symlinked or out-of-repo inputs are rejected before staging and publishing.
- No DMS or cross-runtime contract changes.

## Backward compatibility
- additive hardening
- THE-390 closed as false positive / no-code-change under the supported Python 3.14 toolchain.

## Tasks
- [x] THE-389 — fix(scripts): reject symlinks in subtree staging
- [x] THE-390 — closed as false positive under current Python 3.14 support policy (no code change)

## Validation
- [x] `bash scripts/verify-theorycloud-tabletheory-subtree.sh`
- [x] negative staging check with a temporary symlink under `docs/`
- [x] `make rubric`

## Cross-repo coordination
- none
