### PR TITLE
feat(go): enforce release-state write policies

### DIFF
--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/model"
 	"github.com/theory-cloud/tabletheory/pkg/session"
 )
 
@@ -88,6 +89,7 @@ func (d *TheorydbDriver) Capabilities() []string {
 		"lifecycle.timestamps",
 		"optimistic_lock.version",
 		"ttl.epoch_seconds",
+		"release_state.write_policy",
 	}
 }
 
@@ -172,10 +174,13 @@ func (d *TheorydbDriver) Get(ctx context.Context, model string, key map[string]a
 	}
 }
 
-func (d *TheorydbDriver) Update(ctx context.Context, model string, item map[string]any, fields []string, _ []string) error {
+func (d *TheorydbDriver) Update(ctx context.Context, model string, item map[string]any, fields []string, protectedAttributes []string) error {
 	instance, err := modelFromMap(model, item)
 	if err != nil {
 		return err
+	}
+	if mutatesProtectedAttribute(fields, protectedAttributes) {
+		return fmt.Errorf("%w: per-call protected attribute", theorydbErrors.ErrProtectedFieldMutation)
 	}
 	return d.db.WithContext(ctx).Model(instance).Update(fields...)
 }
@@ -316,6 +321,22 @@ func asInt64(v any) (int64, error) {
 	}
 }
 
+func mutatesProtectedAttribute(fields []string, protectedAttributes []string) bool {
+	if len(fields) == 0 || len(protectedAttributes) == 0 {
+		return false
+	}
+	protected := make(map[string]struct{}, len(protectedAttributes))
+	for _, attr := range protectedAttributes {
+		protected[attr] = struct{}{}
+	}
+	for _, field := range fields {
+		if _, ok := protected[field]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // ---- Models (Go reference) ----
 
 // User matches the v0.1 DMS fixture under `contract-tests/dms/v0.1/models/user.yml`.
@@ -365,6 +386,13 @@ type ReleaseStateActual struct {
 
 func (ReleaseStateActual) TableName() string { return "release_state_contract" }
 
+func (ReleaseStateActual) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{
+		Mode:                model.WritePolicyModeMutable,
+		ProtectedAttributes: []string{"pinnedReleaseId"},
+	}
+}
+
 // ReleaseStateEvent matches the v0.1 release-state event-row DMS fixture.
 type ReleaseStateEvent struct {
 	PK         string         `theorydb:"pk"`
@@ -378,6 +406,10 @@ type ReleaseStateEvent struct {
 }
 
 func (ReleaseStateEvent) TableName() string { return "release_state_contract" }
+
+func (ReleaseStateEvent) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{Mode: model.WritePolicyModeWriteOnce}
+}
 
 func userFromMap(item map[string]any) (*User, error) {
 	u := &User{}

--- a/internal/theorydb/query_support.go
+++ b/internal/theorydb/query_support.go
@@ -253,3 +253,10 @@ func (ma *metadataAdapter) VersionFieldName() string {
 	}
 	return ""
 }
+
+func (ma *metadataAdapter) WritePolicy() model.WritePolicy {
+	if ma == nil || ma.metadata == nil {
+		return model.DefaultWritePolicy()
+	}
+	return ma.metadata.WritePolicy
+}

--- a/internal/theorydb/write_policy_metadata_test.go
+++ b/internal/theorydb/write_policy_metadata_test.go
@@ -1,0 +1,40 @@
+package theorydb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/model"
+)
+
+type writePolicyAdapterModel struct {
+	PK              string `theorydb:"pk"`
+	PinnedReleaseID string `theorydb:"attr:pinnedReleaseId"`
+}
+
+func (writePolicyAdapterModel) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{
+		Mode:                model.WritePolicyModeMutable,
+		ProtectedAttributes: []string{"PinnedReleaseID"},
+	}
+}
+
+func TestWritePolicyMetadataAdapter(t *testing.T) {
+	db := newBareDB()
+	require.NoError(t, db.registry.Register(&writePolicyAdapterModel{}))
+
+	metadata, err := db.registry.GetMetadata(&writePolicyAdapterModel{})
+	require.NoError(t, err)
+
+	adapter := &metadataAdapter{metadata: metadata}
+	require.Equal(t, model.WritePolicy{
+		Mode:                model.WritePolicyModeMutable,
+		ProtectedAttributes: []string{"pinnedReleaseId"},
+	}, adapter.WritePolicy())
+}
+
+func TestWritePolicyMetadataAdapterNilDefaultsMutable(t *testing.T) {
+	adapter := &metadataAdapter{}
+	require.Equal(t, model.DefaultWritePolicy(), adapter.WritePolicy())
+}

--- a/pkg/core/interfaces.go
+++ b/pkg/core/interfaces.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
+	"github.com/theory-cloud/tabletheory/pkg/model"
 	pkgTypes "github.com/theory-cloud/tabletheory/pkg/types"
 )
 
@@ -363,6 +364,14 @@ type ModelMetadata interface {
 	Indexes() []IndexSchema
 	AttributeMetadata(field string) *AttributeMetadata
 	VersionFieldName() string
+}
+
+// WritePolicyProvider is an optional metadata extension for runtimes that
+// expose model-level write policy guardrails. It is intentionally separate
+// from ModelMetadata so existing custom ModelMetadata implementations remain
+// source-compatible.
+type WritePolicyProvider interface {
+	WritePolicy() model.WritePolicy
 }
 
 // KeySchema represents a primary key or index key schema

--- a/pkg/core/interfaces_test.go
+++ b/pkg/core/interfaces_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/theory-cloud/tabletheory/pkg/model"
 )
 
 func mustQuery(v any) Query {
@@ -879,6 +881,17 @@ func TestModelMetadataInterface(t *testing.T) {
 
 		mockMeta.AssertExpectations(t)
 	})
+}
+
+type mockWritePolicyProvider struct{}
+
+func (mockWritePolicyProvider) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{Mode: model.WritePolicyModeWriteOnce}
+}
+
+func TestWritePolicyProviderInterface(t *testing.T) {
+	var provider WritePolicyProvider = mockWritePolicyProvider{}
+	assert.Equal(t, model.WritePolicyModeWriteOnce, provider.WritePolicy().Mode)
 }
 
 // TestDBTransaction tests transaction behavior

--- a/pkg/model/registry.go
+++ b/pkg/model/registry.go
@@ -107,8 +107,8 @@ type Metadata struct {
 	UpdatedAtField   *FieldMetadata
 	TableName        string
 	Indexes          []IndexSchema
-	NamingConvention naming.Convention
 	WritePolicy      WritePolicy
+	NamingConvention naming.Convention
 }
 
 // KeySchema represents a primary key or index key schema

--- a/pkg/model/registry.go
+++ b/pkg/model/registry.go
@@ -4,6 +4,7 @@ package model
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 
@@ -107,6 +108,7 @@ type Metadata struct {
 	TableName        string
 	Indexes          []IndexSchema
 	NamingConvention naming.Convention
+	WritePolicy      WritePolicy
 }
 
 // KeySchema represents a primary key or index key schema
@@ -179,6 +181,10 @@ func parseMetadata(modelType reflect.Type) (*Metadata, error) {
 		return nil, err
 	}
 
+	if err := applyWritePolicy(modelType, metadata); err != nil {
+		return nil, err
+	}
+
 	return metadata, nil
 }
 
@@ -187,10 +193,92 @@ func newMetadata(modelType reflect.Type, tableName string, convention naming.Con
 		Type:             modelType,
 		TableName:        tableName,
 		NamingConvention: convention,
+		WritePolicy:      DefaultWritePolicy(),
 		Fields:           make(map[string]*FieldMetadata),
 		FieldsByDBName:   make(map[string]*FieldMetadata),
 		Indexes:          make([]IndexSchema, 0),
 	}
+}
+
+func applyWritePolicy(modelType reflect.Type, metadata *Metadata) error {
+	policy, ok := writePolicyFromModel(modelType)
+	if !ok {
+		metadata.WritePolicy = DefaultWritePolicy()
+		return nil
+	}
+
+	normalized, err := normalizeWritePolicy(policy, metadata)
+	if err != nil {
+		return err
+	}
+	metadata.WritePolicy = normalized
+	return nil
+}
+
+type writePolicyProvider interface {
+	WritePolicy() WritePolicy
+}
+
+func writePolicyFromModel(modelType reflect.Type) (WritePolicy, bool) {
+	if provider, ok := reflect.New(modelType).Elem().Interface().(writePolicyProvider); ok {
+		return provider.WritePolicy(), true
+	}
+	if provider, ok := reflect.New(modelType).Interface().(writePolicyProvider); ok {
+		return provider.WritePolicy(), true
+	}
+	return WritePolicy{}, false
+}
+
+func normalizeWritePolicy(policy WritePolicy, metadata *Metadata) (WritePolicy, error) {
+	mode := policy.Mode
+	if mode == "" {
+		mode = WritePolicyModeMutable
+	}
+	switch mode {
+	case WritePolicyModeMutable, WritePolicyModeWriteOnce:
+	default:
+		return WritePolicy{}, fmt.Errorf("%w: unsupported write_policy.mode %q", errors.ErrInvalidModel, mode)
+	}
+
+	protected, err := resolveProtectedAttributes(policy.ProtectedAttributes, metadata)
+	if err != nil {
+		return WritePolicy{}, err
+	}
+
+	return WritePolicy{
+		Mode:                mode,
+		ProtectedAttributes: protected,
+	}, nil
+}
+
+func resolveProtectedAttributes(attributes []string, metadata *Metadata) ([]string, error) {
+	if len(attributes) == 0 {
+		return []string{}, nil
+	}
+
+	protected := make(map[string]struct{}, len(attributes))
+	for _, attr := range attributes {
+		attr = strings.TrimSpace(attr)
+		if attr == "" {
+			return nil, fmt.Errorf("%w: write_policy protected attributes must be non-empty", errors.ErrInvalidModel)
+		}
+
+		fieldMeta := metadata.Fields[attr]
+		if fieldMeta == nil {
+			fieldMeta = metadata.FieldsByDBName[attr]
+		}
+		if fieldMeta == nil {
+			return nil, fmt.Errorf("%w: write_policy protected attribute not found: %s", errors.ErrInvalidModel, attr)
+		}
+		protected[fieldMeta.DBName] = struct{}{}
+	}
+
+	resolved := make([]string, 0, len(protected))
+	for attr := range protected {
+		resolved = append(resolved, attr)
+	}
+	sort.Strings(resolved)
+	return resolved, nil
 }
 
 func resolveTableName(modelType reflect.Type) string {

--- a/pkg/model/write_policy.go
+++ b/pkg/model/write_policy.go
@@ -1,0 +1,34 @@
+package model
+
+// WritePolicyMode describes how high-level write APIs may mutate a model.
+type WritePolicyMode string
+
+const (
+	// WritePolicyModeMutable preserves the historical TableTheory behavior:
+	// create, update, upsert, and delete operations are allowed unless other
+	// model metadata or call-level conditions reject them.
+	WritePolicyModeMutable WritePolicyMode = "mutable"
+
+	// WritePolicyModeWriteOnce permits initial creation but rejects generic
+	// high-level mutation APIs such as update, upsert, and delete.
+	WritePolicyModeWriteOnce WritePolicyMode = "write_once"
+)
+
+// WritePolicy declares opt-in model-level mutation guardrails.
+//
+// The zero value is equivalent to Mutable with no protected attributes.
+// ProtectedAttributes are normalized by Metadata parsing to canonical
+// DynamoDB attribute names.
+type WritePolicy struct {
+	Mode                WritePolicyMode
+	ProtectedAttributes []string
+}
+
+// DefaultWritePolicy returns the default mutation policy for models that do
+// not opt into write_policy metadata.
+func DefaultWritePolicy() WritePolicy {
+	return WritePolicy{
+		Mode:                WritePolicyModeMutable,
+		ProtectedAttributes: []string{},
+	}
+}

--- a/pkg/model/write_policy_test.go
+++ b/pkg/model/write_policy_test.go
@@ -1,0 +1,124 @@
+package model
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+type writePolicyDefaultModel struct {
+	PK    string `theorydb:"pk"`
+	SK    string `theorydb:"sk"`
+	Value string
+}
+
+type writePolicyValueReceiverModel struct {
+	PK              string `theorydb:"pk"`
+	SK              string `theorydb:"sk"`
+	PinnedReleaseID string `theorydb:"attr:pinnedReleaseId"`
+	Status          string
+}
+
+func (writePolicyValueReceiverModel) WritePolicy() WritePolicy {
+	return WritePolicy{
+		Mode: WritePolicyModeMutable,
+		ProtectedAttributes: []string{
+			"Status",
+			"pinnedReleaseId",
+			"PinnedReleaseID",
+		},
+	}
+}
+
+type writePolicyPointerReceiverModel struct {
+	PK    string `theorydb:"pk"`
+	SK    string `theorydb:"sk"`
+	Event string
+}
+
+func (*writePolicyPointerReceiverModel) WritePolicy() WritePolicy {
+	return WritePolicy{Mode: WritePolicyModeWriteOnce}
+}
+
+type writePolicyInvalidModeModel struct {
+	PK string `theorydb:"pk"`
+}
+
+func (writePolicyInvalidModeModel) WritePolicy() WritePolicy {
+	return WritePolicy{Mode: WritePolicyMode("frozen")}
+}
+
+type writePolicyMissingProtectedModel struct {
+	PK string `theorydb:"pk"`
+}
+
+func (writePolicyMissingProtectedModel) WritePolicy() WritePolicy {
+	return WritePolicy{ProtectedAttributes: []string{"missing"}}
+}
+
+type writePolicyEmptyProtectedModel struct {
+	PK string `theorydb:"pk"`
+}
+
+func (writePolicyEmptyProtectedModel) WritePolicy() WritePolicy {
+	return WritePolicy{ProtectedAttributes: []string{" "}}
+}
+
+func TestWritePolicyMetadata_DefaultsMutable(t *testing.T) {
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&writePolicyDefaultModel{}))
+
+	metadata, err := registry.GetMetadata(&writePolicyDefaultModel{})
+	require.NoError(t, err)
+	require.Equal(t, WritePolicy{
+		Mode:                WritePolicyModeMutable,
+		ProtectedAttributes: []string{},
+	}, metadata.WritePolicy)
+}
+
+func TestWritePolicyMetadata_ResolvesProtectedAttributesToCanonicalDBNames(t *testing.T) {
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&writePolicyValueReceiverModel{}))
+
+	metadata, err := registry.GetMetadata(&writePolicyValueReceiverModel{})
+	require.NoError(t, err)
+	require.Equal(t, WritePolicyModeMutable, metadata.WritePolicy.Mode)
+	require.Equal(t, []string{"pinnedReleaseId", "status"}, metadata.WritePolicy.ProtectedAttributes)
+}
+
+func TestWritePolicyMetadata_UsesPointerReceiver(t *testing.T) {
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&writePolicyPointerReceiverModel{}))
+
+	metadata, err := registry.GetMetadata(&writePolicyPointerReceiverModel{})
+	require.NoError(t, err)
+	require.Equal(t, WritePolicyModeWriteOnce, metadata.WritePolicy.Mode)
+	require.Equal(t, []string{}, metadata.WritePolicy.ProtectedAttributes)
+}
+
+func TestWritePolicyMetadata_RejectsInvalidMode(t *testing.T) {
+	registry := NewRegistry()
+	err := registry.Register(&writePolicyInvalidModeModel{})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, theorydbErrors.ErrInvalidModel))
+	require.Contains(t, err.Error(), "unsupported write_policy.mode")
+}
+
+func TestWritePolicyMetadata_RejectsMissingProtectedAttribute(t *testing.T) {
+	registry := NewRegistry()
+	err := registry.Register(&writePolicyMissingProtectedModel{})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, theorydbErrors.ErrInvalidModel))
+	require.Contains(t, err.Error(), "write_policy protected attribute not found")
+}
+
+func TestWritePolicyMetadata_RejectsEmptyProtectedAttribute(t *testing.T) {
+	registry := NewRegistry()
+	err := registry.Register(&writePolicyEmptyProtectedModel{})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, theorydbErrors.ErrInvalidModel))
+	require.Contains(t, err.Error(), "write_policy protected attributes must be non-empty")
+}

--- a/pkg/query/batch_operations.go
+++ b/pkg/query/batch_operations.go
@@ -65,6 +65,13 @@ func (q *Query) BatchUpdateWithOptions(items []any, fields []string, options ...
 
 // batchUpdateWithOptionsInternal is the actual implementation with the internal signature
 func (q *Query) batchUpdateWithOptionsInternal(items any, opts *BatchUpdateOptions, fields ...string) error {
+	if err := q.rejectWriteOnceMutation("batch update"); err != nil {
+		return err
+	}
+	if err := q.rejectProtectedFieldMutation(fields, nil); err != nil {
+		return err
+	}
+
 	// Validate input
 	itemsValue := reflect.ValueOf(items)
 	if itemsValue.Kind() != reflect.Slice {
@@ -97,6 +104,9 @@ func (q *Query) BatchDelete(keys []any) error {
 func (q *Query) BatchDeleteWithOptions(keys []any, opts *BatchUpdateOptions) error {
 	if len(keys) == 0 {
 		return nil
+	}
+	if err := q.rejectWriteOnceMutation("batch delete"); err != nil {
+		return err
 	}
 
 	// Prepare key batches
@@ -644,6 +654,16 @@ func (q *Query) BatchWriteWithOptions(putItems []any, deleteKeys []any, opts *Ba
 	totalItems := len(putItems) + len(deleteKeys)
 	if totalItems == 0 {
 		return nil
+	}
+	if len(putItems) > 0 {
+		if err := q.rejectWriteOnceMutation("batch put"); err != nil {
+			return err
+		}
+	}
+	if len(deleteKeys) > 0 {
+		if err := q.rejectWriteOnceMutation("batch delete"); err != nil {
+			return err
+		}
 	}
 
 	// Validate batch size

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -782,7 +782,14 @@ func (q *Query) Create() error {
 		TableName: q.metadata.TableName(),
 	}
 
-	conditionExpr, names, values, err := q.buildConditionExpression(nil, false, false, false)
+	conditionBuilder := q.newBuilder()
+	if q.writePolicy().Mode == model.WritePolicyModeWriteOnce {
+		if defaultErr := q.addDefaultCondition(conditionBuilder); defaultErr != nil {
+			return defaultErr
+		}
+	}
+
+	conditionExpr, names, values, err := q.buildConditionExpression(conditionBuilder, false, false, false)
 	if err != nil {
 		return err
 	}
@@ -815,6 +822,9 @@ func (q *Query) Create() error {
 // CreateOrUpdate creates a new item or updates an existing one (upsert)
 func (q *Query) CreateOrUpdate() error {
 	if err := q.checkBuilderError(); err != nil {
+		return err
+	}
+	if err := q.rejectWriteOnceMutation("upsert"); err != nil {
 		return err
 	}
 	item, err := q.marshalItem(q.model)
@@ -891,6 +901,17 @@ func (q *Query) Update(fields ...string) error {
 	modelValue, err := q.updateModelValue()
 	if err != nil {
 		return err
+	}
+	if policyErr := q.rejectWriteOnceMutation("update"); policyErr != nil {
+		return policyErr
+	}
+
+	policyFields, err := q.updatePolicyFields(modelValue, fields)
+	if err != nil {
+		return err
+	}
+	if policyErr := q.rejectProtectedFieldMutation(policyFields, nil); policyErr != nil {
+		return policyErr
 	}
 
 	builder := q.newBuilder()
@@ -1146,6 +1167,9 @@ func (q *Query) Delete() error {
 	if err := q.checkBuilderError(); err != nil {
 		return err
 	}
+	if err := q.rejectWriteOnceMutation("delete"); err != nil {
+		return err
+	}
 
 	key, keyErr := q.buildPrimaryKeyMap("delete")
 	if keyErr != nil {
@@ -1304,6 +1328,9 @@ func (q *Query) ScanAllSegments(dest any, totalSegments int32) error {
 // BatchCreate creates multiple items
 func (q *Query) BatchCreate(items any) error {
 	if err := q.checkBuilderError(); err != nil {
+		return err
+	}
+	if err := q.rejectWriteOnceMutation("batch create"); err != nil {
 		return err
 	}
 	// Validate items is a slice

--- a/pkg/query/update_builder.go
+++ b/pkg/query/update_builder.go
@@ -56,8 +56,26 @@ func (ub *UpdateBuilder) normalizeFieldValue(field string, value any) (any, erro
 	return ub.query.normalizeJSONFieldValue(field, value)
 }
 
+func (ub *UpdateBuilder) rejectMutation(field string) bool {
+	if ub == nil || ub.buildErr != nil || ub.query == nil {
+		return ub != nil && ub.buildErr != nil
+	}
+	if err := ub.query.rejectWriteOnceMutation("update builder"); err != nil {
+		ub.buildErr = err
+		return true
+	}
+	if err := ub.query.rejectProtectedFieldMutation([]string{field}, nil); err != nil {
+		ub.buildErr = err
+		return true
+	}
+	return false
+}
+
 // Set adds a SET expression to update a field
 func (ub *UpdateBuilder) Set(field string, value any) core.UpdateBuilder {
+	if ub.rejectMutation(field) {
+		return ub
+	}
 	dbFieldName := ub.mapFieldToDynamoDBName(field)
 	normalized, err := ub.normalizeFieldValue(field, value)
 	if err != nil {
@@ -74,6 +92,9 @@ func (ub *UpdateBuilder) Set(field string, value any) core.UpdateBuilder {
 
 // SetIfNotExists sets a field only if it doesn't exist
 func (ub *UpdateBuilder) SetIfNotExists(field string, value any, defaultValue any) core.UpdateBuilder {
+	if ub.rejectMutation(field) {
+		return ub
+	}
 	dbFieldName := ub.mapFieldToDynamoDBName(field)
 	normalizedDefault, err := ub.normalizeFieldValue(field, defaultValue)
 	if err != nil {
@@ -93,6 +114,9 @@ func (ub *UpdateBuilder) SetIfNotExists(field string, value any, defaultValue an
 
 // Add increments a numeric field (atomic counter)
 func (ub *UpdateBuilder) Add(field string, value any) core.UpdateBuilder {
+	if ub.rejectMutation(field) {
+		return ub
+	}
 	dbFieldName := ub.mapFieldToDynamoDBName(field)
 	if err := ub.expr.AddUpdateAdd(dbFieldName, value); err != nil && ub.buildErr == nil {
 		ub.buildErr = fmt.Errorf("Add(%s): %w", field, err)
@@ -112,6 +136,9 @@ func (ub *UpdateBuilder) Decrement(field string) core.UpdateBuilder {
 
 // Remove removes an attribute from the item
 func (ub *UpdateBuilder) Remove(field string) core.UpdateBuilder {
+	if ub.rejectMutation(field) {
+		return ub
+	}
 	dbFieldName := ub.mapFieldToDynamoDBName(field)
 	if err := ub.expr.AddUpdateRemove(dbFieldName); err != nil && ub.buildErr == nil {
 		ub.buildErr = fmt.Errorf("Remove(%s): %w", field, err)
@@ -121,6 +148,9 @@ func (ub *UpdateBuilder) Remove(field string) core.UpdateBuilder {
 
 // Delete removes elements from a set
 func (ub *UpdateBuilder) Delete(field string, value any) core.UpdateBuilder {
+	if ub.rejectMutation(field) {
+		return ub
+	}
 	dbFieldName := ub.mapFieldToDynamoDBName(field)
 
 	// DynamoDB DELETE action is for removing elements from a set
@@ -156,6 +186,9 @@ func (ub *UpdateBuilder) Delete(field string, value any) core.UpdateBuilder {
 
 // AppendToList appends values to the end of a list
 func (ub *UpdateBuilder) AppendToList(field string, values any) core.UpdateBuilder {
+	if ub.rejectMutation(field) {
+		return ub
+	}
 	dbFieldName := ub.mapFieldToDynamoDBName(field)
 	normalized, err := ub.normalizeFieldValue(field, values)
 	if err != nil {
@@ -175,6 +208,9 @@ func (ub *UpdateBuilder) AppendToList(field string, values any) core.UpdateBuild
 
 // PrependToList prepends values to the beginning of a list
 func (ub *UpdateBuilder) PrependToList(field string, values any) core.UpdateBuilder {
+	if ub.rejectMutation(field) {
+		return ub
+	}
 	dbFieldName := ub.mapFieldToDynamoDBName(field)
 	normalized, err := ub.normalizeFieldValue(field, values)
 	if err != nil {
@@ -194,6 +230,9 @@ func (ub *UpdateBuilder) PrependToList(field string, values any) core.UpdateBuil
 
 // RemoveFromListAt removes an element from a list at a specific index
 func (ub *UpdateBuilder) RemoveFromListAt(field string, index int) core.UpdateBuilder {
+	if ub.rejectMutation(field) {
+		return ub
+	}
 	dbFieldName := ub.mapFieldToDynamoDBName(field)
 	if err := ub.expr.AddUpdateRemove(fmt.Sprintf("%s[%d]", dbFieldName, index)); err != nil && ub.buildErr == nil {
 		ub.buildErr = fmt.Errorf("RemoveFromListAt(%s): %w", field, err)
@@ -203,6 +242,9 @@ func (ub *UpdateBuilder) RemoveFromListAt(field string, index int) core.UpdateBu
 
 // SetListElement sets a specific element in a list
 func (ub *UpdateBuilder) SetListElement(field string, index int, value any) core.UpdateBuilder {
+	if ub.rejectMutation(field) {
+		return ub
+	}
 	dbFieldName := ub.mapFieldToDynamoDBName(field)
 	normalized, err := ub.normalizeFieldValue(field, value)
 	if err != nil {

--- a/pkg/query/write_policy.go
+++ b/pkg/query/write_policy.go
@@ -1,0 +1,137 @@
+package query
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/model"
+)
+
+func (q *Query) writePolicy() model.WritePolicy {
+	if q == nil {
+		return model.DefaultWritePolicy()
+	}
+	if q.rawMetadata != nil {
+		return q.rawMetadata.WritePolicy
+	}
+	if provider, ok := q.metadata.(core.WritePolicyProvider); ok && provider != nil {
+		return provider.WritePolicy()
+	}
+	return model.DefaultWritePolicy()
+}
+
+func (q *Query) rejectWriteOnceMutation(operation string) error {
+	if q.writePolicy().Mode != model.WritePolicyModeWriteOnce {
+		return nil
+	}
+	if operation == "" {
+		operation = "mutation"
+	}
+	return fmt.Errorf("%w: %s", theorydbErrors.ErrImmutableModelMutation, operation)
+}
+
+func (q *Query) rejectProtectedFieldMutation(fields []string, extraProtected []string) error {
+	protected := q.protectedAttributeSet(extraProtected)
+	if len(protected) == 0 {
+		return nil
+	}
+
+	for _, field := range fields {
+		attrName := q.canonicalAttributeName(field)
+		root := rootAttributeName(attrName)
+		if _, ok := protected[root]; ok {
+			return fmt.Errorf("%w: %s", theorydbErrors.ErrProtectedFieldMutation, root)
+		}
+	}
+	return nil
+}
+
+func (q *Query) updatePolicyFields(modelValue reflect.Value, fields []string) ([]string, error) {
+	if len(fields) > 0 {
+		return appendPolicyAutoFields(append([]string(nil), fields...), q.rawMetadata), nil
+	}
+	if q.rawMetadata == nil {
+		return nil, nil
+	}
+	return appendPolicyAutoFields(q.metadataFieldsToUpdate(modelValue), q.rawMetadata), nil
+}
+
+func appendPolicyAutoFields(fields []string, metadata *model.Metadata) []string {
+	if metadata == nil {
+		return fields
+	}
+	if metadata.UpdatedAtField != nil {
+		fields = append(fields, metadata.UpdatedAtField.DBName)
+	}
+	if metadata.VersionField != nil {
+		fields = append(fields, metadata.VersionField.DBName)
+	}
+	return fields
+}
+
+func (q *Query) protectedAttributeSet(extra []string) map[string]struct{} {
+	policy := q.writePolicy()
+	if len(policy.ProtectedAttributes) == 0 && len(extra) == 0 {
+		return nil
+	}
+
+	protected := make(map[string]struct{}, len(policy.ProtectedAttributes)+len(extra))
+	for _, attr := range policy.ProtectedAttributes {
+		addProtectedAttribute(protected, q.canonicalAttributeName(attr))
+	}
+	for _, attr := range extra {
+		addProtectedAttribute(protected, q.canonicalAttributeName(attr))
+	}
+	return protected
+}
+
+func addProtectedAttribute(protected map[string]struct{}, attr string) {
+	attr = rootAttributeName(attr)
+	if attr == "" {
+		return
+	}
+	protected[attr] = struct{}{}
+}
+
+func (q *Query) canonicalAttributeName(field string) string {
+	field = strings.TrimSpace(field)
+	if field == "" || q == nil || q.metadata == nil {
+		return field
+	}
+	root := rootAttributeName(field)
+	if root == "" {
+		return field
+	}
+	if meta := q.metadata.AttributeMetadata(root); meta != nil {
+		if meta.DynamoDBName != "" {
+			return replaceRootAttribute(field, meta.DynamoDBName)
+		}
+		if meta.Name != "" {
+			return replaceRootAttribute(field, meta.Name)
+		}
+	}
+	return field
+}
+
+func rootAttributeName(field string) string {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return ""
+	}
+	root := field
+	if idx := strings.IndexAny(root, ".["); idx >= 0 {
+		root = root[:idx]
+	}
+	return root
+}
+
+func replaceRootAttribute(field, replacement string) string {
+	root := rootAttributeName(field)
+	if root == "" || replacement == "" || root == replacement {
+		return field
+	}
+	return replacement + strings.TrimPrefix(field, root)
+}

--- a/pkg/query/write_policy_test.go
+++ b/pkg/query/write_policy_test.go
@@ -1,0 +1,229 @@
+package query
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/model"
+)
+
+type writePolicyQueryMetadata struct {
+	meta *model.Metadata
+}
+
+func (m writePolicyQueryMetadata) TableName() string { return m.meta.TableName }
+
+func (m writePolicyQueryMetadata) PrimaryKey() core.KeySchema {
+	schema := core.KeySchema{}
+	if m.meta.PrimaryKey != nil && m.meta.PrimaryKey.PartitionKey != nil {
+		schema.PartitionKey = m.meta.PrimaryKey.PartitionKey.Name
+	}
+	if m.meta.PrimaryKey != nil && m.meta.PrimaryKey.SortKey != nil {
+		schema.SortKey = m.meta.PrimaryKey.SortKey.Name
+	}
+	return schema
+}
+
+func (m writePolicyQueryMetadata) Indexes() []core.IndexSchema { return nil }
+
+func (m writePolicyQueryMetadata) AttributeMetadata(field string) *core.AttributeMetadata {
+	if meta := m.meta.Fields[field]; meta != nil {
+		return writePolicyAttributeMetadata(meta)
+	}
+	if meta := m.meta.FieldsByDBName[field]; meta != nil {
+		return writePolicyAttributeMetadata(meta)
+	}
+	return nil
+}
+
+func (m writePolicyQueryMetadata) VersionFieldName() string { return "" }
+
+func (m writePolicyQueryMetadata) RawMetadata() *model.Metadata { return m.meta }
+
+func (m writePolicyQueryMetadata) WritePolicy() model.WritePolicy {
+	return m.meta.WritePolicy
+}
+
+func writePolicyAttributeMetadata(field *model.FieldMetadata) *core.AttributeMetadata {
+	typeName := ""
+	if field.Type != nil {
+		typeName = field.Type.String()
+	}
+	return &core.AttributeMetadata{
+		Name:         field.Name,
+		Type:         typeName,
+		DynamoDBName: field.DBName,
+		Tags:         field.Tags,
+	}
+}
+
+type writePolicyRecordingExecutor struct {
+	compiled *core.CompiledQuery
+}
+
+func (e *writePolicyRecordingExecutor) ExecuteQuery(*core.CompiledQuery, any) error { return nil }
+func (e *writePolicyRecordingExecutor) ExecuteScan(*core.CompiledQuery, any) error  { return nil }
+
+func (e *writePolicyRecordingExecutor) ExecutePutItem(input *core.CompiledQuery, _ map[string]types.AttributeValue) error {
+	e.compiled = input
+	return nil
+}
+
+func (e *writePolicyRecordingExecutor) ExecuteUpdateItem(input *core.CompiledQuery, _ map[string]types.AttributeValue) error {
+	e.compiled = input
+	return nil
+}
+
+func (e *writePolicyRecordingExecutor) ExecuteDeleteItem(input *core.CompiledQuery, _ map[string]types.AttributeValue) error {
+	e.compiled = input
+	return nil
+}
+
+type writePolicyActualItem struct {
+	PK              string `theorydb:"pk"`
+	SK              string `theorydb:"sk"`
+	Status          string
+	PinnedReleaseID string `theorydb:"attr:pinnedReleaseId,omitempty"`
+	Version         int64  `theorydb:"version"`
+}
+
+func (writePolicyActualItem) TableName() string { return "write_policy_items" }
+
+func (writePolicyActualItem) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{
+		Mode:                model.WritePolicyModeMutable,
+		ProtectedAttributes: []string{"pinnedReleaseId"},
+	}
+}
+
+type writePolicyEventItem struct {
+	PK        string `theorydb:"pk"`
+	SK        string `theorydb:"sk"`
+	EventType string `theorydb:"attr:eventType"`
+}
+
+func (writePolicyEventItem) TableName() string { return "write_policy_items" }
+
+func (writePolicyEventItem) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{Mode: model.WritePolicyModeWriteOnce}
+}
+
+func newWritePolicyQuery(t *testing.T, item any) (*Query, *writePolicyRecordingExecutor) {
+	t.Helper()
+
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(item))
+	meta, err := registry.GetMetadata(item)
+	require.NoError(t, err)
+
+	executor := &writePolicyRecordingExecutor{}
+	q := New(item, writePolicyQueryMetadata{meta: meta}, executor)
+	return q, executor
+}
+
+func TestWritePolicy_CreateOnWriteOnceAddsNotExistsCondition(t *testing.T) {
+	item := &writePolicyEventItem{PK: "release#svc", SK: "event#1", EventType: "promoted"}
+	q, executor := newWritePolicyQuery(t, item)
+
+	require.NoError(t, q.Create())
+	require.NotNil(t, executor.compiled)
+	require.Contains(t, executor.compiled.ConditionExpression, "attribute_not_exists")
+}
+
+func TestWritePolicy_WriteOnceRejectsGenericMutations(t *testing.T) {
+	tests := []struct {
+		run  func(*Query) error
+		name string
+	}{
+		{run: func(q *Query) error { return q.Update("eventType") }, name: "update"},
+		{run: func(q *Query) error { return q.CreateOrUpdate() }, name: "upsert"},
+		{run: func(q *Query) error { return q.Delete() }, name: "delete"},
+		{run: func(q *Query) error {
+			return q.UpdateBuilder().Set("eventType", "mutated").Execute()
+		}, name: "update_builder"},
+		{run: func(q *Query) error {
+			return q.BatchCreate([]writePolicyEventItem{{PK: "release#svc", SK: "event#2"}})
+		}, name: "batch_create"},
+		{run: func(q *Query) error {
+			return q.BatchDelete([]any{core.KeyPair{PartitionKey: "release#svc", SortKey: "event#1"}})
+		}, name: "batch_delete"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := &writePolicyEventItem{PK: "release#svc", SK: "event#1", EventType: "promoted"}
+			q, _ := newWritePolicyQuery(t, item)
+			err := tt.run(q)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, theorydbErrors.ErrImmutableModelMutation))
+		})
+	}
+}
+
+func TestWritePolicy_ProtectedAttributesRejectRoutineUpdates(t *testing.T) {
+	item := &writePolicyActualItem{
+		PK:              "release#svc",
+		SK:              "actual",
+		Status:          "warming",
+		PinnedReleaseID: "rel-2",
+		Version:         1,
+	}
+
+	tests := []struct {
+		run  func(*Query) error
+		name string
+	}{
+		{run: func(q *Query) error { return q.Update("PinnedReleaseID") }, name: "update_named_go_field"},
+		{run: func(q *Query) error { return q.Update("pinnedReleaseId") }, name: "update_named_db_attr"},
+		{run: func(q *Query) error { return q.Update() }, name: "update_all_non_empty_fields"},
+		{run: func(q *Query) error {
+			return q.UpdateBuilder().Set("pinnedReleaseId", "rel-3").Execute()
+		}, name: "update_builder_set"},
+		{run: func(q *Query) error {
+			return q.UpdateBuilder().Set("pinnedReleaseId.value", "rel-3").Execute()
+		}, name: "update_builder_nested"},
+		{run: func(q *Query) error {
+			return q.BatchUpdate([]writePolicyActualItem{*item}, "pinnedReleaseId")
+		}, name: "batch_update"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, _ := newWritePolicyQuery(t, item)
+			err := tt.run(q)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, theorydbErrors.ErrProtectedFieldMutation))
+		})
+	}
+}
+
+func TestWritePolicy_ProtectedAttributesAllowOtherUpdatesAndDelete(t *testing.T) {
+	item := &writePolicyActualItem{
+		PK:      "release#svc",
+		SK:      "actual",
+		Status:  "active",
+		Version: 1,
+	}
+	q, executor := newWritePolicyQuery(t, item)
+
+	require.NoError(t, q.Update("Status"))
+	require.NotNil(t, executor.compiled)
+	require.Equal(t, "UpdateItem", executor.compiled.Operation)
+
+	executor.compiled = nil
+	require.NoError(t, q.Delete())
+	require.NotNil(t, executor.compiled)
+	require.Equal(t, "DeleteItem", executor.compiled.Operation)
+}
+
+func TestWritePolicy_FieldRootHelpers(t *testing.T) {
+	require.Equal(t, "pinnedReleaseId", rootAttributeName("pinnedReleaseId.value"))
+	require.Equal(t, "pinnedReleaseId", rootAttributeName("pinnedReleaseId[0]"))
+	require.Equal(t, "status.tail", replaceRootAttribute("Status.tail", "status"))
+	require.Equal(t, "status[0]", replaceRootAttribute("Status[0]", "status"))
+}

--- a/pkg/transaction/builder.go
+++ b/pkg/transaction/builder.go
@@ -1105,6 +1105,13 @@ func (m *metadataAdapter) VersionFieldName() string {
 	return ""
 }
 
+func (m *metadataAdapter) WritePolicy() model.WritePolicy {
+	if m.meta == nil {
+		return model.DefaultWritePolicy()
+	}
+	return m.meta.WritePolicy
+}
+
 func convertFieldMetadata(field *model.FieldMetadata) *core.AttributeMetadata {
 	if field == nil {
 		return nil

--- a/pkg/transaction/builder.go
+++ b/pkg/transaction/builder.go
@@ -207,6 +207,10 @@ func (b *Builder) addOperation(opType operationType, model any, fields []string,
 		b.recordError(err)
 		return
 	}
+	if err := validateWritePolicyForOperation(opType, metadata, fields); err != nil {
+		b.recordError(err)
+		return
+	}
 
 	b.operations = append(b.operations, transactOperation{
 		typ:        opType,
@@ -216,6 +220,26 @@ func (b *Builder) addOperation(opType operationType, model any, fields []string,
 		updateFn:   updateFn,
 		conditions: cloneTransactConditions(conditions),
 	})
+}
+
+func validateWritePolicyForOperation(opType operationType, metadata *model.Metadata, fields []string) error {
+	switch opType {
+	case opCreate, opConditionCheck:
+		return nil
+	case opPut:
+		return rejectWriteOnceMutation(metadata, "transaction put")
+	case opUpdate:
+		if err := rejectWriteOnceMutation(metadata, "transaction update"); err != nil {
+			return err
+		}
+		return rejectProtectedFieldMutation(metadata, fields)
+	case opUpdateWithBuilder:
+		return rejectWriteOnceMutation(metadata, "transaction update builder")
+	case opDelete:
+		return rejectWriteOnceMutation(metadata, "transaction delete")
+	default:
+		return nil
+	}
 }
 
 func (b *Builder) recordError(err error) {

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -159,6 +159,13 @@ func (tx *Transaction) Update(model any) error {
 }
 
 func (tx *Transaction) buildUpdateExpression(modelValue reflect.Value, metadata *model.Metadata) (string, map[string]string, map[string]types.AttributeValue, error) {
+	if err := rejectWriteOnceMutation(metadata, "transaction update"); err != nil {
+		return "", nil, nil, err
+	}
+	if err := rejectProtectedFieldMutation(metadata, fieldsMutatedByTransactionUpdate(modelValue, metadata)); err != nil {
+		return "", nil, nil, err
+	}
+
 	updateExpression := "SET "
 	expressionAttributeNames := make(map[string]string)
 	expressionAttributeValues := make(map[string]types.AttributeValue)
@@ -269,6 +276,9 @@ func (tx *Transaction) Delete(model any) error {
 	metadata, err := tx.registry.GetMetadata(model)
 	if err != nil {
 		return fmt.Errorf("failed to get model metadata: %w", err)
+	}
+	if policyErr := rejectWriteOnceMutation(metadata, "transaction delete"); policyErr != nil {
+		return policyErr
 	}
 
 	// Extract primary key

--- a/pkg/transaction/write_policy.go
+++ b/pkg/transaction/write_policy.go
@@ -1,0 +1,81 @@
+package transaction
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/theory-cloud/tabletheory/internal/reflectutil"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/model"
+)
+
+func rejectWriteOnceMutation(metadata *model.Metadata, operation string) error {
+	if metadata == nil || metadata.WritePolicy.Mode != model.WritePolicyModeWriteOnce {
+		return nil
+	}
+	if operation == "" {
+		operation = "mutation"
+	}
+	return fmt.Errorf("%w: %s", theorydbErrors.ErrImmutableModelMutation, operation)
+}
+
+func rejectProtectedFieldMutation(metadata *model.Metadata, fields []string) error {
+	protected := protectedAttributeSet(metadata)
+	if len(protected) == 0 {
+		return nil
+	}
+
+	for _, field := range fields {
+		attrName := resolveMetadataAttributeName(metadata, field)
+		if _, ok := protected[attrName]; ok {
+			return fmt.Errorf("%w: %s", theorydbErrors.ErrProtectedFieldMutation, attrName)
+		}
+	}
+	return nil
+}
+
+func protectedAttributeSet(metadata *model.Metadata) map[string]struct{} {
+	if metadata == nil || len(metadata.WritePolicy.ProtectedAttributes) == 0 {
+		return nil
+	}
+	protected := make(map[string]struct{}, len(metadata.WritePolicy.ProtectedAttributes))
+	for _, attr := range metadata.WritePolicy.ProtectedAttributes {
+		if attr == "" {
+			continue
+		}
+		protected[resolveMetadataAttributeName(metadata, attr)] = struct{}{}
+	}
+	return protected
+}
+
+func resolveMetadataAttributeName(metadata *model.Metadata, field string) string {
+	if metadata == nil || field == "" {
+		return field
+	}
+	if meta := metadata.Fields[field]; meta != nil && meta.DBName != "" {
+		return meta.DBName
+	}
+	if meta := metadata.FieldsByDBName[field]; meta != nil && meta.DBName != "" {
+		return meta.DBName
+	}
+	return field
+}
+
+func fieldsMutatedByTransactionUpdate(modelValue reflect.Value, metadata *model.Metadata) []string {
+	if metadata == nil {
+		return nil
+	}
+	fields := make([]string, 0, len(metadata.Fields))
+	for _, fieldMeta := range metadata.Fields {
+		if fieldMeta == nil || fieldMeta.IsPK || fieldMeta.IsSK {
+			continue
+		}
+
+		fieldValue := modelValue.FieldByIndex(fieldMeta.IndexPath)
+		if !fieldValue.IsValid() || (fieldMeta.OmitEmpty && reflectutil.IsEmpty(fieldValue)) {
+			continue
+		}
+		fields = append(fields, fieldMeta.DBName)
+	}
+	return fields
+}

--- a/pkg/transaction/write_policy_test.go
+++ b/pkg/transaction/write_policy_test.go
@@ -1,0 +1,137 @@
+package transaction
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/model"
+	"github.com/theory-cloud/tabletheory/pkg/session"
+	pkgTypes "github.com/theory-cloud/tabletheory/pkg/types"
+)
+
+type writePolicyTransactionActual struct {
+	PK              string `theorydb:"pk"`
+	SK              string `theorydb:"sk"`
+	Status          string
+	PinnedReleaseID string `theorydb:"attr:pinnedReleaseId,omitempty"`
+}
+
+func (writePolicyTransactionActual) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{
+		Mode:                model.WritePolicyModeMutable,
+		ProtectedAttributes: []string{"pinnedReleaseId"},
+	}
+}
+
+type writePolicyTransactionEvent struct {
+	PK        string `theorydb:"pk"`
+	SK        string `theorydb:"sk"`
+	EventType string `theorydb:"attr:eventType"`
+}
+
+func (writePolicyTransactionEvent) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{Mode: model.WritePolicyModeWriteOnce}
+}
+
+func newWritePolicyTransactionBuilder(t *testing.T) (*Builder, *model.Registry) {
+	t.Helper()
+
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&writePolicyTransactionActual{}))
+	require.NoError(t, registry.Register(&writePolicyTransactionEvent{}))
+
+	return NewBuilder(&session.Session{}, registry, pkgTypes.NewConverter()), registry
+}
+
+func TestWritePolicyTransactionBuilder_WriteOnceRules(t *testing.T) {
+	event := &writePolicyTransactionEvent{PK: "release#svc", SK: "event#1", EventType: "promoted"}
+
+	t.Run("create allowed", func(t *testing.T) {
+		builder, _ := newWritePolicyTransactionBuilder(t)
+		builder.Create(event)
+		items, err := builder.materializeOperations()
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		require.NotNil(t, items[0].Put)
+		require.NotNil(t, items[0].Put.ConditionExpression)
+	})
+
+	for _, tt := range []struct {
+		run  func(*Builder)
+		name string
+	}{
+		{run: func(b *Builder) { b.Put(event) }, name: "put"},
+		{run: func(b *Builder) { b.Update(event, []string{"EventType"}) }, name: "update"},
+		{run: func(b *Builder) {
+			b.UpdateWithBuilder(event, func(ub core.UpdateBuilder) error {
+				ub.Set("eventType", "mutated")
+				return nil
+			})
+		}, name: "update_builder"},
+		{run: func(b *Builder) { b.Delete(event) }, name: "delete"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, _ := newWritePolicyTransactionBuilder(t)
+			tt.run(builder)
+			err := builder.Execute()
+			require.Error(t, err)
+			require.True(t, errors.Is(err, theorydbErrors.ErrImmutableModelMutation))
+		})
+	}
+}
+
+func TestWritePolicyTransactionBuilder_ProtectedFieldRules(t *testing.T) {
+	actual := &writePolicyTransactionActual{
+		PK:              "release#svc",
+		SK:              "actual",
+		Status:          "active",
+		PinnedReleaseID: "rel-1",
+	}
+
+	t.Run("field update rejects protected attr", func(t *testing.T) {
+		builder, _ := newWritePolicyTransactionBuilder(t)
+		builder.Update(actual, []string{"pinnedReleaseId"})
+		err := builder.Execute()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, theorydbErrors.ErrProtectedFieldMutation))
+	})
+
+	t.Run("update builder rejects protected attr", func(t *testing.T) {
+		builder, _ := newWritePolicyTransactionBuilder(t)
+		builder.UpdateWithBuilder(actual, func(ub core.UpdateBuilder) error {
+			ub.Set("pinnedReleaseId", "rel-2")
+			return nil
+		})
+		_, err := builder.materializeOperations()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, theorydbErrors.ErrProtectedFieldMutation))
+	})
+}
+
+func TestWritePolicyTransaction_EnforcesPolicies(t *testing.T) {
+	_, registry := newWritePolicyTransactionBuilder(t)
+	tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+
+	event := &writePolicyTransactionEvent{PK: "release#svc", SK: "event#1", EventType: "promoted"}
+	err := tx.Update(event)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, theorydbErrors.ErrImmutableModelMutation))
+
+	err = tx.Delete(event)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, theorydbErrors.ErrImmutableModelMutation))
+
+	actual := &writePolicyTransactionActual{
+		PK:              "release#svc",
+		SK:              "actual",
+		Status:          "active",
+		PinnedReleaseID: "rel-1",
+	}
+	err = tx.Update(actual)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, theorydbErrors.ErrProtectedFieldMutation))
+}


### PR DESCRIPTION
## Milestone
tt-release-state-go-policy — Parse and enforce release-state write policies in the Go runtime.

## Linear
https://linear.app/pay-theory/project/tabletheory-release-state-write-policies-0ebbc8f7b4c1 / `tt-release-state-go-policy`

## Affected runtimes
Go

## Contract impact
Additive runtime implementation for the previously pinned release-state write policy contract. Go now advertises `release_state.write_policy` in the contract runner; release-state write-policy and protected-field P0 scenarios execute for Go. No DMS or scenario shape changes are introduced in this milestone.

## Backward compatibility
Additive for opt-in models. Models without `WritePolicy()` continue to behave as mutable with no protected attributes. `write_once` / protected-field enforcement only applies to models that declare `WritePolicy() model.WritePolicy`.

## Tasks
- [x] IO-73 — Parse Go model WritePolicy metadata
- [x] IO-74 — Enforce Go write_once and protected-field mutation rules

## Validation
- [x] Baseline `make test-unit` on staging before branching
- [x] Baseline `make rubric` on staging before branching
- [x] `go test ./pkg/model ./pkg/core`
- [x] `go test ./internal/theorydb -run WritePolicy`
- [x] `go test ./pkg/query ./pkg/transaction ./internal/theorydb`
- [x] `cd contract-tests/runners/go && go test ./... -v`
- [x] `make test-unit`
- [x] `make lint`
- [x] `bash scripts/verify-branch-version-sync.sh` (SKIP; branch is not a release branch)
- [x] `make rubric`

## Cross-repo coordination
None for this milestone. Downstream release-control-plane adoption remains gated on the full cross-runtime release-state roadmap.
