### PR TITLE
feat(py): enforce release-state write policies

### DIFF
--- a/contract-tests/runners/py/test_contract_release_state_fixtures.py
+++ b/contract-tests/runners/py/test_contract_release_state_fixtures.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 import yaml
+
+from theorydb_py import (
+    ConditionFailedError,
+    ImmutableModelMutationError,
+    ModelDefinition,
+    ProtectedFieldMutationError,
+    Table,
+    WritePolicy,
+    theorydb_field,
+)
 
 
 def _repo_root() -> Path:
@@ -53,6 +65,33 @@ def test_release_state_p0_scenarios_are_capability_gated() -> None:
         _validate_scenario_steps(path.name, scenario)
 
 
+def test_release_state_write_policy_scenarios_execute_for_python() -> None:
+    root = _repo_root()
+    scenario_dir = root / "contract-tests" / "scenarios" / "p0"
+    scenarios = [
+        _load_yaml(scenario_dir / "06-release-state-write-policy.yml"),
+        _load_yaml(scenario_dir / "07-release-state-protected-fields.yml"),
+    ]
+
+    for scenario in scenarios:
+        assert "release_state.write_policy" in scenario.get("requires_capabilities", [])
+        driver = _ReleaseStatePyDriver()
+        for step in scenario["steps"]:
+            error = _capture_contract_error(
+                lambda driver=driver, scenario=scenario, step=step: driver.run_step(scenario, step)
+            )
+            expected = step.get("expect", {})
+            if expected.get("ok") is True:
+                assert error is None, f"{scenario['name']} step {step['op']} expected ok, got {error}"
+                continue
+            if "error" in expected:
+                assert error == expected["error"], (
+                    f"{scenario['name']} step {step['op']} expected {expected['error']}, got {error}"
+                )
+                continue
+            assert error is None
+
+
 def _validate_scenario_steps(name: str, scenario: dict[str, Any]) -> None:
     steps = scenario.get("steps")
     assert isinstance(steps, list) and steps, f"{name} must declare steps[]"
@@ -96,3 +135,161 @@ def _validate_transition_event(name: str, index: int, value: Any) -> None:
     assert isinstance(value, dict), f"{name} step {index} transition event must be an object"
     assert isinstance(value.get("model"), str) and value["model"], f"{name} step {index} event.model required"
     assert isinstance(value.get("item"), dict) and value["item"], f"{name} step {index} event.item required"
+
+
+@dataclass(frozen=True)
+class _ReleaseStateActual:
+    PK: str = theorydb_field(name="PK", roles=["pk"])
+    SK: str = theorydb_field(name="SK", roles=["sk"])
+    status: str | None = theorydb_field(default=None)
+    pinnedReleaseId: str | None = theorydb_field(default=None)
+    previousReleaseId: str | None = theorydb_field(default=None)
+    provenance: dict[str, Any] | None = theorydb_field(json=True, default=None)
+    confidence: dict[str, Any] | None = theorydb_field(json=True, default=None)
+    version: int = theorydb_field(roles=["version"], default=0)
+
+
+@dataclass(frozen=True)
+class _ReleaseStateEvent:
+    PK: str = theorydb_field(name="PK", roles=["pk"])
+    SK: str = theorydb_field(name="SK", roles=["sk"])
+    releaseId: str | None = theorydb_field(default=None)
+    eventType: str | None = theorydb_field(default=None)
+    provenance: dict[str, Any] | None = theorydb_field(json=True, default=None)
+    confidence: dict[str, Any] | None = theorydb_field(json=True, default=None)
+    recordedAt: str | None = theorydb_field(default=None)
+    ttl: int | None = theorydb_field(roles=["ttl"], omitempty=True, default=None)
+
+
+class _ReleaseStatePyDriver:
+    def __init__(self) -> None:
+        self.client = _InMemoryDynamoDBClient()
+        self.tables: dict[str, Table[Any]] = {
+            "ReleaseStateActual": Table(
+                ModelDefinition.from_dataclass(
+                    _ReleaseStateActual,
+                    table_name="release_state_contract",
+                    write_policy=WritePolicy(mode="mutable", protected_attributes=["pinnedReleaseId"]),
+                ),
+                client=self.client,
+            ),
+            "ReleaseStateEvent": Table(
+                ModelDefinition.from_dataclass(
+                    _ReleaseStateEvent,
+                    table_name="release_state_contract",
+                    write_policy=WritePolicy(mode="write_once"),
+                ),
+                client=self.client,
+            ),
+        }
+
+    def run_step(self, scenario: dict[str, Any], step: dict[str, Any]) -> None:
+        model_name = step.get("model") or scenario["model"]
+        table = self.tables[model_name]
+
+        if step["op"] == "create":
+            kwargs: dict[str, Any] = {}
+            if step.get("if_not_exists"):
+                kwargs = {
+                    "condition_expression": "attribute_not_exists(#pk)",
+                    "expression_attribute_names": {"#pk": table._model.pk.attribute_name},
+                }
+            table.put(self._item(model_name, step["item"]), **kwargs)
+            return
+
+        if step["op"] == "save":
+            table.save(self._item(model_name, step["item"]))
+            return
+
+        if step["op"] == "update":
+            item = step["item"]
+            updates = {field: item[field] for field in step.get("fields", []) if field in item}
+            table.update(
+                item["PK"],
+                item["SK"],
+                updates,
+                protected_attributes=step.get("protected_attributes", []),
+            )
+            return
+
+        if step["op"] == "delete":
+            key = step["key"]
+            table.delete(key["PK"], key["SK"])
+            return
+
+        if step["op"] == "get":
+            key = step["key"]
+            table.get(key["PK"], key["SK"], consistent_read=True)
+            return
+
+        raise AssertionError(f"unsupported executable op: {step['op']}")
+
+    @staticmethod
+    def _item(model_name: str, item: dict[str, Any]) -> Any:
+        if model_name == "ReleaseStateActual":
+            return _ReleaseStateActual(**item)
+        if model_name == "ReleaseStateEvent":
+            return _ReleaseStateEvent(**item)
+        raise AssertionError(f"unknown model: {model_name}")
+
+
+class _InMemoryDynamoDBClient:
+    def __init__(self) -> None:
+        self.items: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    def put_item(self, **req: Any) -> dict[str, Any]:
+        key = self._key(req["TableName"], req["Item"])
+        if "attribute_not_exists" in req.get("ConditionExpression", "") and key in self.items:
+            raise ConditionFailedError("conditional write failed")
+        self.items[key] = dict(req["Item"])
+        return {}
+
+    def get_item(self, **req: Any) -> dict[str, Any]:
+        item = self.items.get(self._key(req["TableName"], req["Key"]))
+        return {"Item": dict(item)} if item is not None else {}
+
+    def delete_item(self, **req: Any) -> dict[str, Any]:
+        self.items.pop(self._key(req["TableName"], req["Key"]), None)
+        return {}
+
+    def update_item(self, **req: Any) -> dict[str, Any]:
+        key = self._key(req["TableName"], req["Key"])
+        item = dict(self.items[key])
+        names = req.get("ExpressionAttributeNames", {})
+        values = req.get("ExpressionAttributeValues", {})
+        for assignment in _set_assignments(req["UpdateExpression"]):
+            left, right = [part.strip() for part in assignment.split("=", 1)]
+            item[names[left]] = values[right]
+        self.items[key] = item
+        return {"Attributes": dict(item)}
+
+    @staticmethod
+    def _key(table_name: str, attrs: dict[str, Any]) -> tuple[str, str, str]:
+        return (table_name, _av_to_string(attrs["PK"]), _av_to_string(attrs["SK"]))
+
+
+def _set_assignments(update_expression: str) -> list[str]:
+    match = re.search(r"\bSET\b([\s\S]*?)(?=\b(?:REMOVE|ADD|DELETE)\b|$)", update_expression)
+    if not match:
+        return []
+    return [part.strip() for part in match.group(1).split(",") if part.strip()]
+
+
+def _av_to_string(value: dict[str, Any]) -> str:
+    if "S" in value:
+        return str(value["S"])
+    if "N" in value:
+        return str(value["N"])
+    raise AssertionError(f"unsupported key attribute value: {value!r}")
+
+
+def _capture_contract_error(fn: Any) -> str | None:
+    try:
+        fn()
+    except ImmutableModelMutationError:
+        return "ErrImmutableModelMutation"
+    except ProtectedFieldMutationError:
+        return "ErrProtectedFieldMutation"
+    except ConditionFailedError:
+        return "ErrConditionFailed"
+    return None

--- a/py/src/theorydb_py/model.py
+++ b/py/src/theorydb_py/model.py
@@ -76,17 +76,35 @@ class WritePolicy:
     protected_attributes: Sequence[str] = ()
 
     def __post_init__(self) -> None:
-        if self.mode not in {"mutable", "write_once"}:
+        mode = self.mode or "mutable"
+        if mode not in {"mutable", "write_once"}:
             raise ModelDefinitionError(f"unsupported write_policy.mode: {self.mode}")
+        object.__setattr__(self, "mode", mode)
         if isinstance(self.protected_attributes, str):
             raise ModelDefinitionError("write_policy protected attributes must be a sequence of names")
-        protected = tuple(self.protected_attributes)
-        object.__setattr__(self, "protected_attributes", protected)
-        for attr in protected:
+        protected: set[str] = set()
+        for attr in self.protected_attributes:
             if not isinstance(attr, str):
                 raise ModelDefinitionError("write_policy protected attributes must contain strings")
+            attr = attr.strip()
             if not attr:
                 raise ModelDefinitionError("write_policy protected attributes must be non-empty")
+            protected.add(attr)
+        object.__setattr__(self, "protected_attributes", tuple(sorted(protected)))
+
+
+def _resolve_write_policy(
+    policy: WritePolicy | None, attributes: Mapping[str, AttributeDefinition]
+) -> WritePolicy:
+    resolved = policy or WritePolicy()
+    protected: set[str] = set()
+    by_attribute_name = {attr.attribute_name: attr for attr in attributes.values()}
+    for attr in resolved.protected_attributes:
+        attr_def = attributes.get(attr) or by_attribute_name.get(attr)
+        if attr_def is None:
+            raise ModelDefinitionError(f"write_policy protected attribute not found: {attr}")
+        protected.add(attr_def.attribute_name)
+    return WritePolicy(mode=resolved.mode, protected_attributes=tuple(sorted(protected)))
 
 
 @overload
@@ -337,11 +355,7 @@ class ModelDefinition[T]:
                 )
             )
 
-        resolved_write_policy = write_policy or WritePolicy()
-        attribute_names = {attr.attribute_name for attr in attributes.values()}
-        for attr in resolved_write_policy.protected_attributes:
-            if attr not in attribute_names:
-                raise ModelDefinitionError(f"write_policy protected attribute not found: {attr}")
+        resolved_write_policy = _resolve_write_policy(write_policy, attributes)
 
         return cls(
             model_type=model_type,

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -39,6 +39,11 @@ from .transaction import (
     UpdateAdd,
     UpdateSetIfNotExists,
 )
+from .write_policy import (
+    apply_write_once_create_condition,
+    assert_mutable_write_policy,
+    assert_protected_fields_can_mutate,
+)
 
 if TYPE_CHECKING:
     from .optimizer import QueryShape, ScanShape
@@ -648,6 +653,11 @@ class Table[T]:
         if max_retries < 0:
             raise ValidationError("max_retries must be >= 0")
 
+        if puts:
+            assert_mutable_write_policy(self._model, "batch put")
+        if deletes:
+            assert_mutable_write_policy(self._model, "batch delete")
+
         requests: list[dict[str, Any]] = []
         for item in puts:
             requests.append({"PutRequest": {"Item": self._to_item(item)}})
@@ -706,10 +716,12 @@ class Table[T]:
                     req["ExpressionAttributeValues"] = self._serialize_values(
                         action.expression_attribute_values
                     )
+                apply_write_once_create_condition(self._model, req)
                 transact_items.append({"Put": req})
                 continue
 
             if isinstance(action, TransactDelete):
+                assert_mutable_write_policy(self._model, "transaction delete")
                 req = {"TableName": self._table_name, "Key": self._to_key(action.pk, action.sk)}
                 if action.condition_expression:
                     req["ConditionExpression"] = action.condition_expression
@@ -732,6 +744,7 @@ class Table[T]:
                             condition_expression=action.condition_expression,
                             expression_attribute_names=action.expression_attribute_names,
                             expression_attribute_values=action.expression_attribute_values,
+                            protected_attributes=action.protected_attributes,
                         )
                     }
                 )
@@ -776,9 +789,26 @@ class Table[T]:
                 req["ExpressionAttributeNames"] = dict(expression_attribute_names)
             if expression_attribute_values:
                 req["ExpressionAttributeValues"] = self._serialize_values(expression_attribute_values)
+            apply_write_once_create_condition(self._model, req)
             self._client.put_item(**req)
         except ClientError as err:  # pragma: no cover (depends on AWS error shapes)
             raise _map_client_error(err) from err
+
+    def save(
+        self,
+        item: T,
+        *,
+        condition_expression: str | None = None,
+        expression_attribute_names: Mapping[str, str] | None = None,
+        expression_attribute_values: Mapping[str, Any] | None = None,
+    ) -> None:
+        assert_mutable_write_policy(self._model, "save")
+        self.put(
+            item,
+            condition_expression=condition_expression,
+            expression_attribute_names=expression_attribute_names,
+            expression_attribute_values=expression_attribute_values,
+        )
 
     def get(self, pk: Any, sk: Any | None = None, *, consistent_read: bool = False) -> T:
         key = self._to_key(pk, sk)
@@ -801,6 +831,7 @@ class Table[T]:
         expression_attribute_names: Mapping[str, str] | None = None,
         expression_attribute_values: Mapping[str, Any] | None = None,
     ) -> None:
+        assert_mutable_write_policy(self._model, "delete")
         key = self._to_key(pk, sk)
         req: dict[str, Any] = {"TableName": self._table_name, "Key": key}
         if condition_expression:
@@ -824,6 +855,7 @@ class Table[T]:
         condition_expression: str | None = None,
         expression_attribute_names: Mapping[str, str] | None = None,
         expression_attribute_values: Mapping[str, Any] | None = None,
+        protected_attributes: Sequence[str] = (),
     ) -> T:
         req = self._build_update_request(
             pk,
@@ -832,6 +864,7 @@ class Table[T]:
             condition_expression=condition_expression,
             expression_attribute_names=expression_attribute_names,
             expression_attribute_values=expression_attribute_values,
+            protected_attributes=protected_attributes,
             return_values="ALL_NEW",
         )
 
@@ -859,9 +892,16 @@ class Table[T]:
         condition_expression: str | None = None,
         expression_attribute_names: Mapping[str, str] | None = None,
         expression_attribute_values: Mapping[str, Any] | None = None,
+        protected_attributes: Sequence[str] = (),
         return_values: str | None = None,
     ) -> dict[str, Any]:
         key = self._to_key(pk, sk)
+        assert_mutable_write_policy(self._model, "update")
+        assert_protected_fields_can_mutate(
+            self._model,
+            tuple(str(field) for field in updates.keys()),
+            protected_attributes,
+        )
 
         update_names: dict[str, str] = {}
         update_values: dict[str, Any] = {}

--- a/py/src/theorydb_py/transaction.py
+++ b/py/src/theorydb_py/transaction.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -40,6 +40,7 @@ class TransactUpdate:
     condition_expression: str | None = None
     expression_attribute_names: Mapping[str, str] | None = None
     expression_attribute_values: Mapping[str, Any] | None = None
+    protected_attributes: Sequence[str] = ()
 
 
 @dataclass(frozen=True)

--- a/py/src/theorydb_py/update_builder.py
+++ b/py/src/theorydb_py/update_builder.py
@@ -9,6 +9,7 @@ from botocore.exceptions import ClientError
 from .aws_errors import map_client_error as _map_client_error
 from .errors import ValidationError
 from .model import AttributeDefinition
+from .write_policy import assert_mutable_write_policy, assert_protected_fields_can_mutate
 
 if TYPE_CHECKING:
     from .table import Table
@@ -119,6 +120,7 @@ class UpdateBuilder[T]:
 
     def _build_request(self) -> dict[str, Any]:
         key = self._table._to_key(self._pk, self._sk)
+        assert_mutable_write_policy(self._table._model, "update builder")
 
         names: dict[str, str] = {}
         update_values: dict[str, Any] = {}
@@ -139,6 +141,8 @@ class UpdateBuilder[T]:
                 self._table._model.sk is not None and field_name == self._table._model.sk.python_name
             ):
                 raise ValidationError(f"cannot update key field: {field_name}")
+
+            assert_protected_fields_can_mutate(self._table._model, [field_name])
 
             attr_def = self._table._model.attributes[field_name]
             ref = f"#u_{field_name}"

--- a/py/src/theorydb_py/write_policy.py
+++ b/py/src/theorydb_py/write_policy.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .errors import ImmutableModelMutationError, ProtectedFieldMutationError, ValidationError
+from .model import ModelDefinition
+
+
+def is_write_once_model(model: ModelDefinition[Any]) -> bool:
+    return model.write_policy.mode == "write_once"
+
+
+def assert_mutable_write_policy(model: ModelDefinition[Any], operation: str) -> None:
+    if not is_write_once_model(model):
+        return
+    raise ImmutableModelMutationError(operation or "mutation")
+
+
+def assert_protected_fields_can_mutate(
+    model: ModelDefinition[Any],
+    fields: Sequence[str],
+    extra_protected: Sequence[str] = (),
+) -> None:
+    protected = _protected_attribute_set(model, extra_protected)
+    if not protected:
+        return
+
+    for field in fields:
+        attr = root_attribute_name(canonical_attribute_name(model, field))
+        if attr in protected:
+            raise ProtectedFieldMutationError(attr)
+
+
+def apply_write_once_create_condition(model: ModelDefinition[Any], request: dict[str, Any]) -> None:
+    if not is_write_once_model(model):
+        return
+
+    names = dict(request.get("ExpressionAttributeNames") or {})
+    placeholder = _write_once_pk_placeholder(names, model.pk.attribute_name)
+    names[placeholder] = model.pk.attribute_name
+
+    write_once_condition = f"attribute_not_exists({placeholder})"
+    condition = request.get("ConditionExpression")
+    if condition:
+        request["ConditionExpression"] = f"({condition}) AND {write_once_condition}"
+    else:
+        request["ConditionExpression"] = write_once_condition
+    request["ExpressionAttributeNames"] = names
+
+
+def canonical_attribute_name(model: ModelDefinition[Any], field: str) -> str:
+    field = str(field).strip()
+    if not field:
+        return field
+
+    root = root_attribute_name(field)
+    if not root:
+        return field
+
+    attr_def = model.attributes.get(root)
+    if attr_def is not None:
+        return _replace_root_attribute(field, attr_def.attribute_name)
+
+    for candidate in model.attributes.values():
+        if candidate.attribute_name == root:
+            return field
+
+    return field
+
+
+def root_attribute_name(field: str) -> str:
+    field = str(field).strip()
+    if not field:
+        return ""
+    match = re.match(r"^[^\s.\[=,)]+", field)
+    return match.group(0) if match else field
+
+
+def _protected_attribute_set(
+    model: ModelDefinition[Any],
+    extra_protected: Sequence[str],
+) -> set[str]:
+    protected: set[str] = set()
+    for attr in model.write_policy.protected_attributes:
+        root = root_attribute_name(canonical_attribute_name(model, attr))
+        if root:
+            protected.add(root)
+    for attr in _normalize_extra_protected(extra_protected):
+        root = root_attribute_name(canonical_attribute_name(model, attr))
+        if root:
+            protected.add(root)
+    return protected
+
+
+def _normalize_extra_protected(extra_protected: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(extra_protected, str):
+        raise ValidationError("protected_attributes must be a sequence of names")
+    protected: set[str] = set()
+    for attr in extra_protected:
+        if not isinstance(attr, str):
+            raise ValidationError("protected_attributes must contain strings")
+        attr = attr.strip()
+        if not attr:
+            raise ValidationError("protected_attributes must be non-empty")
+        protected.add(attr)
+    return tuple(sorted(protected))
+
+
+def _replace_root_attribute(field: str, replacement: str) -> str:
+    root = root_attribute_name(field)
+    if not root:
+        return replacement
+    return replacement + field[len(root) :]
+
+
+def _write_once_pk_placeholder(names: Mapping[str, str], pk_attribute: str) -> str:
+    if names.get("#pk") in {None, pk_attribute}:
+        return "#pk"
+
+    base = "#write_once_pk"
+    placeholder = base
+    index = 1
+    while placeholder in names and names[placeholder] != pk_attribute:
+        placeholder = f"{base}{index}"
+        index += 1
+    return placeholder

--- a/py/tests/unit/test_model_definition.py
+++ b/py/tests/unit/test_model_definition.py
@@ -4,7 +4,15 @@ from dataclasses import dataclass
 
 import pytest
 
-from theorydb_py.model import ModelDefinition, ModelDefinitionError, Projection, gsi, lsi, theorydb_field
+from theorydb_py.model import (
+    ModelDefinition,
+    ModelDefinitionError,
+    Projection,
+    WritePolicy,
+    gsi,
+    lsi,
+    theorydb_field,
+)
 
 
 @dataclass(frozen=True)
@@ -98,3 +106,34 @@ def test_model_definition_rejects_json_set_and_json_binary() -> None:
 
     with pytest.raises(ModelDefinitionError, match="json and binary"):
         ModelDefinition.from_dataclass(JsonBinary)
+
+
+def test_model_definition_normalizes_write_policy() -> None:
+    model = ModelDefinition.from_dataclass(
+        User,
+        table_name="users",
+        write_policy=WritePolicy(
+            mode="",
+            protected_attributes=[" emailHash ", "email_hash", "emailHash"],
+        ),
+    )
+
+    assert model.write_policy.mode == "mutable"
+    assert model.write_policy.protected_attributes == ("emailHash",)
+
+
+def test_model_definition_rejects_invalid_write_policy() -> None:
+    with pytest.raises(ModelDefinitionError, match="unsupported write_policy.mode"):
+        WritePolicy(mode="frozen")
+
+    with pytest.raises(ModelDefinitionError, match="protected attributes must be a sequence"):
+        WritePolicy(protected_attributes="emailHash")  # type: ignore[arg-type]
+
+    with pytest.raises(ModelDefinitionError, match="must contain strings"):
+        WritePolicy(protected_attributes=[123])  # type: ignore[list-item]
+
+    with pytest.raises(ModelDefinitionError, match="must be non-empty"):
+        WritePolicy(protected_attributes=[" "])
+
+    with pytest.raises(ModelDefinitionError, match="protected attribute not found"):
+        ModelDefinition.from_dataclass(User, write_policy=WritePolicy(protected_attributes=["missing"]))

--- a/py/tests/unit/test_write_policy.py
+++ b/py/tests/unit/test_write_policy.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from theorydb_py import (
+    ImmutableModelMutationError,
+    ModelDefinition,
+    ProtectedFieldMutationError,
+    Table,
+    TransactDelete,
+    TransactPut,
+    TransactUpdate,
+    WritePolicy,
+    theorydb_field,
+)
+from theorydb_py.mocks import FakeDynamoDBClient
+
+
+@dataclass(frozen=True)
+class ReleaseStateActual:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    status: str = theorydb_field(default="")
+    pinned_release_id: str = theorydb_field(name="pinnedReleaseId", default="")
+    previous_release_id: str = theorydb_field(name="previousReleaseId", default="")
+    version: int = theorydb_field(roles=["version"], default=0)
+
+
+@dataclass(frozen=True)
+class ReleaseStateEvent:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    release_id: str = theorydb_field(name="releaseId", default="")
+    event_type: str = theorydb_field(name="eventType", default="")
+
+
+def _actual_model() -> ModelDefinition[ReleaseStateActual]:
+    return ModelDefinition.from_dataclass(
+        ReleaseStateActual,
+        table_name="release_state_contract",
+        write_policy=WritePolicy(
+            mode="mutable",
+            protected_attributes=["pinned_release_id", "pinnedReleaseId"],
+        ),
+    )
+
+
+def _event_model() -> ModelDefinition[ReleaseStateEvent]:
+    return ModelDefinition.from_dataclass(
+        ReleaseStateEvent,
+        table_name="release_state_contract",
+        write_policy=WritePolicy(mode="write_once"),
+    )
+
+
+def test_write_once_put_adds_default_condition_and_save_mutations_reject() -> None:
+    client = FakeDynamoDBClient()
+
+    def validate_put(req: dict[str, Any]) -> None:
+        assert req["ConditionExpression"] == "attribute_not_exists(#pk)"
+        assert req["ExpressionAttributeNames"]["#pk"] == "PK"
+
+    client.expect("put_item", validate_put, response={})
+    table: Table[ReleaseStateEvent] = Table(_event_model(), client=client)
+
+    event = ReleaseStateEvent(pk="RELEASE#service-a", sk="EVENT#1", event_type="promoted")
+    table.put(event)
+    client.assert_no_pending()
+
+    for operation in (
+        lambda: table.save(event),
+        lambda: table.update("RELEASE#service-a", "EVENT#1", {"event_type": "mutated"}),
+        lambda: table.delete("RELEASE#service-a", "EVENT#1"),
+        lambda: table.batch_write(puts=[event]),
+        lambda: table.batch_write(deletes=[("RELEASE#service-a", "EVENT#1")]),
+    ):
+        with pytest.raises(ImmutableModelMutationError):
+            operation()
+
+    assert len(client.calls) == 1
+
+
+def test_write_once_put_combines_existing_condition_without_loosened_names() -> None:
+    client = FakeDynamoDBClient()
+
+    def validate_put(req: dict[str, Any]) -> None:
+        assert (
+            req["ConditionExpression"] == "(#existing = :expected) AND attribute_not_exists(#write_once_pk)"
+        )
+        assert req["ExpressionAttributeNames"] == {
+            "#pk": "notPK",
+            "#existing": "eventType",
+            "#write_once_pk": "PK",
+        }
+
+    client.expect("put_item", validate_put, response={})
+    table: Table[ReleaseStateEvent] = Table(_event_model(), client=client)
+    table.put(
+        ReleaseStateEvent(pk="RELEASE#service-a", sk="EVENT#1", event_type="promoted"),
+        condition_expression="#existing = :expected",
+        expression_attribute_names={"#pk": "notPK", "#existing": "eventType"},
+        expression_attribute_values={":expected": "promoted"},
+    )
+    client.assert_no_pending()
+
+
+def test_protected_attributes_block_table_updates_with_additive_tightening() -> None:
+    client = FakeDynamoDBClient()
+    model = _actual_model()
+    table: Table[ReleaseStateActual] = Table(model, client=client)
+
+    def validate_status_update(req: dict[str, Any]) -> None:
+        assert _updates_field(req, "status")
+
+    client.expect(
+        "update_item",
+        validate_status_update,
+        response={
+            "Attributes": table._to_item(
+                ReleaseStateActual(pk="RELEASE#service-a", sk="ACTUAL", status="warming")
+            )
+        },
+    )
+
+    table.update("RELEASE#service-a", "ACTUAL", {"status": "warming"})
+    client.assert_no_pending()
+
+    with pytest.raises(ProtectedFieldMutationError):
+        table.update("RELEASE#service-a", "ACTUAL", {"pinned_release_id": "rel_002"})
+
+    with pytest.raises(ProtectedFieldMutationError):
+        table.update("RELEASE#service-a", "ACTUAL", {"pinned_release_id.value": "rel_002"})
+
+    with pytest.raises(ProtectedFieldMutationError):
+        table.update(
+            "RELEASE#service-a",
+            "ACTUAL",
+            {"status": "active"},
+            protected_attributes=["status"],
+        )
+
+    client.expect("delete_item", response={})
+    table.delete("RELEASE#service-a", "ACTUAL")
+    client.assert_no_pending()
+
+
+def test_protected_attributes_block_update_builder_mutations() -> None:
+    table: Table[ReleaseStateActual] = Table(_actual_model(), client=FakeDynamoDBClient())
+
+    with pytest.raises(ProtectedFieldMutationError):
+        table.update_builder("RELEASE#service-a", "ACTUAL").set("pinned_release_id", "rel_002").execute()
+
+    with pytest.raises(ProtectedFieldMutationError):
+        table.update_builder("RELEASE#service-a", "ACTUAL").remove("pinned_release_id").execute()
+
+
+def test_transactions_enforce_write_policy() -> None:
+    event_client = FakeDynamoDBClient()
+
+    def validate_put(req: dict[str, Any]) -> None:
+        put = req["TransactItems"][0]["Put"]
+        assert put["ConditionExpression"] == "attribute_not_exists(#pk)"
+        assert put["ExpressionAttributeNames"]["#pk"] == "PK"
+
+    event_client.expect("transact_write_items", validate_put, response={})
+    event_table: Table[ReleaseStateEvent] = Table(_event_model(), client=event_client)
+    event_table.transact_write(
+        [TransactPut(item=ReleaseStateEvent(pk="RELEASE#service-a", sk="EVENT#1", event_type="promoted"))]
+    )
+    event_client.assert_no_pending()
+
+    with pytest.raises(ImmutableModelMutationError):
+        event_table.transact_write(
+            [TransactUpdate(pk="RELEASE#service-a", sk="EVENT#1", updates={"event_type": "mutated"})]
+        )
+
+    with pytest.raises(ImmutableModelMutationError):
+        event_table.transact_write([TransactDelete(pk="RELEASE#service-a", sk="EVENT#1")])
+
+    actual_table: Table[ReleaseStateActual] = Table(_actual_model(), client=FakeDynamoDBClient())
+    with pytest.raises(ProtectedFieldMutationError):
+        actual_table.transact_write(
+            [
+                TransactUpdate(
+                    pk="RELEASE#service-a",
+                    sk="ACTUAL",
+                    updates={"status": "warming"},
+                    protected_attributes=["status"],
+                )
+            ]
+        )
+
+
+def _updates_field(req: dict[str, Any], attribute_name: str) -> bool:
+    return attribute_name in req["ExpressionAttributeNames"].values()


### PR DESCRIPTION
## Milestone
tt-release-state-py-policy — Add Python ModelDefinition support and enforcement for release-state write policies.

## Linear
https://linear.app/pay-theory/project/tabletheory-release-state-write-policies-0ebbc8f7b4c1/overview / IO-76

## Affected runtimes
Python, plus Python contract-runner coverage for release-state write-policy scenarios.

## Contract impact
Additive runtime enforcement for the existing DMS `write_policy` contract. Python now executes P0 release-state scenarios 06/07 in its contract runner; transactional transition and provenance/confidence remain future capability-gated work.

## Backward compatibility
Additive / opt-in. Existing Python models without `write_policy` continue to normalize to mutable mode with no protected attributes. New `Table.save(...)` is additive; `Table.put(...)` remains available and write-once models receive a create-only condition.

## Tasks
- [x] IO-76 Add Python write_policy metadata and enforcement

## Validation
- `git diff --check`
- `cd py && python -m ruff format --check src tests && python -m ruff check src tests ../contract-tests/runners/py`
- `cd py && python -m pytest -q --import-mode=importlib`
- `uv --directory py run pytest -q ../contract-tests/runners/py --import-mode=importlib`
- `cd contract-tests/runners/go && go test ./... -v`
- `npm --prefix contract-tests/runners/ts test`
- `make test-unit`
- `bash scripts/verify-branch-version-sync.sh` (SKIP on non-release branch)
- `make rubric`

## Cross-repo coordination
None for this additive, opt-in Python runtime enforcement milestone.
