### PR TITLE
feat(ts): enforce release-state write policies

### DIFF
--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -71,6 +71,7 @@ export class TheorydbDriver implements Driver {
       "lifecycle.timestamps",
       "optimistic_lock.version",
       "ttl.epoch_seconds",
+      "release_state.write_policy",
     ];
   }
 
@@ -93,16 +94,20 @@ export class TheorydbDriver implements Driver {
     model: string,
     item: Record<string, unknown>,
     fields: string[],
-    _opts?: { protectedAttributes?: readonly string[] },
+    opts?: { protectedAttributes?: readonly string[] },
   ): Promise<void> {
-    await this.client.update(model, item, fields);
+    await this.client.update(
+      model,
+      item,
+      fields,
+      opts?.protectedAttributes
+        ? { protectedAttributes: opts.protectedAttributes }
+        : {},
+    );
   }
 
-  async save(model: string, _item: Record<string, unknown>): Promise<void> {
-    throw new TheorydbError(
-      "ErrInvalidModel",
-      `save not implemented for contract model ${model}`,
-    );
+  async save(model: string, item: Record<string, unknown>): Promise<void> {
+    await this.client.save(model, item);
   }
 
   async delete(model: string, key: Record<string, unknown>): Promise<void> {

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -45,6 +45,13 @@ import {
   modelHasEncryptedAttributes,
   type EncryptionProvider,
 } from './encryption.js';
+import {
+  assertMutableWritePolicy,
+  assertProtectedFieldsCanMutate,
+  assertRawUpdateExpressionAllowed,
+  isWriteOnceModel,
+  type WritePolicyOptions,
+} from './write-policy.js';
 
 export class TheorydbClient {
   private readonly models = new Map<string, Model>();
@@ -134,15 +141,44 @@ export class TheorydbClient {
         )
       : marshalPutItem(model, item, { now });
 
+    const requireIfNotExists = opts.ifNotExists || isWriteOnceModel(model);
     const cmd = new PutItemCommand({
       TableName: model.tableName,
       Item: putItem,
-      ...(opts.ifNotExists
+      ...(requireIfNotExists
         ? {
             ConditionExpression: 'attribute_not_exists(#pk)',
             ExpressionAttributeNames: { '#pk': model.roles.pk },
           }
         : {}),
+    });
+
+    try {
+      await this.ddb.send(cmd, this.sendOptions);
+    } catch (err) {
+      throw mapDynamoError(err);
+    }
+  }
+
+  async save(modelName: string, item: Record<string, unknown>): Promise<void> {
+    const model = this.requireModel(modelName);
+    assertMutableWritePolicy(model, 'save');
+
+    const now = this.now();
+    const putItem = modelHasEncryptedAttributes(model)
+      ? await marshalPutItemEncrypted(
+          model,
+          item,
+          this.requireEncryption(model),
+          {
+            now,
+          },
+        )
+      : marshalPutItem(model, item, { now });
+
+    const cmd = new PutItemCommand({
+      TableName: model.tableName,
+      Item: putItem,
     });
 
     try {
@@ -183,8 +219,10 @@ export class TheorydbClient {
     modelName: string,
     item: Record<string, unknown>,
     fields: string[],
+    opts: WritePolicyOptions = {},
   ): Promise<void> {
     const model = this.requireModel(modelName);
+    assertMutableWritePolicy(model, 'update');
     const provider = modelHasEncryptedAttributes(model)
       ? this.requireEncryption(model)
       : undefined;
@@ -225,6 +263,12 @@ export class TheorydbClient {
       values[':now'] = { S: now };
       setParts.push('#updatedAt = :now');
     }
+
+    assertProtectedFieldsCanMutate(
+      model,
+      policyFieldsForUpdate(model, fields),
+      opts.protectedAttributes ?? [],
+    );
 
     for (const field of fields) {
       const fieldIndex = setParts.length + removeParts.length;
@@ -305,6 +349,7 @@ export class TheorydbClient {
 
   async delete(modelName: string, key: Record<string, unknown>): Promise<void> {
     const model = this.requireModel(modelName);
+    assertMutableWritePolicy(model, 'delete');
     if (modelHasEncryptedAttributes(model)) this.requireEncryption(model);
     const cmd = new DeleteItemCommand({
       TableName: model.tableName,
@@ -388,6 +433,12 @@ export class TheorydbClient {
     opts: RetryOptions = {},
   ): Promise<BatchWriteResult> {
     const model = this.requireModel(modelName);
+    if ((req.puts?.length ?? 0) > 0) {
+      assertMutableWritePolicy(model, 'batch put');
+    }
+    if ((req.deletes?.length ?? 0) > 0) {
+      assertMutableWritePolicy(model, 'batch delete');
+    }
     const provider = modelHasEncryptedAttributes(model)
       ? this.requireEncryption(model)
       : undefined;
@@ -468,7 +519,7 @@ export class TheorydbClient {
             TableName: model.tableName,
             Item: item,
           };
-          if (a.ifNotExists) {
+          if (a.ifNotExists || isWriteOnceModel(model)) {
             put.ConditionExpression = 'attribute_not_exists(#pk)';
             put.ExpressionAttributeNames = { '#pk': model.roles.pk };
           }
@@ -476,13 +527,15 @@ export class TheorydbClient {
           break;
         }
         case 'update': {
+          assertMutableWritePolicy(model, 'transaction update');
           const update: Update = {
             TableName: model.tableName,
             Key: marshalKey(model, a.key),
             UpdateExpression: '',
           };
 
-          if ('updateFn' in a) {
+          const updateFn = 'updateFn' in a ? a.updateFn : undefined;
+          if (typeof updateFn === 'function') {
             const builder = new UpdateBuilder(
               this.ddb,
               model,
@@ -490,20 +543,32 @@ export class TheorydbClient {
               provider,
               this.sendOptions,
             );
-            await a.updateFn(builder);
+            await updateFn(builder);
             const built = await builder.build();
             update.UpdateExpression = built.updateExpression;
             update.ConditionExpression = built.conditionExpression;
             update.ExpressionAttributeNames = built.expressionAttributeNames;
             update.ExpressionAttributeValues = built.expressionAttributeValues;
           } else {
+            const updateExpression = a.updateExpression;
+            if (!updateExpression) {
+              throw new TheorydbError(
+                'ErrInvalidOperator',
+                'Transaction update requires an updateExpression',
+              );
+            }
+            assertRawUpdateExpressionAllowed(
+              model,
+              updateExpression,
+              a.expressionAttributeNames,
+            );
             if (provider) {
               throw new TheorydbError(
                 'ErrInvalidModel',
                 `Encrypted transaction updates for model ${model.name} must use updateFn`,
               );
             }
-            update.UpdateExpression = a.updateExpression;
+            update.UpdateExpression = updateExpression;
             update.ConditionExpression = a.conditionExpression;
             update.ExpressionAttributeNames = a.expressionAttributeNames;
             update.ExpressionAttributeValues = a.expressionAttributeValues;
@@ -513,6 +578,7 @@ export class TheorydbClient {
           break;
         }
         case 'delete':
+          assertMutableWritePolicy(model, 'transaction delete');
           transactItems.push({
             Delete: {
               TableName: model.tableName,
@@ -575,4 +641,14 @@ export class TheorydbClient {
       this.sendOptions,
     );
   }
+}
+
+function policyFieldsForUpdate(
+  model: Model,
+  fields: readonly string[],
+): string[] {
+  const out = [...fields];
+  if (model.roles.updatedAt) out.push(model.roles.updatedAt);
+  if (model.roles.version) out.push(model.roles.version);
+  return out;
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -18,5 +18,6 @@ export * from './multiaccount.js';
 export * from './send-options.js';
 export * from './validation.js';
 export * from './protection.js';
+export * from './write-policy.js';
 export * from './lease.js';
 export * from './facetheory-isr.js';

--- a/ts/src/model.ts
+++ b/ts/src/model.ts
@@ -357,7 +357,7 @@ function resolveWritePolicy(schema: ModelSchema): WritePolicy {
   return {
     mode: schema.write_policy?.mode ?? 'mutable',
     protectedAttributes: [
-      ...(schema.write_policy?.protected_attributes ?? []),
+      ...new Set(schema.write_policy?.protected_attributes ?? []),
     ].sort(),
   };
 }

--- a/ts/src/update-builder.ts
+++ b/ts/src/update-builder.ts
@@ -20,6 +20,10 @@ import {
 } from './marshal.js';
 import type { AttributeSchema, Model } from './model.js';
 import type { SendOptions } from './send-options.js';
+import {
+  assertMutableWritePolicy,
+  assertProtectedFieldsCanMutate,
+} from './write-policy.js';
 
 export type ReturnValuesOption =
   | 'NONE'
@@ -381,6 +385,7 @@ export class UpdateBuilder {
     if (this.updateOps.length === 0) {
       throw new TheorydbError('ErrInvalidOperator', 'No updates provided');
     }
+    assertMutableWritePolicy(this.model, 'update builder');
     if (modelHasEncryptedAttributes(this.model) && !this.encryption) {
       throw new TheorydbError(
         'ErrEncryptionNotConfigured',
@@ -718,6 +723,7 @@ export class UpdateBuilder {
         `Cannot update key field: ${field}`,
       );
     }
+    assertProtectedFieldsCanMutate(this.model, [field]);
   }
 }
 

--- a/ts/src/write-policy.ts
+++ b/ts/src/write-policy.ts
@@ -1,0 +1,129 @@
+import { TheorydbError } from './errors.js';
+import type { Model } from './model.js';
+
+export interface WritePolicyOptions {
+  protectedAttributes?: readonly string[];
+}
+
+export function isWriteOnceModel(model: Model): boolean {
+  return model.writePolicy.mode === 'write_once';
+}
+
+export function assertMutableWritePolicy(
+  model: Model,
+  operation: string,
+): void {
+  if (!isWriteOnceModel(model)) return;
+  throw new TheorydbError('ErrImmutableModelMutation', operation);
+}
+
+export function assertProtectedFieldsCanMutate(
+  model: Model,
+  fields: readonly string[],
+  extraProtected: readonly string[] = [],
+): void {
+  const protectedAttributes = protectedAttributeSet(model, extraProtected);
+  if (protectedAttributes.size === 0) return;
+
+  for (const field of fields) {
+    const attr = rootAttributeName(field);
+    if (attr && protectedAttributes.has(attr)) {
+      throw new TheorydbError('ErrProtectedFieldMutation', attr);
+    }
+  }
+}
+
+export function assertRawUpdateExpressionAllowed(
+  model: Model,
+  updateExpression: string,
+  expressionAttributeNames?: Record<string, string>,
+): void {
+  assertMutableWritePolicy(model, 'transaction update');
+  assertProtectedFieldsCanMutate(
+    model,
+    fieldsMutatedByUpdateExpression(updateExpression, expressionAttributeNames),
+  );
+}
+
+function protectedAttributeSet(
+  model: Model,
+  extraProtected: readonly string[],
+): Set<string> {
+  const protectedAttributes = new Set<string>();
+  for (const attr of model.writePolicy.protectedAttributes) {
+    const root = rootAttributeName(attr);
+    if (root) protectedAttributes.add(root);
+  }
+  for (const attr of extraProtected) {
+    const root = rootAttributeName(attr);
+    if (root) protectedAttributes.add(root);
+  }
+  return protectedAttributes;
+}
+
+function fieldsMutatedByUpdateExpression(
+  updateExpression: string,
+  expressionAttributeNames: Record<string, string> = {},
+): string[] {
+  const fields: string[] = [];
+  const sections = updateExpression.matchAll(
+    /\b(SET|REMOVE|ADD|DELETE)\b([\s\S]*?)(?=\b(?:SET|REMOVE|ADD|DELETE)\b|$)/gi,
+  );
+
+  for (const section of sections) {
+    const op = section[1]?.toUpperCase();
+    const body = section[2] ?? '';
+    for (const clause of splitTopLevelCommas(body)) {
+      const root = rootTokenForClause(op, clause);
+      const resolved = resolveAttributeName(root, expressionAttributeNames);
+      if (resolved) fields.push(resolved);
+    }
+  }
+
+  return fields;
+}
+
+function splitTopLevelCommas(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === '(') depth++;
+    else if (ch === ')' && depth > 0) depth--;
+    else if (ch === ',' && depth === 0) {
+      parts.push(value.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+
+  parts.push(value.slice(start).trim());
+  return parts.filter((part) => part.length > 0);
+}
+
+function rootTokenForClause(op: string | undefined, clause: string): string {
+  if (op === 'SET') {
+    return rootAttributeName(clause.split('=', 1)[0] ?? '');
+  }
+  return rootAttributeName(clause.split(/\s+/, 1)[0] ?? '');
+}
+
+function resolveAttributeName(
+  token: string,
+  expressionAttributeNames: Record<string, string>,
+): string {
+  if (!token.startsWith('#')) return token;
+  const match = token.match(/^#[A-Za-z0-9_]+/);
+  if (!match) return token;
+  const resolved = expressionAttributeNames[match[0]];
+  if (!resolved) return token;
+  return resolved + token.slice(match[0].length);
+}
+
+function rootAttributeName(field: string): string {
+  const trimmed = field.trim();
+  if (!trimmed) return '';
+  const match = trimmed.match(/^[^\s.[=,)]+/);
+  return match?.[0] ?? trimmed;
+}

--- a/ts/test/unit/client.test.ts
+++ b/ts/test/unit/client.test.ts
@@ -51,6 +51,45 @@ const EncryptedUser = defineModel({
   ],
 });
 
+const ReleaseStateActual = defineModel({
+  name: 'ReleaseStateActual',
+  table: { name: 'release_state_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort: { attribute: 'SK', type: 'S' },
+  },
+  write_policy: {
+    mode: 'mutable',
+    protected_attributes: ['pinnedReleaseId'],
+  },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'SK', type: 'S', roles: ['sk'] },
+    { attribute: 'status', type: 'S', optional: true },
+    { attribute: 'pinnedReleaseId', type: 'S', optional: true },
+    { attribute: 'updatedAt', type: 'S', roles: ['updated_at'] },
+    { attribute: 'version', type: 'N', roles: ['version'] },
+  ],
+});
+
+const ReleaseStateEvent = defineModel({
+  name: 'ReleaseStateEvent',
+  table: { name: 'release_state_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort: { attribute: 'SK', type: 'S' },
+  },
+  write_policy: {
+    mode: 'write_once',
+  },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'SK', type: 'S', roles: ['sk'] },
+    { attribute: 'releaseId', type: 'S', optional: true },
+    { attribute: 'eventType', type: 'S', optional: true },
+  ],
+});
+
 class StubDdb {
   sent: unknown[] = [];
   calls = 0;
@@ -76,6 +115,23 @@ class StubDdb {
   const cmd = ddb.sent[0];
   assert.ok(cmd instanceof PutItemCommand);
   assert.equal(cmd.input.TableName, 'users_contract');
+  assert.equal(cmd.input.ConditionExpression, 'attribute_not_exists(#pk)');
+  assert.deepEqual(cmd.input.ExpressionAttributeNames, { '#pk': 'PK' });
+}
+
+{
+  const ddb = new StubDdb(() => ({}));
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    ReleaseStateEvent,
+  );
+
+  await client.create('ReleaseStateEvent', {
+    PK: 'RELEASE#service-a',
+    SK: 'EVENT#1',
+    eventType: 'promoted',
+  });
+  const cmd = ddb.sent[0];
+  assert.ok(cmd instanceof PutItemCommand);
   assert.equal(cmd.input.ConditionExpression, 'attribute_not_exists(#pk)');
   assert.deepEqual(cmd.input.ExpressionAttributeNames, { '#pk': 'PK' });
 }
@@ -128,6 +184,20 @@ class StubDdb {
 
 {
   const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof PutItemCommand) return {};
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+  await client.save('User', { PK: 'A', SK: 'B', nickname: 'saved' });
+  const cmd = ddb.sent[0];
+  assert.ok(cmd instanceof PutItemCommand);
+  assert.equal(cmd.input.ConditionExpression, undefined);
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
     if (cmd instanceof UpdateItemCommand) return {};
     throw new Error('unexpected');
   });
@@ -156,6 +226,85 @@ class StubDdb {
 }
 
 {
+  const ddb = new StubDdb(() => {
+    throw new Error('write_once mutation should not send');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    ReleaseStateEvent,
+  );
+
+  await assert.rejects(
+    () =>
+      client.update(
+        'ReleaseStateEvent',
+        { PK: 'RELEASE#service-a', SK: 'EVENT#1', eventType: 'mutated' },
+        ['eventType'],
+      ),
+    (e) => e instanceof TheorydbError && e.code === 'ErrImmutableModelMutation',
+  );
+  await assert.rejects(
+    () =>
+      client.save('ReleaseStateEvent', {
+        PK: 'RELEASE#service-a',
+        SK: 'EVENT#1',
+        eventType: 'overwritten',
+      }),
+    (e) => e instanceof TheorydbError && e.code === 'ErrImmutableModelMutation',
+  );
+  await assert.rejects(
+    () =>
+      client.batchWrite('ReleaseStateEvent', {
+        puts: [{ PK: 'RELEASE#service-a', SK: 'EVENT#2' }],
+      }),
+    (e) => e instanceof TheorydbError && e.code === 'ErrImmutableModelMutation',
+  );
+  assert.equal(ddb.sent.length, 0);
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof UpdateItemCommand) return {};
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    ReleaseStateActual,
+  );
+
+  await client.update(
+    'ReleaseStateActual',
+    { PK: 'RELEASE#service-a', SK: 'ACTUAL', status: 'warming', version: 0 },
+    ['status'],
+  );
+  assert.ok(ddb.sent[0] instanceof UpdateItemCommand);
+
+  await assert.rejects(
+    () =>
+      client.update(
+        'ReleaseStateActual',
+        {
+          PK: 'RELEASE#service-a',
+          SK: 'ACTUAL',
+          pinnedReleaseId: 'rel_002',
+          version: 1,
+        },
+        ['pinnedReleaseId'],
+      ),
+    (e) => e instanceof TheorydbError && e.code === 'ErrProtectedFieldMutation',
+  );
+  await assert.rejects(
+    () =>
+      client.update(
+        'ReleaseStateActual',
+        { PK: 'RELEASE#service-a', SK: 'ACTUAL', status: 'active', version: 1 },
+        ['status'],
+        { protectedAttributes: ['status'] },
+      ),
+    (e) => e instanceof TheorydbError && e.code === 'ErrProtectedFieldMutation',
+  );
+  assert.equal(ddb.sent.length, 1);
+}
+
+{
   const ddb = new StubDdb((cmd) => {
     if (cmd instanceof DeleteItemCommand) return {};
     throw new Error('unexpected');
@@ -165,6 +314,24 @@ class StubDdb {
   );
   await client.delete('User', { PK: 'A', SK: 'B' });
   assert.ok(ddb.sent[0] instanceof DeleteItemCommand);
+}
+
+{
+  const ddb = new StubDdb(() => {
+    throw new Error('write_once delete should not send');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    ReleaseStateEvent,
+  );
+  await assert.rejects(
+    () =>
+      client.delete('ReleaseStateEvent', {
+        PK: 'RELEASE#service-a',
+        SK: 'EVENT#1',
+      }),
+    (e) => e instanceof TheorydbError && e.code === 'ErrImmutableModelMutation',
+  );
+  assert.equal(ddb.sent.length, 0);
 }
 
 {
@@ -318,6 +485,105 @@ class StubDdb {
   assert.ok(update?.UpdateExpression?.includes('if_not_exists'));
   assert.ok(update?.ConditionExpression?.includes('attribute_not_exists'));
   assert.ok(update?.ConditionExpression?.includes('<'));
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof TransactWriteItemsCommand) return {};
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    ReleaseStateEvent,
+  );
+
+  await client.transactWrite([
+    {
+      kind: 'put',
+      model: 'ReleaseStateEvent',
+      item: { PK: 'RELEASE#service-a', SK: 'EVENT#1' },
+    },
+  ]);
+
+  const cmd = ddb.sent[0];
+  assert.ok(cmd instanceof TransactWriteItemsCommand);
+  const put = cmd.input.TransactItems?.[0]?.Put;
+  assert.equal(put?.ConditionExpression, 'attribute_not_exists(#pk)');
+  assert.deepEqual(put?.ExpressionAttributeNames, { '#pk': 'PK' });
+}
+
+{
+  const ddb = new StubDdb(() => {
+    throw new Error('write_once transaction mutation should not send');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    ReleaseStateEvent,
+  );
+
+  await assert.rejects(
+    () =>
+      client.transactWrite([
+        {
+          kind: 'update',
+          model: 'ReleaseStateEvent',
+          key: { PK: 'RELEASE#service-a', SK: 'EVENT#1' },
+          updateExpression: 'SET #e = :e',
+          expressionAttributeNames: { '#e': 'eventType' },
+          expressionAttributeValues: { ':e': { S: 'mutated' } },
+        },
+      ]),
+    (e) => e instanceof TheorydbError && e.code === 'ErrImmutableModelMutation',
+  );
+  await assert.rejects(
+    () =>
+      client.transactWrite([
+        {
+          kind: 'delete',
+          model: 'ReleaseStateEvent',
+          key: { PK: 'RELEASE#service-a', SK: 'EVENT#1' },
+        },
+      ]),
+    (e) => e instanceof TheorydbError && e.code === 'ErrImmutableModelMutation',
+  );
+  assert.equal(ddb.sent.length, 0);
+}
+
+{
+  const ddb = new StubDdb(() => {
+    throw new Error('protected transaction update should not send');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    ReleaseStateActual,
+  );
+
+  await assert.rejects(
+    () =>
+      client.transactWrite([
+        {
+          kind: 'update',
+          model: 'ReleaseStateActual',
+          key: { PK: 'RELEASE#service-a', SK: 'ACTUAL' },
+          updateExpression: 'SET #p = :p',
+          expressionAttributeNames: { '#p': 'pinnedReleaseId' },
+          expressionAttributeValues: { ':p': { S: 'rel_002' } },
+        },
+      ]),
+    (e) => e instanceof TheorydbError && e.code === 'ErrProtectedFieldMutation',
+  );
+  await assert.rejects(
+    () =>
+      client.transactWrite([
+        {
+          kind: 'update',
+          model: 'ReleaseStateActual',
+          key: { PK: 'RELEASE#service-a', SK: 'ACTUAL' },
+          updateFn: (u) => {
+            u.set('pinnedReleaseId', 'rel_002');
+          },
+        },
+      ]),
+    (e) => e instanceof TheorydbError && e.code === 'ErrProtectedFieldMutation',
+  );
+  assert.equal(ddb.sent.length, 0);
 }
 
 {

--- a/ts/test/unit/model.test.ts
+++ b/ts/test/unit/model.test.ts
@@ -92,7 +92,7 @@ const userSchema: ModelSchema = {
     ...userSchema,
     write_policy: {
       mode: 'mutable',
-      protected_attributes: ['nickname'],
+      protected_attributes: ['nickname', 'nickname'],
     },
     attributes: [
       ...userSchema.attributes,
@@ -103,6 +103,29 @@ const userSchema: ModelSchema = {
   const model = defineModel(schema);
   assert.equal(model.writePolicy.mode, 'mutable');
   assert.deepEqual(model.writePolicy.protectedAttributes, ['nickname']);
+}
+
+{
+  const schema = {
+    ...userSchema,
+    write_policy: {
+      mode: 'append_only',
+    },
+    attributes: [
+      ...userSchema.attributes,
+      { attribute: 'emailHash', type: 'S', optional: true },
+    ],
+  } as unknown as ModelSchema;
+
+  assert.throws(
+    () => defineModel(schema),
+    (err) => {
+      assert.ok(err instanceof TheorydbError);
+      assert.equal(err.code, 'ErrInvalidModel');
+      assert.match(String(err.message), /Unsupported write_policy.mode/);
+      return true;
+    },
+  );
 }
 
 {

--- a/ts/test/unit/update-builder.test.ts
+++ b/ts/test/unit/update-builder.test.ts
@@ -288,6 +288,67 @@ import {
 
 {
   const mock = createMockDynamoDBClient();
+  mock.when(UpdateItemCommand, async () => {
+    throw new Error('write_once update builder should not send');
+  });
+
+  const model = defineModel({
+    name: 'Event',
+    table: { name: 't' },
+    keys: { partition: { attribute: 'PK', type: 'S' } },
+    write_policy: { mode: 'write_once' },
+    attributes: [
+      { attribute: 'PK', type: 'S', roles: ['pk'] },
+      { attribute: 'eventType', type: 'S', optional: true },
+    ],
+  });
+
+  const client = new TheorydbClient(mock.client).register(model);
+  await assert.rejects(
+    () =>
+      client
+        .updateBuilder('Event', { PK: 'A' })
+        .set('eventType', 'mutated')
+        .execute(),
+    (e) => e instanceof TheorydbError && e.code === 'ErrImmutableModelMutation',
+  );
+  assert.equal(mock.calls.length, 0);
+}
+
+{
+  const mock = createMockDynamoDBClient();
+  mock.when(UpdateItemCommand, async () => {
+    throw new Error('protected update builder should not send');
+  });
+
+  const model = defineModel({
+    name: 'Actual',
+    table: { name: 't' },
+    keys: { partition: { attribute: 'PK', type: 'S' } },
+    write_policy: {
+      mode: 'mutable',
+      protected_attributes: ['pinnedReleaseId'],
+    },
+    attributes: [
+      { attribute: 'PK', type: 'S', roles: ['pk'] },
+      { attribute: 'pinnedReleaseId', type: 'S', optional: true },
+    ],
+  });
+
+  const client = new TheorydbClient(mock.client).register(model);
+  await assert.rejects(
+    () =>
+      client
+        .updateBuilder('Actual', { PK: 'A' })
+        .set('pinnedReleaseId', 'rel_002')
+        .execute(),
+    (e) => e instanceof TheorydbError && e.code === 'ErrProtectedFieldMutation',
+  );
+  assert.equal(mock.calls.length, 0);
+}
+
+{
+  const mock = createMockDynamoDBClient();
   mock.when(UpdateItemCommand, async () => ({ $metadata: {} }));
   const provider = createDeterministicEncryptionProvider('seed');
 


### PR DESCRIPTION
## Milestone
tt-release-state-ts-policy — Add TypeScript schema support and enforcement for release-state write policies.

## Linear
https://linear.app/pay-theory/project/tabletheory-release-state-write-policies-0ebbc8f7b4c1 / tt-release-state-ts-policy

## Affected runtimes
TypeScript

## Contract impact
Additive runtime implementation for the existing DMS `write_policy` contract. The TypeScript contract runner now advertises `release_state.write_policy`, so P0 scenarios 06/07 execute for TS. Scenarios 08/09 remain capability-skipped until the helper/provenance milestones.

## Backward compatibility
Additive. `write_policy` remains optional and defaults to mutable with no protected attributes. Existing models without `write_policy` keep current behavior.

## Tasks
- [x] IO-75 — Add TypeScript write_policy schema support and enforcement

## Validation
- [x] `cd ts && npm run format:check && npm run lint && npm run typecheck && npm run test:unit`
- [x] `npm --prefix contract-tests/runners/ts test`
- [x] `cd contract-tests/runners/go && go test ./... -v`
- [x] `uv --directory py run pytest -q ../contract-tests/runners/py --import-mode=importlib`
- [x] `make test-unit`
- [x] `bash scripts/verify-branch-version-sync.sh` (SKIP on non-release branch)
- [x] `make rubric`

## Cross-repo coordination
None for this additive TS milestone. Downstream release-control-plane usage should wait until Go/TS/Py enforcement and helper milestones are all complete.
