### PR TITLE
feat(releasestate): add release-state helpers

### DIFF
--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	"github.com/theory-cloud/tabletheory/pkg/model"
+	"github.com/theory-cloud/tabletheory/pkg/releasestate"
 	"github.com/theory-cloud/tabletheory/pkg/session"
 )
 
@@ -90,6 +91,7 @@ func (d *TheorydbDriver) Capabilities() []string {
 		"optimistic_lock.version",
 		"ttl.epoch_seconds",
 		"release_state.write_policy",
+		"release_state.transactional_transition",
 	}
 }
 
@@ -214,12 +216,30 @@ func (d *TheorydbDriver) Delete(ctx context.Context, model string, key map[strin
 }
 
 func (d *TheorydbDriver) TransitionAppendEvent(ctx context.Context, actual TransitionActual, event TransitionEvent) error {
-	return fmt.Errorf(
-		"%w: transition_append_event not implemented for %s/%s",
-		theorydbErrors.ErrInvalidModel,
-		actual.Model,
-		event.Model,
-	)
+	if actual.Model != "ReleaseStateActual" || event.Model != "ReleaseStateEvent" {
+		return fmt.Errorf("%w: unsupported transition models %s/%s", theorydbErrors.ErrInvalidModel, actual.Model, event.Model)
+	}
+
+	actualItem := make(map[string]any, len(actual.Key))
+	for k, v := range actual.Key {
+		actualItem[k] = v
+	}
+	actualModel, err := releaseStateActualFromMap(actualItem)
+	if err != nil {
+		return err
+	}
+
+	eventModel, err := releaseStateEventFromMap(event.Item)
+	if err != nil {
+		return err
+	}
+
+	return releasestate.TransitionAppendEvent(ctx, d.db, releasestate.TransitionAppendEventInput{
+		Actual:          actualModel,
+		Event:           eventModel,
+		Set:             actual.Set,
+		ExpectedVersion: actual.ExpectedVersion,
+	})
 }
 
 func (d *TheorydbDriver) ValidateProvenance(ctx context.Context, model string, item map[string]any) error {

--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -92,6 +92,7 @@ func (d *TheorydbDriver) Capabilities() []string {
 		"ttl.epoch_seconds",
 		"release_state.write_policy",
 		"release_state.transactional_transition",
+		"release_state.provenance_confidence",
 	}
 }
 
@@ -124,6 +125,9 @@ func NewTheorydbDriver() (*TheorydbDriver, error) {
 }
 
 func (d *TheorydbDriver) Create(ctx context.Context, model string, item map[string]any, ifNotExists bool) error {
+	if err := validateReleaseStateMetadataIfPresent(model, item); err != nil {
+		return err
+	}
 	instance, err := modelFromMap(model, item)
 	if err != nil {
 		return err
@@ -188,6 +192,9 @@ func (d *TheorydbDriver) Update(ctx context.Context, model string, item map[stri
 }
 
 func (d *TheorydbDriver) Save(ctx context.Context, model string, item map[string]any) error {
+	if err := validateReleaseStateMetadataIfPresent(model, item); err != nil {
+		return err
+	}
 	instance, err := modelFromMap(model, item)
 	if err != nil {
 		return err
@@ -243,7 +250,22 @@ func (d *TheorydbDriver) TransitionAppendEvent(ctx context.Context, actual Trans
 }
 
 func (d *TheorydbDriver) ValidateProvenance(ctx context.Context, model string, item map[string]any) error {
-	return fmt.Errorf("%w: validate_provenance not implemented for %s", theorydbErrors.ErrInvalidModel, model)
+	if model != "ReleaseStateActual" {
+		return fmt.Errorf("%w: validate_provenance unsupported for %s", theorydbErrors.ErrInvalidModel, model)
+	}
+	return releasestate.ValidateDeployAuthorityMetadata(item)
+}
+
+func validateReleaseStateMetadataIfPresent(model string, item map[string]any) error {
+	if model != "ReleaseStateActual" {
+		return nil
+	}
+	_, hasProvenance := item["provenance"]
+	_, hasConfidence := item["confidence"]
+	if !hasProvenance && !hasConfidence {
+		return nil
+	}
+	return releasestate.ValidateDeployAuthorityMetadata(item)
 }
 
 func keyValues(key map[string]any) (string, string, error) {

--- a/contract-tests/runners/py/test_contract_release_state_fixtures.py
+++ b/contract-tests/runners/py/test_contract_release_state_fixtures.py
@@ -14,10 +14,12 @@ from theorydb_py import (
     ImmutableModelMutationError,
     ModelDefinition,
     ProtectedFieldMutationError,
+    RejectedDeployAuthorityEvidenceError,
     Table,
     WritePolicy,
     theorydb_field,
     transition_release_state,
+    validate_deploy_authority_metadata,
 )
 
 
@@ -75,10 +77,11 @@ def test_release_state_scenarios_execute_for_python() -> None:
         _load_yaml(scenario_dir / "06-release-state-write-policy.yml"),
         _load_yaml(scenario_dir / "07-release-state-protected-fields.yml"),
         _load_yaml(scenario_dir / "08-release-state-transactional-transition.yml"),
+        _load_yaml(scenario_dir / "09-release-state-provenance-confidence.yml"),
     ]
 
     for scenario in scenarios:
-        assert "release_state.write_policy" in scenario.get("requires_capabilities", [])
+        assert scenario.get("requires_capabilities", [])
         driver = _ReleaseStatePyDriver()
         for step in scenario["steps"]:
             result, error = _capture_contract_result(
@@ -183,6 +186,7 @@ class _ReleaseStatePyDriver:
         table = self.tables[model_name]
 
         if step["op"] == "create":
+            self._validate_metadata_if_present(model_name, step["item"])
             kwargs: dict[str, Any] = {}
             if step.get("if_not_exists"):
                 kwargs = {
@@ -193,6 +197,7 @@ class _ReleaseStatePyDriver:
             return
 
         if step["op"] == "save":
+            self._validate_metadata_if_present(model_name, step["item"])
             table.save(self._item(model_name, step["item"]))
             return
 
@@ -229,7 +234,20 @@ class _ReleaseStatePyDriver:
             )
             return None
 
+        if step["op"] == "validate_provenance":
+            if model_name != "ReleaseStateActual":
+                raise AssertionError(f"unsupported validate_provenance model: {model_name}")
+            validate_deploy_authority_metadata(step["item"])
+            return None
+
         raise AssertionError(f"unsupported executable op: {step['op']}")
+
+    @staticmethod
+    def _validate_metadata_if_present(model_name: str, item: dict[str, Any]) -> None:
+        if model_name != "ReleaseStateActual":
+            return
+        if "provenance" in item or "confidence" in item:
+            validate_deploy_authority_metadata(item)
 
     @staticmethod
     def _item(model_name: str, item: dict[str, Any]) -> Any:
@@ -372,6 +390,8 @@ def _capture_contract_result(fn: Any) -> tuple[Any, str | None]:
         return None, "ErrProtectedFieldMutation"
     except ConditionFailedError:
         return None, "ErrConditionFailed"
+    except RejectedDeployAuthorityEvidenceError:
+        return None, "ErrRejectedDeployAuthorityEvidence"
 
 
 def _assert_contract_expectation(

--- a/contract-tests/runners/py/test_contract_release_state_fixtures.py
+++ b/contract-tests/runners/py/test_contract_release_state_fixtures.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from copy import deepcopy
+from dataclasses import asdict, dataclass, is_dataclass
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, cast
 
@@ -15,6 +17,7 @@ from theorydb_py import (
     Table,
     WritePolicy,
     theorydb_field,
+    transition_release_state,
 )
 
 
@@ -65,31 +68,23 @@ def test_release_state_p0_scenarios_are_capability_gated() -> None:
         _validate_scenario_steps(path.name, scenario)
 
 
-def test_release_state_write_policy_scenarios_execute_for_python() -> None:
+def test_release_state_scenarios_execute_for_python() -> None:
     root = _repo_root()
     scenario_dir = root / "contract-tests" / "scenarios" / "p0"
     scenarios = [
         _load_yaml(scenario_dir / "06-release-state-write-policy.yml"),
         _load_yaml(scenario_dir / "07-release-state-protected-fields.yml"),
+        _load_yaml(scenario_dir / "08-release-state-transactional-transition.yml"),
     ]
 
     for scenario in scenarios:
         assert "release_state.write_policy" in scenario.get("requires_capabilities", [])
         driver = _ReleaseStatePyDriver()
         for step in scenario["steps"]:
-            error = _capture_contract_error(
+            result, error = _capture_contract_result(
                 lambda driver=driver, scenario=scenario, step=step: driver.run_step(scenario, step)
             )
-            expected = step.get("expect", {})
-            if expected.get("ok") is True:
-                assert error is None, f"{scenario['name']} step {step['op']} expected ok, got {error}"
-                continue
-            if "error" in expected:
-                assert error == expected["error"], (
-                    f"{scenario['name']} step {step['op']} expected {expected['error']}, got {error}"
-                )
-                continue
-            assert error is None
+            _assert_contract_expectation(scenario["name"], step, result, error)
 
 
 def _validate_scenario_steps(name: str, scenario: dict[str, Any]) -> None:
@@ -183,7 +178,7 @@ class _ReleaseStatePyDriver:
             ),
         }
 
-    def run_step(self, scenario: dict[str, Any], step: dict[str, Any]) -> None:
+    def run_step(self, scenario: dict[str, Any], step: dict[str, Any]) -> Any:
         model_name = step.get("model") or scenario["model"]
         table = self.tables[model_name]
 
@@ -219,8 +214,20 @@ class _ReleaseStatePyDriver:
 
         if step["op"] == "get":
             key = step["key"]
-            table.get(key["PK"], key["SK"], consistent_read=True)
-            return
+            return _contract_item(table.get(key["PK"], key["SK"], consistent_read=True))
+
+        if step["op"] == "transition_append_event":
+            actual = step["actual"]
+            event = step["event"]
+            transition_release_state(
+                self.tables[actual["model"]],
+                self.tables[event["model"]],
+                actual_key=actual["key"],
+                expected_version=actual.get("expected_version"),
+                set_values=actual["set"],
+                event_item=self._item(event["model"], event["item"]),
+            )
+            return None
 
         raise AssertionError(f"unsupported executable op: {step['op']}")
 
@@ -253,15 +260,63 @@ class _InMemoryDynamoDBClient:
         return {}
 
     def update_item(self, **req: Any) -> dict[str, Any]:
+        return self._apply_update(req, self.items)
+
+    def transact_write_items(self, **req: Any) -> dict[str, Any]:
+        draft = deepcopy(self.items)
+        for action in req["TransactItems"]:
+            if "Put" in action:
+                put = action["Put"]
+                key = self._key(put["TableName"], put["Item"])
+                if not self._condition_matches(put, draft.get(key)):
+                    raise ConditionFailedError("conditional write failed")
+                draft[key] = dict(put["Item"])
+                continue
+            if "Update" in action:
+                self._apply_update(action["Update"], draft)
+                continue
+            raise AssertionError(f"unsupported transact action: {action!r}")
+        self.items = draft
+        return {}
+
+    def _apply_update(
+        self,
+        req: dict[str, Any],
+        items: dict[tuple[str, str, str], dict[str, Any]],
+    ) -> dict[str, Any]:
         key = self._key(req["TableName"], req["Key"])
-        item = dict(self.items[key])
+        item = dict(items[key])
+        if not self._condition_matches(req, item):
+            raise ConditionFailedError("conditional write failed")
         names = req.get("ExpressionAttributeNames", {})
         values = req.get("ExpressionAttributeValues", {})
         for assignment in _set_assignments(req["UpdateExpression"]):
             left, right = [part.strip() for part in assignment.split("=", 1)]
             item[names[left]] = values[right]
-        self.items[key] = item
+        for assignment in _add_assignments(req["UpdateExpression"]):
+            left, right = [part.strip() for part in assignment.split(None, 1)]
+            attr = names[left]
+            item[attr] = _add_number(item.get(attr), values[right])
+        items[key] = item
         return {"Attributes": dict(item)}
+
+    def _condition_matches(self, req: dict[str, Any], item: dict[str, Any] | None) -> bool:
+        condition = req.get("ConditionExpression", "")
+        if not condition:
+            return True
+        names = req.get("ExpressionAttributeNames", {})
+        values = req.get("ExpressionAttributeValues", {})
+        if "attribute_not_exists" in condition:
+            if item is not None:
+                return False
+        equality = re.search(r"(#[A-Za-z0-9_]+)\s*=\s*(:[A-Za-z0-9_]+)", condition)
+        if equality:
+            if item is None:
+                return False
+            left, right = equality.groups()
+            if item.get(names[left]) != values[right]:
+                return False
+        return True
 
     @staticmethod
     def _key(table_name: str, attrs: dict[str, Any]) -> tuple[str, str, str]:
@@ -275,6 +330,24 @@ def _set_assignments(update_expression: str) -> list[str]:
     return [part.strip() for part in match.group(1).split(",") if part.strip()]
 
 
+def _add_assignments(update_expression: str) -> list[str]:
+    match = re.search(r"\bADD\b([\s\S]*?)(?=\b(?:SET|REMOVE|DELETE)\b|$)", update_expression)
+    if not match:
+        return []
+    return [part.strip() for part in match.group(1).split(",") if part.strip()]
+
+
+def _add_number(current: dict[str, Any] | None, increment: dict[str, Any]) -> dict[str, str]:
+    current_value = Decimal(str((current or {"N": "0"})["N"]))
+    increment_value = Decimal(str(increment["N"]))
+    result = current_value + increment_value
+    if result == result.to_integral_value():
+        text = str(int(result))
+    else:
+        text = format(result, "f")
+    return {"N": text}
+
+
 def _av_to_string(value: dict[str, Any]) -> str:
     if "S" in value:
         return str(value["S"])
@@ -283,13 +356,44 @@ def _av_to_string(value: dict[str, Any]) -> str:
     raise AssertionError(f"unsupported key attribute value: {value!r}")
 
 
-def _capture_contract_error(fn: Any) -> str | None:
+def _contract_item(value: Any) -> dict[str, Any]:
+    if is_dataclass(value):
+        return asdict(value)
+    assert isinstance(value, dict)
+    return value
+
+
+def _capture_contract_result(fn: Any) -> tuple[Any, str | None]:
     try:
-        fn()
+        return fn(), None
     except ImmutableModelMutationError:
-        return "ErrImmutableModelMutation"
+        return None, "ErrImmutableModelMutation"
     except ProtectedFieldMutationError:
-        return "ErrProtectedFieldMutation"
+        return None, "ErrProtectedFieldMutation"
     except ConditionFailedError:
-        return "ErrConditionFailed"
-    return None
+        return None, "ErrConditionFailed"
+
+
+def _assert_contract_expectation(
+    scenario_name: str,
+    step: dict[str, Any],
+    result: Any,
+    error: str | None,
+) -> None:
+    expected = step.get("expect", {})
+    if expected.get("ok") is True:
+        assert error is None, f"{scenario_name} step {step['op']} expected ok, got {error}"
+    elif "error" in expected:
+        assert error == expected["error"], (
+            f"{scenario_name} step {step['op']} expected {expected['error']}, got {error}"
+        )
+        return
+    else:
+        assert error is None
+
+    if "item_contains" in expected:
+        assert isinstance(result, dict), f"{scenario_name} step {step['op']} did not return an item"
+        for key, value in expected["item_contains"].items():
+            assert result.get(key) == value, (
+                f"{scenario_name} step {step['op']} expected {key}={value!r}, got {result.get(key)!r}"
+            )

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -2,7 +2,10 @@ import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { TheorydbClient } from "../../../../ts/src/client.js";
 import { TheorydbError } from "../../../../ts/src/errors.js";
 import type { Model } from "../../../../ts/src/model.js";
-import { transitionReleaseState } from "../../../../ts/src/release-state.js";
+import {
+  transitionReleaseState,
+  validateDeployAuthorityMetadata,
+} from "../../../../ts/src/release-state.js";
 
 export type ErrorCode =
   | "ErrItemNotFound"
@@ -74,6 +77,7 @@ export class TheorydbDriver implements Driver {
       "ttl.epoch_seconds",
       "release_state.write_policy",
       "release_state.transactional_transition",
+      "release_state.provenance_confidence",
     ];
   }
 
@@ -82,6 +86,7 @@ export class TheorydbDriver implements Driver {
     item: Record<string, unknown>,
     opts: { ifNotExists?: boolean },
   ): Promise<void> {
+    validateReleaseStateMetadataIfPresent(model, item);
     await this.client.create(model, item, { ifNotExists: opts.ifNotExists });
   }
 
@@ -109,6 +114,7 @@ export class TheorydbDriver implements Driver {
   }
 
   async save(model: string, item: Record<string, unknown>): Promise<void> {
+    validateReleaseStateMetadataIfPresent(model, item);
     await this.client.save(model, item);
   }
 
@@ -132,11 +138,24 @@ export class TheorydbDriver implements Driver {
 
   async validateProvenance(
     model: string,
-    _item: Record<string, unknown>,
+    item: Record<string, unknown>,
   ): Promise<void> {
-    throw new TheorydbError(
-      "ErrInvalidModel",
-      `validate_provenance not implemented for ${model}`,
-    );
+    if (model !== "ReleaseStateActual") {
+      throw new TheorydbError(
+        "ErrInvalidModel",
+        `validate_provenance unsupported for ${model}`,
+      );
+    }
+    validateDeployAuthorityMetadata(item);
+  }
+}
+
+function validateReleaseStateMetadataIfPresent(
+  model: string,
+  item: Record<string, unknown>,
+): void {
+  if (model !== "ReleaseStateActual") return;
+  if (Object.hasOwn(item, "provenance") || Object.hasOwn(item, "confidence")) {
+    validateDeployAuthorityMetadata(item);
   }
 }

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -2,6 +2,7 @@ import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { TheorydbClient } from "../../../../ts/src/client.js";
 import { TheorydbError } from "../../../../ts/src/errors.js";
 import type { Model } from "../../../../ts/src/model.js";
+import { transitionReleaseState } from "../../../../ts/src/release-state.js";
 
 export type ErrorCode =
   | "ErrItemNotFound"
@@ -72,6 +73,7 @@ export class TheorydbDriver implements Driver {
       "optimistic_lock.version",
       "ttl.epoch_seconds",
       "release_state.write_policy",
+      "release_state.transactional_transition",
     ];
   }
 
@@ -118,10 +120,14 @@ export class TheorydbDriver implements Driver {
     actual: TransitionActual,
     event: TransitionEvent,
   ): Promise<void> {
-    throw new TheorydbError(
-      "ErrInvalidModel",
-      `transition_append_event not implemented for ${actual.model}/${event.model}`,
-    );
+    await transitionReleaseState(this.client, {
+      actualModel: actual.model,
+      actualKey: actual.key,
+      set: actual.set,
+      eventModel: event.model,
+      eventItem: event.item,
+      expectedVersion: actual.expectedVersion,
+    });
   }
 
   async validateProvenance(

--- a/pkg/releasestate/provenance.go
+++ b/pkg/releasestate/provenance.go
@@ -1,0 +1,317 @@
+package releasestate
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+var (
+	allowedProvenanceKeys = map[string]struct{}{
+		"mode":          {},
+		"system":        {},
+		"kind":          {},
+		"ref":           {},
+		"commit_sha":    {},
+		"observed_at":   {},
+		"recorded_at":   {},
+		"import_run_id": {},
+		"evidence":      {},
+	}
+	allowedEvidenceKeys = map[string]struct{}{
+		"kind":        {},
+		"source":      {},
+		"ref":         {},
+		"observed_at": {},
+		"digest":      {},
+	}
+	allowedConfidenceKeys = map[string]struct{}{
+		"level":   {},
+		"reasons": {},
+	}
+	allowedProvenanceModes = map[string]struct{}{
+		"native":   {},
+		"imported": {},
+		"inferred": {},
+	}
+)
+
+// ValidateDeployAuthorityMetadata validates deterministic provenance and
+// confidence metadata for deploy-authoritative release-state actual rows.
+//
+// Ambiguous/conflicting or low-confidence evidence is rejected with
+// ErrRejectedDeployAuthorityEvidence so callers do not accidentally persist it
+// as deploy authority. Such evidence should be stored as separate immutable
+// visibility/event records instead.
+func ValidateDeployAuthorityMetadata(item map[string]any) error {
+	if item == nil {
+		return fmt.Errorf("%w: release-state item is required", theorydbErrors.ErrInvalidModel)
+	}
+	provenanceRaw, hasProvenance := item["provenance"]
+	confidenceRaw, hasConfidence := item["confidence"]
+	if !hasProvenance && !hasConfidence {
+		return nil
+	}
+	if !hasProvenance || !hasConfidence {
+		return fmt.Errorf("%w: provenance and confidence must be provided together", theorydbErrors.ErrInvalidModel)
+	}
+
+	provenance, err := mapValue(provenanceRaw)
+	if err != nil {
+		return fmt.Errorf("%w: provenance must be an object", theorydbErrors.ErrInvalidModel)
+	}
+	confidence, err := mapValue(confidenceRaw)
+	if err != nil {
+		return fmt.Errorf("%w: confidence must be an object", theorydbErrors.ErrInvalidModel)
+	}
+	err = validateAllowedKeys("provenance", provenance, allowedProvenanceKeys)
+	if err != nil {
+		return err
+	}
+	err = validateAllowedKeys("confidence", confidence, allowedConfidenceKeys)
+	if err != nil {
+		return err
+	}
+	err = validateProvenanceShape(provenance)
+	if err != nil {
+		return err
+	}
+
+	reason, err := deriveDeployAuthorityReason(provenance)
+	if err != nil {
+		return err
+	}
+	return validateConfidence(confidence, reason)
+}
+
+func validateProvenanceShape(provenance map[string]any) error {
+	mode, err := requiredString(provenance, "mode")
+	if err != nil {
+		return err
+	}
+	if _, ok := allowedProvenanceModes[mode]; !ok {
+		return fmt.Errorf("%w: unsupported provenance.mode %q", theorydbErrors.ErrInvalidModel, mode)
+	}
+
+	for _, key := range []string{"system", "kind", "ref"} {
+		if _, err := requiredString(provenance, key); err != nil {
+			return err
+		}
+	}
+	for _, key := range []string{"observed_at", "recorded_at"} {
+		value, err := requiredString(provenance, key)
+		if err != nil {
+			return err
+		}
+		if err := validateRFC3339(key, value); err != nil {
+			return err
+		}
+	}
+	for _, key := range []string{"commit_sha", "import_run_id"} {
+		if value, ok := provenance[key]; ok {
+			if _, ok := value.(string); !ok {
+				return fmt.Errorf("%w: provenance.%s must be a string", theorydbErrors.ErrInvalidModel, key)
+			}
+		}
+	}
+	return nil
+}
+
+func deriveDeployAuthorityReason(provenance map[string]any) (string, error) {
+	evidenceList, err := evidenceValues(provenance["evidence"])
+	if err != nil {
+		return "", err
+	}
+	if len(evidenceList) == 0 {
+		return "", fmt.Errorf("%w: deploy authority requires evidence", theorydbErrors.ErrRejectedDeployAuthorityEvidence)
+	}
+
+	var signature string
+	var first deployEvidence
+	for i, evidence := range evidenceList {
+		parsed, err := parseDeployEvidence(evidence)
+		if err != nil {
+			return "", err
+		}
+
+		currentSignature := parsed.signature()
+		if i == 0 {
+			signature = currentSignature
+			first = parsed
+			continue
+		}
+		if currentSignature != signature {
+			return "", fmt.Errorf("%w: conflicting deploy authority evidence", theorydbErrors.ErrRejectedDeployAuthorityEvidence)
+		}
+	}
+
+	return authorityReasonForEvidence(first)
+}
+
+type deployEvidence struct {
+	kind   string
+	source string
+	ref    string
+}
+
+func (e deployEvidence) signature() string {
+	return e.kind + "|" + e.source + "|" + e.ref
+}
+
+func parseDeployEvidence(evidence map[string]any) (deployEvidence, error) {
+	if err := validateAllowedKeys("provenance.evidence", evidence, allowedEvidenceKeys); err != nil {
+		return deployEvidence{}, err
+	}
+
+	kind, err := requiredString(evidence, "kind")
+	if err != nil {
+		return deployEvidence{}, err
+	}
+	source, err := requiredString(evidence, "source")
+	if err != nil {
+		return deployEvidence{}, err
+	}
+	ref, err := requiredString(evidence, "ref")
+	if err != nil {
+		return deployEvidence{}, err
+	}
+	observedAt, err := requiredString(evidence, "observed_at")
+	if err != nil {
+		return deployEvidence{}, err
+	}
+	if err := validateRFC3339("evidence.observed_at", observedAt); err != nil {
+		return deployEvidence{}, err
+	}
+	if digest, ok := evidence["digest"]; ok {
+		if _, ok := digest.(string); !ok {
+			return deployEvidence{}, fmt.Errorf("%w: evidence.digest must be a string", theorydbErrors.ErrInvalidModel)
+		}
+	}
+
+	return deployEvidence{kind: kind, source: source, ref: ref}, nil
+}
+
+func authorityReasonForEvidence(evidence deployEvidence) (string, error) {
+	reasons := map[deployEvidence]string{
+		{kind: "operator_command", source: "release-control-plane"}: "operator_command_authority",
+		{kind: "factory_batch_manifest", source: "partner-factory"}: "unique_factory_manifest_match",
+		{kind: "codepipeline_execution", source: "service-ci"}:      "codepipeline_execution_authority",
+		{kind: "submodule_pin", source: "service-ci"}:               "unique_submodule_pin_match",
+	}
+	key := deployEvidence{kind: evidence.kind, source: evidence.source}
+	if reason, ok := reasons[key]; ok {
+		return reason, nil
+	}
+	return "", fmt.Errorf("%w: unsupported deploy authority evidence %s/%s", theorydbErrors.ErrRejectedDeployAuthorityEvidence, evidence.source, evidence.kind)
+}
+
+func validateConfidence(confidence map[string]any, expectedReason string) error {
+	level, err := requiredString(confidence, "level")
+	if err != nil {
+		return err
+	}
+	if level != "high" {
+		return fmt.Errorf("%w: %s confidence cannot authorize deploy state", theorydbErrors.ErrRejectedDeployAuthorityEvidence, level)
+	}
+	reasons, err := stringSliceValue(confidence["reasons"])
+	if err != nil {
+		return fmt.Errorf("%w: confidence.reasons must be a string array", theorydbErrors.ErrInvalidModel)
+	}
+	if len(reasons) != 1 || reasons[0] != expectedReason {
+		return fmt.Errorf("%w: confidence reasons do not match deterministic authority", theorydbErrors.ErrRejectedDeployAuthorityEvidence)
+	}
+	return nil
+}
+
+func validateAllowedKeys(label string, values map[string]any, allowed map[string]struct{}) error {
+	for key := range values {
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("%w: unsupported %s key %q", theorydbErrors.ErrInvalidModel, label, key)
+		}
+	}
+	return nil
+}
+
+func requiredString(values map[string]any, key string) (string, error) {
+	value, ok := values[key]
+	if !ok {
+		return "", fmt.Errorf("%w: %s is required", theorydbErrors.ErrInvalidModel, key)
+	}
+	text, ok := value.(string)
+	if !ok || text == "" {
+		return "", fmt.Errorf("%w: %s must be a non-empty string", theorydbErrors.ErrInvalidModel, key)
+	}
+	return text, nil
+}
+
+func validateRFC3339(label string, value string) error {
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		return fmt.Errorf("%w: %s must be RFC3339", theorydbErrors.ErrInvalidModel, label)
+	}
+	return nil
+}
+
+func mapValue(value any) (map[string]any, error) {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, v := range typed {
+			out[k] = v
+		}
+		return out, nil
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for k, v := range typed {
+			key, ok := k.(string)
+			if !ok {
+				return nil, fmt.Errorf("map key must be string")
+			}
+			out[key] = v
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("expected object, got %T", value)
+	}
+}
+
+func evidenceValues(value any) ([]map[string]any, error) {
+	if value == nil {
+		return nil, fmt.Errorf("%w: provenance.evidence is required", theorydbErrors.ErrInvalidModel)
+	}
+
+	rv := reflect.ValueOf(value)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return nil, fmt.Errorf("%w: provenance.evidence must be an array", theorydbErrors.ErrInvalidModel)
+	}
+
+	out := make([]map[string]any, 0, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		entry, err := mapValue(rv.Index(i).Interface())
+		if err != nil {
+			return nil, fmt.Errorf("%w: provenance.evidence entries must be objects", theorydbErrors.ErrInvalidModel)
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func stringSliceValue(value any) ([]string, error) {
+	switch typed := value.(type) {
+	case []string:
+		return append([]string(nil), typed...), nil
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			text, ok := item.(string)
+			if !ok || text == "" {
+				return nil, fmt.Errorf("expected string")
+			}
+			out = append(out, text)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("expected string array")
+	}
+}

--- a/pkg/releasestate/provenance_test.go
+++ b/pkg/releasestate/provenance_test.go
@@ -1,0 +1,297 @@
+package releasestate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+func validDeployAuthorityItem() map[string]any {
+	return map[string]any{
+		"provenance": map[string]any{
+			"mode":        "native",
+			"system":      "release-control-plane",
+			"kind":        "operator_command",
+			"ref":         "operator://deploy/service-a/rel_001",
+			"observed_at": "2026-04-24T19:00:00Z",
+			"recorded_at": "2026-04-24T19:00:01Z",
+			"evidence": []any{
+				map[string]any{
+					"kind":        "operator_command",
+					"source":      "release-control-plane",
+					"ref":         "operator://deploy/service-a/rel_001",
+					"observed_at": "2026-04-24T19:00:00Z",
+				},
+			},
+		},
+		"confidence": map[string]any{
+			"level":   "high",
+			"reasons": []any{"operator_command_authority"},
+		},
+	}
+}
+
+func TestValidateDeployAuthorityMetadataAcceptsDeterministicHighConfidence(t *testing.T) {
+	require.NoError(t, ValidateDeployAuthorityMetadata(validDeployAuthorityItem()))
+	require.NoError(t, ValidateDeployAuthorityMetadata(map[string]any{"PK": "RELEASE#svc"}))
+}
+
+func TestValidateDeployAuthorityMetadataRejectsConflictingEvidence(t *testing.T) {
+	item := validDeployAuthorityItem()
+	provenance := requireMapValue(t, item, "provenance")
+	provenance["mode"] = "imported"
+	provenance["system"] = "partner-factory"
+	provenance["kind"] = "factory_batch_manifest"
+	provenance["ref"] = "s3://factory/manifests/ambiguous.json"
+	provenance["evidence"] = []any{
+		map[string]any{
+			"kind":        "factory_batch_manifest",
+			"source":      "partner-factory",
+			"ref":         "s3://factory/manifests/a.json",
+			"observed_at": "2026-04-24T19:09:59Z",
+		},
+		map[string]any{
+			"kind":        "submodule_pin",
+			"source":      "service-ci",
+			"ref":         "https://github.com/acme/service-b/tree/conflicting",
+			"observed_at": "2026-04-24T19:09:59Z",
+		},
+	}
+	item["confidence"] = map[string]any{
+		"level":   "low",
+		"reasons": []any{"conflicting_evidence"},
+	}
+
+	err := ValidateDeployAuthorityMetadata(item)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, theorydbErrors.ErrRejectedDeployAuthorityEvidence))
+}
+
+func TestValidateDeployAuthorityMetadataRejectsFreeFormNotes(t *testing.T) {
+	item := validDeployAuthorityItem()
+	requireMapValue(t, item, "provenance")["notes"] = "human note"
+
+	err := ValidateDeployAuthorityMetadata(item)
+	require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+}
+
+func TestValidateDeployAuthorityMetadata_InvalidShapes(t *testing.T) {
+	for _, tt := range []struct {
+		item map[string]any
+		want error
+		name string
+	}{
+		{
+			name: "nil item",
+			item: nil,
+			want: theorydbErrors.ErrInvalidModel,
+		},
+		{
+			name: "missing confidence",
+			item: map[string]any{"provenance": map[string]any{}},
+			want: theorydbErrors.ErrInvalidModel,
+		},
+		{
+			name: "provenance not object",
+			item: map[string]any{"provenance": "note", "confidence": map[string]any{}},
+			want: theorydbErrors.ErrInvalidModel,
+		},
+		{
+			name: "confidence not object",
+			item: map[string]any{"provenance": map[string]any{}, "confidence": "low"},
+			want: theorydbErrors.ErrInvalidModel,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDeployAuthorityMetadata(tt.item)
+			require.ErrorIs(t, err, tt.want)
+		})
+	}
+}
+
+func TestValidateDeployAuthorityMetadata_ProvenanceShapeErrors(t *testing.T) {
+	for _, tt := range []struct {
+		mutate func(map[string]any)
+		name   string
+	}{
+		{
+			name: "unsupported mode",
+			mutate: func(item map[string]any) {
+				requireMapValue(t, item, "provenance")["mode"] = "guessed"
+			},
+		},
+		{
+			name: "missing required string",
+			mutate: func(item map[string]any) {
+				delete(requireMapValue(t, item, "provenance"), "system")
+			},
+		},
+		{
+			name: "invalid observed time",
+			mutate: func(item map[string]any) {
+				requireMapValue(t, item, "provenance")["observed_at"] = "2026/04/24"
+			},
+		},
+		{
+			name: "non-string commit",
+			mutate: func(item map[string]any) {
+				requireMapValue(t, item, "provenance")["commit_sha"] = 123
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			item := validDeployAuthorityItem()
+			tt.mutate(item)
+			err := ValidateDeployAuthorityMetadata(item)
+			require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+		})
+	}
+}
+
+func TestValidateDeployAuthorityMetadata_EvidenceAndConfidenceErrors(t *testing.T) {
+	for _, tt := range []struct {
+		mutate func(map[string]any)
+		want   error
+		name   string
+	}{
+		{
+			name: "missing evidence",
+			mutate: func(item map[string]any) {
+				delete(requireMapValue(t, item, "provenance"), "evidence")
+			},
+			want: theorydbErrors.ErrInvalidModel,
+		},
+		{
+			name: "empty evidence",
+			mutate: func(item map[string]any) {
+				requireMapValue(t, item, "provenance")["evidence"] = []any{}
+			},
+			want: theorydbErrors.ErrRejectedDeployAuthorityEvidence,
+		},
+		{
+			name: "evidence not object",
+			mutate: func(item map[string]any) {
+				requireMapValue(t, item, "provenance")["evidence"] = []any{"note"}
+			},
+			want: theorydbErrors.ErrInvalidModel,
+		},
+		{
+			name: "evidence missing source",
+			mutate: func(item map[string]any) {
+				evidence := firstEvidence(t, item)
+				delete(evidence, "source")
+			},
+			want: theorydbErrors.ErrInvalidModel,
+		},
+		{
+			name: "evidence invalid time",
+			mutate: func(item map[string]any) {
+				firstEvidence(t, item)["observed_at"] = "Friday"
+			},
+			want: theorydbErrors.ErrInvalidModel,
+		},
+		{
+			name: "evidence digest not string",
+			mutate: func(item map[string]any) {
+				firstEvidence(t, item)["digest"] = 7
+			},
+			want: theorydbErrors.ErrInvalidModel,
+		},
+		{
+			name: "unsupported authority",
+			mutate: func(item map[string]any) {
+				firstEvidence(t, item)["source"] = "unknown"
+			},
+			want: theorydbErrors.ErrRejectedDeployAuthorityEvidence,
+		},
+		{
+			name: "low confidence",
+			mutate: func(item map[string]any) {
+				requireMapValue(t, item, "confidence")["level"] = "low"
+			},
+			want: theorydbErrors.ErrRejectedDeployAuthorityEvidence,
+		},
+		{
+			name: "reasons not array",
+			mutate: func(item map[string]any) {
+				requireMapValue(t, item, "confidence")["reasons"] = "operator_command_authority"
+			},
+			want: theorydbErrors.ErrInvalidModel,
+		},
+		{
+			name: "reason mismatch",
+			mutate: func(item map[string]any) {
+				requireMapValue(t, item, "confidence")["reasons"] = []any{"manual_note"}
+			},
+			want: theorydbErrors.ErrRejectedDeployAuthorityEvidence,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			item := validDeployAuthorityItem()
+			tt.mutate(item)
+			err := ValidateDeployAuthorityMetadata(item)
+			require.ErrorIs(t, err, tt.want)
+		})
+	}
+}
+
+func TestValidateDeployAuthorityMetadata_AcceptsOtherDeterministicAuthorities(t *testing.T) {
+	for _, tt := range []struct {
+		kind   string
+		source string
+		reason string
+	}{
+		{kind: "factory_batch_manifest", source: "partner-factory", reason: "unique_factory_manifest_match"},
+		{kind: "codepipeline_execution", source: "service-ci", reason: "codepipeline_execution_authority"},
+		{kind: "submodule_pin", source: "service-ci", reason: "unique_submodule_pin_match"},
+	} {
+		t.Run(tt.reason, func(t *testing.T) {
+			item := validDeployAuthorityItem()
+			evidence := firstEvidence(t, item)
+			evidence["kind"] = tt.kind
+			evidence["source"] = tt.source
+			requireMapValue(t, item, "confidence")["reasons"] = []string{tt.reason}
+
+			require.NoError(t, ValidateDeployAuthorityMetadata(item))
+		})
+	}
+}
+
+func TestInternalValueHelpers(t *testing.T) {
+	value, err := mapValue(map[any]any{"ok": "yes"})
+	require.NoError(t, err)
+	require.Equal(t, "yes", value["ok"])
+
+	_, err = mapValue(map[any]any{1: "bad"})
+	require.Error(t, err)
+
+	values, err := stringSliceValue([]string{"a", "b"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, values)
+
+	_, err = stringSliceValue([]any{"a", 1})
+	require.Error(t, err)
+}
+
+func requireMapValue(t *testing.T, item map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := item[key]
+	require.True(t, ok)
+	typed, ok := value.(map[string]any)
+	require.True(t, ok)
+	return typed
+}
+
+func firstEvidence(t *testing.T, item map[string]any) map[string]any {
+	t.Helper()
+	provenance := requireMapValue(t, item, "provenance")
+	values, ok := provenance["evidence"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, values)
+	typed, ok := values[0].(map[string]any)
+	require.True(t, ok)
+	return typed
+}

--- a/pkg/releasestate/transition.go
+++ b/pkg/releasestate/transition.go
@@ -1,0 +1,98 @@
+// Package releasestate contains opt-in helpers for release-state registry
+// records. The helpers compose existing TableTheory write-policy and
+// transaction primitives; they do not weaken model-level immutability or
+// protected-field enforcement.
+package releasestate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+const defaultVersionField = "version"
+
+// TransactionWriter is the minimal TableTheory surface required to execute a
+// release-state transition. A single DynamoDB TransactWriteItems call is used
+// for the actual-state update and event-history append.
+//
+// External side effects such as Lambda alias flips or CodePipeline executions
+// are intentionally outside this helper's atomicity boundary. Callers should
+// pair those side effects with explicit retry/reconciliation/outbox behavior.
+type TransactionWriter interface {
+	TransactWrite(context.Context, func(core.TransactionBuilder) error) error
+}
+
+// TransitionAppendEventInput describes one release-state transition:
+// update the mutable actual-state row and append one immutable event-history
+// row in the same DynamoDB transaction.
+type TransitionAppendEventInput struct {
+	// Actual is the model instance containing the actual-state row key.
+	Actual any
+	// Event is the model instance to append to event history. Write-once event
+	// models remain protected by their model-level WritePolicy.
+	Event any
+	// Set contains actual-state attributes to SET during the transition. Keys
+	// may be Go field names or DynamoDB attribute names accepted by
+	// core.UpdateBuilder.
+	Set map[string]any
+	// ExpectedVersion, when non-nil, adds an optimistic-lock condition against
+	// the model's theorydb:"version" field before incrementing it.
+	ExpectedVersion *int64
+	// VersionField names the version attribute to increment. Empty defaults to
+	// "version", matching the release-state contract fixture.
+	VersionField string
+}
+
+// TransitionAppendEvent executes a release-state transition with the supplied
+// transaction writer.
+func TransitionAppendEvent(ctx context.Context, db TransactionWriter, input TransitionAppendEventInput) error {
+	if db == nil {
+		return fmt.Errorf("%w: release-state transaction writer is required", theorydbErrors.ErrInvalidModel)
+	}
+	return db.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
+		return AddTransitionAppendEvent(tx, input)
+	})
+}
+
+// AddTransitionAppendEvent adds the release-state actual-row transition and
+// event append to an existing transaction builder. Callers that need to
+// transactionally compose additional internal DynamoDB writes can use this
+// helper before executing the builder.
+func AddTransitionAppendEvent(tx core.TransactionBuilder, input TransitionAppendEventInput) error {
+	if tx == nil {
+		return fmt.Errorf("%w: transaction builder is required", theorydbErrors.ErrInvalidModel)
+	}
+	if input.Actual == nil {
+		return fmt.Errorf("%w: actual model is required", theorydbErrors.ErrInvalidModel)
+	}
+	if input.Event == nil {
+		return fmt.Errorf("%w: event model is required", theorydbErrors.ErrInvalidModel)
+	}
+	if len(input.Set) == 0 {
+		return fmt.Errorf("%w: transition set is required", theorydbErrors.ErrInvalidOperator)
+	}
+
+	versionField := input.VersionField
+	if versionField == "" {
+		versionField = defaultVersionField
+	}
+	if _, ok := input.Set[versionField]; ok {
+		return fmt.Errorf("%w: transition set must not mutate version directly", theorydbErrors.ErrInvalidModel)
+	}
+
+	tx.UpdateWithBuilder(input.Actual, func(ub core.UpdateBuilder) error {
+		for field, value := range input.Set {
+			ub.Set(field, value)
+		}
+		ub.Add(versionField, int64(1))
+		if input.ExpectedVersion != nil {
+			ub.ConditionVersion(*input.ExpectedVersion)
+		}
+		return nil
+	}).Create(input.Event)
+
+	return nil
+}

--- a/pkg/releasestate/transition_test.go
+++ b/pkg/releasestate/transition_test.go
@@ -1,0 +1,177 @@
+package releasestate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+type transitionActual struct {
+	PK string `theorydb:"pk"`
+	SK string `theorydb:"sk"`
+}
+
+type transitionEvent struct {
+	PK string `theorydb:"pk"`
+	SK string `theorydb:"sk"`
+}
+
+type fakeTransactionWriter struct {
+	builder *fakeTransactionBuilder
+	called  bool
+}
+
+func (w *fakeTransactionWriter) TransactWrite(ctx context.Context, fn func(core.TransactionBuilder) error) error {
+	w.called = true
+	if ctx == nil {
+		return errors.New("context is required")
+	}
+	if w.builder == nil {
+		w.builder = &fakeTransactionBuilder{}
+	}
+	return fn(w.builder)
+}
+
+type fakeTransactionBuilder struct {
+	updateModel any
+	createModel any
+	updateFn    func(core.UpdateBuilder) error
+	ops         []string
+}
+
+func (b *fakeTransactionBuilder) Put(model any, conditions ...core.TransactCondition) core.TransactionBuilder {
+	b.ops = append(b.ops, "put")
+	return b
+}
+
+func (b *fakeTransactionBuilder) Create(model any, conditions ...core.TransactCondition) core.TransactionBuilder {
+	b.ops = append(b.ops, "create")
+	b.createModel = model
+	return b
+}
+
+func (b *fakeTransactionBuilder) Update(model any, fields []string, conditions ...core.TransactCondition) core.TransactionBuilder {
+	b.ops = append(b.ops, "update")
+	return b
+}
+
+func (b *fakeTransactionBuilder) UpdateWithBuilder(model any, updateFn func(core.UpdateBuilder) error, conditions ...core.TransactCondition) core.TransactionBuilder {
+	b.ops = append(b.ops, "update_builder")
+	b.updateModel = model
+	b.updateFn = updateFn
+	return b
+}
+
+func (b *fakeTransactionBuilder) Delete(model any, conditions ...core.TransactCondition) core.TransactionBuilder {
+	b.ops = append(b.ops, "delete")
+	return b
+}
+
+func (b *fakeTransactionBuilder) ConditionCheck(model any, conditions ...core.TransactCondition) core.TransactionBuilder {
+	b.ops = append(b.ops, "condition")
+	return b
+}
+
+func (b *fakeTransactionBuilder) WithContext(ctx context.Context) core.TransactionBuilder { return b }
+func (b *fakeTransactionBuilder) Execute() error                                          { return nil }
+func (b *fakeTransactionBuilder) ExecuteWithContext(ctx context.Context) error            { return nil }
+
+type fakeUpdateBuilder struct {
+	sets           map[string]any
+	adds           map[string]any
+	versionChecked *int64
+}
+
+func newFakeUpdateBuilder() *fakeUpdateBuilder {
+	return &fakeUpdateBuilder{sets: make(map[string]any), adds: make(map[string]any)}
+}
+
+func (b *fakeUpdateBuilder) Set(field string, value any) core.UpdateBuilder {
+	b.sets[field] = value
+	return b
+}
+
+func (b *fakeUpdateBuilder) SetIfNotExists(field string, value any, defaultValue any) core.UpdateBuilder {
+	return b
+}
+
+func (b *fakeUpdateBuilder) Add(field string, value any) core.UpdateBuilder {
+	b.adds[field] = value
+	return b
+}
+
+func (b *fakeUpdateBuilder) Increment(field string) core.UpdateBuilder { return b.Add(field, 1) }
+func (b *fakeUpdateBuilder) Decrement(field string) core.UpdateBuilder { return b.Add(field, -1) }
+func (b *fakeUpdateBuilder) Remove(field string) core.UpdateBuilder    { return b }
+func (b *fakeUpdateBuilder) Delete(field string, value any) core.UpdateBuilder {
+	return b
+}
+func (b *fakeUpdateBuilder) AppendToList(field string, values any) core.UpdateBuilder  { return b }
+func (b *fakeUpdateBuilder) PrependToList(field string, values any) core.UpdateBuilder { return b }
+func (b *fakeUpdateBuilder) RemoveFromListAt(field string, index int) core.UpdateBuilder {
+	return b
+}
+func (b *fakeUpdateBuilder) SetListElement(field string, index int, value any) core.UpdateBuilder {
+	return b
+}
+func (b *fakeUpdateBuilder) Condition(field string, operator string, value any) core.UpdateBuilder {
+	return b
+}
+func (b *fakeUpdateBuilder) OrCondition(field string, operator string, value any) core.UpdateBuilder {
+	return b
+}
+func (b *fakeUpdateBuilder) ConditionExists(field string) core.UpdateBuilder    { return b }
+func (b *fakeUpdateBuilder) ConditionNotExists(field string) core.UpdateBuilder { return b }
+func (b *fakeUpdateBuilder) ConditionVersion(currentVersion int64) core.UpdateBuilder {
+	b.versionChecked = &currentVersion
+	return b
+}
+func (b *fakeUpdateBuilder) ReturnValues(option string) core.UpdateBuilder { return b }
+func (b *fakeUpdateBuilder) Execute() error                                { return nil }
+func (b *fakeUpdateBuilder) ExecuteWithResult(result any) error            { return nil }
+
+func TestTransitionAppendEventAddsTransactionalUpdateAndCreate(t *testing.T) {
+	expectedVersion := int64(7)
+	writer := &fakeTransactionWriter{builder: &fakeTransactionBuilder{}}
+
+	err := TransitionAppendEvent(context.Background(), writer, TransitionAppendEventInput{
+		Actual:          &transitionActual{PK: "RELEASE#svc", SK: "ACTUAL"},
+		Event:           &transitionEvent{PK: "RELEASE#svc", SK: "EVENT#1"},
+		Set:             map[string]any{"status": "active", "previousReleaseId": "rel_001"},
+		ExpectedVersion: &expectedVersion,
+	})
+	require.NoError(t, err)
+	require.True(t, writer.called)
+	require.Equal(t, []string{"update_builder", "create"}, writer.builder.ops)
+
+	ub := newFakeUpdateBuilder()
+	require.NoError(t, writer.builder.updateFn(ub))
+	require.Equal(t, "active", ub.sets["status"])
+	require.Equal(t, "rel_001", ub.sets["previousReleaseId"])
+	require.Equal(t, int64(1), ub.adds["version"])
+	require.NotNil(t, ub.versionChecked)
+	require.Equal(t, expectedVersion, *ub.versionChecked)
+}
+
+func TestAddTransitionAppendEventValidatesInput(t *testing.T) {
+	err := AddTransitionAppendEvent(&fakeTransactionBuilder{}, TransitionAppendEventInput{})
+	require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+
+	err = AddTransitionAppendEvent(&fakeTransactionBuilder{}, TransitionAppendEventInput{
+		Actual: &transitionActual{PK: "RELEASE#svc", SK: "ACTUAL"},
+		Event:  &transitionEvent{PK: "RELEASE#svc", SK: "EVENT#1"},
+	})
+	require.ErrorIs(t, err, theorydbErrors.ErrInvalidOperator)
+
+	err = AddTransitionAppendEvent(&fakeTransactionBuilder{}, TransitionAppendEventInput{
+		Actual: &transitionActual{PK: "RELEASE#svc", SK: "ACTUAL"},
+		Event:  &transitionEvent{PK: "RELEASE#svc", SK: "EVENT#1"},
+		Set:    map[string]any{"version": 2},
+	})
+	require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+}

--- a/pkg/releasestate/transition_test.go
+++ b/pkg/releasestate/transition_test.go
@@ -159,7 +159,10 @@ func TestTransitionAppendEventAddsTransactionalUpdateAndCreate(t *testing.T) {
 }
 
 func TestAddTransitionAppendEventValidatesInput(t *testing.T) {
-	err := AddTransitionAppendEvent(&fakeTransactionBuilder{}, TransitionAppendEventInput{})
+	err := TransitionAppendEvent(context.Background(), nil, TransitionAppendEventInput{})
+	require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+
+	err = AddTransitionAppendEvent(&fakeTransactionBuilder{}, TransitionAppendEventInput{})
 	require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
 
 	err = AddTransitionAppendEvent(&fakeTransactionBuilder{}, TransitionAppendEventInput{

--- a/py/src/theorydb_py/__init__.py
+++ b/py/src/theorydb_py/__init__.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
     from .multiaccount import AccountConfig, MultiAccountSessions
     from .optimizer import QueryOptimizer, QueryPlan, QueryShape, ScanShape
     from .protection import ConcurrencyLimiter, SimpleLimiter
+    from .release_state import transition_release_state
     from .runtime import (
         AwsCallMetric,
         create_lambda_boto3_config,
@@ -210,6 +211,10 @@ def __getattr__(name: str) -> Any:
         from . import lease
 
         return getattr(lease, name)
+    if name == "transition_release_state":
+        from .release_state import transition_release_state
+
+        return transition_release_state
     raise AttributeError(name)
 
 
@@ -282,6 +287,7 @@ __all__ = [
     "TransactPut",
     "TransactUpdate",
     "TransactWriteAction",
+    "transition_release_state",
     "UpdateAdd",
     "UpdateSetIfNotExists",
     "TransactionCanceledError",

--- a/py/src/theorydb_py/__init__.py
+++ b/py/src/theorydb_py/__init__.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from .multiaccount import AccountConfig, MultiAccountSessions
     from .optimizer import QueryOptimizer, QueryPlan, QueryShape, ScanShape
     from .protection import ConcurrencyLimiter, SimpleLimiter
-    from .release_state import transition_release_state
+    from .release_state import transition_release_state, validate_deploy_authority_metadata
     from .runtime import (
         AwsCallMetric,
         create_lambda_boto3_config,
@@ -211,10 +211,10 @@ def __getattr__(name: str) -> Any:
         from . import lease
 
         return getattr(lease, name)
-    if name == "transition_release_state":
-        from .release_state import transition_release_state
+    if name in {"transition_release_state", "validate_deploy_authority_metadata"}:
+        from . import release_state
 
-        return transition_release_state
+        return getattr(release_state, name)
     raise AttributeError(name)
 
 
@@ -288,6 +288,7 @@ __all__ = [
     "TransactUpdate",
     "TransactWriteAction",
     "transition_release_state",
+    "validate_deploy_authority_metadata",
     "UpdateAdd",
     "UpdateSetIfNotExists",
     "TransactionCanceledError",

--- a/py/src/theorydb_py/release_state.py
+++ b/py/src/theorydb_py/release_state.py
@@ -1,14 +1,33 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 from botocore.exceptions import ClientError
 
-from .errors import ValidationError
+from .aws_errors import map_transaction_error as _map_transaction_error
+from .errors import RejectedDeployAuthorityEvidenceError, ValidationError
 from .model import AttributeDefinition, ModelDefinition
-from .table import Table, _map_transaction_error
+from .table import Table
 from .transaction import UpdateAdd
+
+_RFC3339_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
+_PROVENANCE_KEYS = {
+    "mode",
+    "system",
+    "kind",
+    "ref",
+    "commit_sha",
+    "observed_at",
+    "recorded_at",
+    "import_run_id",
+    "evidence",
+}
+_EVIDENCE_KEYS = {"kind", "source", "ref", "observed_at", "digest"}
+_CONFIDENCE_KEYS = {"level", "reasons"}
+_PROVENANCE_MODES = {"native", "imported", "inferred"}
 
 
 def transition_release_state(
@@ -82,6 +101,31 @@ def transition_release_state(
         raise _map_transaction_error(err) from err
 
 
+def validate_deploy_authority_metadata(item: Mapping[str, Any]) -> None:
+    """Validate deterministic provenance/confidence deploy authority metadata.
+
+    Ambiguous/conflicting or low-confidence evidence is rejected so it cannot be
+    persisted as deploy authority. Preserve that evidence as separate immutable
+    visibility/event records instead.
+    """
+
+    has_provenance = "provenance" in item
+    has_confidence = "confidence" in item
+    if not has_provenance and not has_confidence:
+        return
+    if not has_provenance or not has_confidence:
+        raise ValidationError("provenance and confidence must be provided together")
+
+    provenance = _mapping_value(item["provenance"], "provenance")
+    confidence = _mapping_value(item["confidence"], "confidence")
+    _validate_allowed_keys("provenance", provenance, _PROVENANCE_KEYS)
+    _validate_allowed_keys("confidence", confidence, _CONFIDENCE_KEYS)
+    _validate_provenance_shape(provenance)
+
+    expected_reason = _derive_deploy_authority_reason(provenance)
+    _validate_confidence(confidence, expected_reason)
+
+
 def _assert_same_transaction_context(actual_table: Table[Any], event_table: Table[Any]) -> None:
     if actual_table._client is not event_table._client:
         raise ValidationError("release-state transaction requires both tables to share one DynamoDB client")
@@ -107,6 +151,111 @@ def _canonical_updates(model: ModelDefinition[Any], values: Mapping[str, Any]) -
             raise ValidationError(f"unknown field: {name}")
         updates[python_name] = value
     return updates
+
+
+def _validate_provenance_shape(provenance: Mapping[str, Any]) -> None:
+    mode = _required_string(provenance, "mode")
+    if mode not in _PROVENANCE_MODES:
+        raise ValidationError(f"unsupported provenance.mode: {mode}")
+    for key in ("system", "kind", "ref"):
+        _required_string(provenance, key)
+    for key in ("observed_at", "recorded_at"):
+        _validate_rfc3339(key, _required_string(provenance, key))
+    for key in ("commit_sha", "import_run_id"):
+        if key in provenance and not isinstance(provenance[key], str):
+            raise ValidationError(f"provenance.{key} must be a string")
+
+
+def _derive_deploy_authority_reason(provenance: Mapping[str, Any]) -> str:
+    evidence = _evidence_values(provenance.get("evidence"))
+    if not evidence:
+        raise RejectedDeployAuthorityEvidenceError("deploy authority requires evidence")
+
+    signature: str | None = None
+    first: Mapping[str, Any] | None = None
+    for entry in evidence:
+        _validate_allowed_keys("provenance.evidence", entry, _EVIDENCE_KEYS)
+        kind = _required_string(entry, "kind")
+        source = _required_string(entry, "source")
+        ref = _required_string(entry, "ref")
+        _validate_rfc3339("evidence.observed_at", _required_string(entry, "observed_at"))
+        if "digest" in entry and not isinstance(entry["digest"], str):
+            raise ValidationError("evidence.digest must be a string")
+
+        current_signature = f"{kind}|{source}|{ref}"
+        if signature is None:
+            signature = current_signature
+            first = entry
+            continue
+        if current_signature != signature:
+            raise RejectedDeployAuthorityEvidenceError("conflicting deploy authority evidence")
+
+    assert first is not None
+    kind = _required_string(first, "kind")
+    source = _required_string(first, "source")
+    if kind == "operator_command" and source == "release-control-plane":
+        return "operator_command_authority"
+    if kind == "factory_batch_manifest" and source == "partner-factory":
+        return "unique_factory_manifest_match"
+    if kind == "codepipeline_execution" and source == "service-ci":
+        return "codepipeline_execution_authority"
+    if kind == "submodule_pin" and source == "service-ci":
+        return "unique_submodule_pin_match"
+    raise RejectedDeployAuthorityEvidenceError(f"unsupported deploy authority evidence: {source}/{kind}")
+
+
+def _validate_confidence(confidence: Mapping[str, Any], expected_reason: str) -> None:
+    level = _required_string(confidence, "level")
+    if level != "high":
+        raise RejectedDeployAuthorityEvidenceError(f"{level} confidence cannot authorize deploy state")
+    reasons = _string_list(confidence.get("reasons"))
+    if len(reasons) != 1 or reasons[0] != expected_reason:
+        raise RejectedDeployAuthorityEvidenceError("confidence reasons do not match deterministic authority")
+
+
+def _validate_allowed_keys(label: str, values: Mapping[str, Any], allowed: set[str]) -> None:
+    for key in values:
+        if key not in allowed:
+            raise ValidationError(f"unsupported {label} key: {key}")
+
+
+def _required_string(values: Mapping[str, Any], key: str) -> str:
+    value = values.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValidationError(f"{key} must be a non-empty string")
+    return value
+
+
+def _validate_rfc3339(label: str, value: str) -> None:
+    if not _RFC3339_RE.match(value):
+        raise ValidationError(f"{label} must be RFC3339")
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as err:
+        raise ValidationError(f"{label} must be RFC3339") from err
+
+
+def _mapping_value(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be an object")
+    return value
+
+
+def _evidence_values(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, list):
+        raise ValidationError("provenance.evidence must be an array")
+    return [_mapping_value(entry, "provenance.evidence entry") for entry in value]
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        raise ValidationError("confidence.reasons must be a string array")
+    out: list[str] = []
+    for entry in value:
+        if not isinstance(entry, str) or not entry:
+            raise ValidationError("confidence.reasons must contain strings")
+        out.append(entry)
+    return out
 
 
 def _resolve_attribute(

--- a/py/src/theorydb_py/release_state.py
+++ b/py/src/theorydb_py/release_state.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+from .errors import ValidationError
+from .model import AttributeDefinition, ModelDefinition
+from .table import Table, _map_transaction_error
+from .transaction import UpdateAdd
+
+
+def transition_release_state(
+    actual_table: Table[Any],
+    event_table: Table[Any],
+    *,
+    actual_key: Mapping[str, Any],
+    set_values: Mapping[str, Any],
+    event_item: Any,
+    expected_version: int | None = None,
+    version_field: str = "version",
+) -> None:
+    """Transactionally update a release-state actual row and append an event.
+
+    The two DynamoDB rows are written through a single TransactWriteItems call
+    when both Table instances share the same local client/table context.
+
+    External side effects such as Lambda alias flips or CodePipeline executions
+    are intentionally outside this helper's atomicity boundary. Callers should
+    pair those side effects with explicit retry/reconciliation/outbox behavior.
+    """
+
+    _assert_same_transaction_context(actual_table, event_table)
+    if not actual_key:
+        raise ValidationError("actual_key is required")
+    if not set_values:
+        raise ValidationError("set_values is required")
+    if event_item is None:
+        raise ValidationError("event_item is required")
+
+    version_attr = _resolve_attribute(actual_table._model, version_field, role="version")
+    updates = _canonical_updates(actual_table._model, set_values)
+    if version_attr.python_name in updates or version_attr.attribute_name in set_values:
+        raise ValidationError("transition set must not mutate version directly")
+    updates[version_attr.python_name] = UpdateAdd(1)
+
+    condition_expression: str | None = None
+    condition_names: dict[str, str] | None = None
+    condition_values: dict[str, Any] | None = None
+    if expected_version is not None:
+        condition_expression = "#rs_version = :rs_expected_version"
+        condition_names = {"#rs_version": version_attr.attribute_name}
+        condition_values = {":rs_expected_version": expected_version}
+
+    pk = _key_value(actual_table._model.pk, actual_key)
+    sk = _key_value(actual_table._model.sk, actual_key) if actual_table._model.sk is not None else None
+
+    update_req = actual_table._build_update_request(
+        pk,
+        sk,
+        updates,
+        condition_expression=condition_expression,
+        expression_attribute_names=condition_names,
+        expression_attribute_values=condition_values,
+    )
+
+    put_req: dict[str, Any] = {
+        "TableName": event_table._table_name,
+        "Item": event_table._to_item(event_item),
+    }
+    _apply_create_condition(event_table._model, put_req)
+
+    try:
+        actual_table._client.transact_write_items(
+            TransactItems=[
+                {"Update": update_req},
+                {"Put": put_req},
+            ]
+        )
+    except ClientError as err:  # pragma: no cover
+        raise _map_transaction_error(err) from err
+
+
+def _assert_same_transaction_context(actual_table: Table[Any], event_table: Table[Any]) -> None:
+    if actual_table._client is not event_table._client:
+        raise ValidationError("release-state transaction requires both tables to share one DynamoDB client")
+    if actual_table._table_name != event_table._table_name:
+        raise ValidationError("release-state transaction requires both rows to share one DynamoDB table")
+
+
+def _key_value(attr: AttributeDefinition, values: Mapping[str, Any]) -> Any:
+    if attr.python_name in values:
+        return values[attr.python_name]
+    if attr.attribute_name in values:
+        return values[attr.attribute_name]
+    raise ValidationError(f"missing key attribute: {attr.attribute_name}")
+
+
+def _canonical_updates(model: ModelDefinition[Any], values: Mapping[str, Any]) -> dict[str, Any]:
+    by_attribute_name = {attr.attribute_name: attr.python_name for attr in model.attributes.values()}
+    updates: dict[str, Any] = {}
+    for field, value in values.items():
+        name = str(field)
+        python_name = name if name in model.attributes else by_attribute_name.get(name)
+        if python_name is None:
+            raise ValidationError(f"unknown field: {name}")
+        updates[python_name] = value
+    return updates
+
+
+def _resolve_attribute(
+    model: ModelDefinition[Any],
+    name: str,
+    *,
+    role: str | None = None,
+) -> AttributeDefinition:
+    attr = model.attributes.get(name)
+    if attr is None:
+        attr = next(
+            (candidate for candidate in model.attributes.values() if candidate.attribute_name == name), None
+        )
+    if attr is None and role is not None:
+        attr = next((candidate for candidate in model.attributes.values() if role in candidate.roles), None)
+    if attr is None:
+        raise ValidationError(f"unknown field: {name}")
+    return attr
+
+
+def _apply_create_condition(model: ModelDefinition[Any], request: dict[str, Any]) -> None:
+    names = dict(request.get("ExpressionAttributeNames") or {})
+    placeholder = _pk_placeholder(names, model.pk.attribute_name)
+    names[placeholder] = model.pk.attribute_name
+
+    condition = f"attribute_not_exists({placeholder})"
+    existing = request.get("ConditionExpression")
+    if existing:
+        request["ConditionExpression"] = f"({existing}) AND {condition}"
+    else:
+        request["ConditionExpression"] = condition
+    request["ExpressionAttributeNames"] = names
+
+
+def _pk_placeholder(names: Mapping[str, str], pk_attribute: str) -> str:
+    if names.get("#pk") in {None, pk_attribute}:
+        return "#pk"
+    index = 1
+    while f"#pk{index}" in names:
+        index += 1
+    return f"#pk{index}"

--- a/py/tests/unit/test_release_state.py
+++ b/py/tests/unit/test_release_state.py
@@ -5,8 +5,15 @@ from typing import Any
 
 import pytest
 
-from theorydb_py import ModelDefinition, Table, WritePolicy, theorydb_field, transition_release_state
-from theorydb_py.errors import ValidationError
+from theorydb_py import (
+    ModelDefinition,
+    Table,
+    WritePolicy,
+    theorydb_field,
+    transition_release_state,
+    validate_deploy_authority_metadata,
+)
+from theorydb_py.errors import RejectedDeployAuthorityEvidenceError, ValidationError
 from theorydb_py.mocks import FakeDynamoDBClient
 
 
@@ -116,3 +123,71 @@ def test_transition_release_state_requires_shared_context_and_blocks_version_set
             set_values={"version": 2},
             event_item=ReleaseStateEvent(pk="RELEASE#service-a", sk="EVENT#1"),
         )
+
+
+def _valid_deploy_authority_item() -> dict[str, Any]:
+    return {
+        "provenance": {
+            "mode": "native",
+            "system": "release-control-plane",
+            "kind": "operator_command",
+            "ref": "operator://deploy/service-a/rel_001",
+            "observed_at": "2026-04-24T19:00:00Z",
+            "recorded_at": "2026-04-24T19:00:01Z",
+            "evidence": [
+                {
+                    "kind": "operator_command",
+                    "source": "release-control-plane",
+                    "ref": "operator://deploy/service-a/rel_001",
+                    "observed_at": "2026-04-24T19:00:00Z",
+                }
+            ],
+        },
+        "confidence": {
+            "level": "high",
+            "reasons": ["operator_command_authority"],
+        },
+    }
+
+
+def test_validate_deploy_authority_metadata_accepts_deterministic_high_confidence() -> None:
+    validate_deploy_authority_metadata(_valid_deploy_authority_item())
+    validate_deploy_authority_metadata({"PK": "RELEASE#service-a"})
+
+
+def test_validate_deploy_authority_metadata_rejects_conflicting_evidence() -> None:
+    item = _valid_deploy_authority_item()
+    item["provenance"] = {
+        "mode": "imported",
+        "system": "partner-factory",
+        "kind": "factory_batch_manifest",
+        "ref": "s3://factory/manifests/ambiguous.json",
+        "observed_at": "2026-04-24T19:10:00Z",
+        "recorded_at": "2026-04-24T19:10:01Z",
+        "evidence": [
+            {
+                "kind": "factory_batch_manifest",
+                "source": "partner-factory",
+                "ref": "s3://factory/manifests/a.json",
+                "observed_at": "2026-04-24T19:09:59Z",
+            },
+            {
+                "kind": "submodule_pin",
+                "source": "service-ci",
+                "ref": "https://github.com/acme/service-b/tree/conflicting",
+                "observed_at": "2026-04-24T19:09:59Z",
+            },
+        ],
+    }
+    item["confidence"] = {"level": "low", "reasons": ["conflicting_evidence"]}
+
+    with pytest.raises(RejectedDeployAuthorityEvidenceError):
+        validate_deploy_authority_metadata(item)
+
+
+def test_validate_deploy_authority_metadata_rejects_free_form_notes() -> None:
+    item = _valid_deploy_authority_item()
+    item["provenance"]["notes"] = "human note"
+
+    with pytest.raises(ValidationError):
+        validate_deploy_authority_metadata(item)

--- a/py/tests/unit/test_release_state.py
+++ b/py/tests/unit/test_release_state.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from theorydb_py import ModelDefinition, Table, WritePolicy, theorydb_field, transition_release_state
+from theorydb_py.errors import ValidationError
+from theorydb_py.mocks import FakeDynamoDBClient
+
+
+@dataclass(frozen=True)
+class ReleaseStateActual:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    status: str = theorydb_field(default="")
+    pinned_release_id: str = theorydb_field(name="pinnedReleaseId", default="")
+    previous_release_id: str = theorydb_field(name="previousReleaseId", default="")
+    version: int = theorydb_field(roles=["version"], default=0)
+
+
+@dataclass(frozen=True)
+class ReleaseStateEvent:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    release_id: str = theorydb_field(name="releaseId", default="")
+    event_type: str = theorydb_field(name="eventType", default="")
+
+
+def _actual_table(client: FakeDynamoDBClient) -> Table[ReleaseStateActual]:
+    return Table(
+        ModelDefinition.from_dataclass(
+            ReleaseStateActual,
+            table_name="release_state_contract",
+            write_policy=WritePolicy(mode="mutable", protected_attributes=["pinnedReleaseId"]),
+        ),
+        client=client,
+    )
+
+
+def _event_table(client: FakeDynamoDBClient) -> Table[ReleaseStateEvent]:
+    return Table(
+        ModelDefinition.from_dataclass(
+            ReleaseStateEvent,
+            table_name="release_state_contract",
+            write_policy=WritePolicy(mode="write_once"),
+        ),
+        client=client,
+    )
+
+
+def test_transition_release_state_uses_one_transaction() -> None:
+    client = FakeDynamoDBClient()
+    actual_table = _actual_table(client)
+    event_table = _event_table(client)
+
+    def validate(req: dict[str, Any]) -> None:
+        items = req["TransactItems"]
+        assert len(items) == 2
+
+        update = items[0]["Update"]
+        assert update["TableName"] == "release_state_contract"
+        assert "SET" in update["UpdateExpression"]
+        assert "ADD" in update["UpdateExpression"]
+        assert update["ConditionExpression"] == "#rs_version = :rs_expected_version"
+        assert update["ExpressionAttributeNames"]["#rs_version"] == "version"
+        assert update["ExpressionAttributeValues"][":rs_expected_version"] == {"N": "0"}
+        assert "previousReleaseId" in update["ExpressionAttributeNames"].values()
+
+        put = items[1]["Put"]
+        assert put["TableName"] == "release_state_contract"
+        assert put["ConditionExpression"] == "attribute_not_exists(#pk)"
+        assert put["ExpressionAttributeNames"]["#pk"] == "PK"
+
+    client.expect("transact_write_items", validate, response={})
+
+    transition_release_state(
+        actual_table,
+        event_table,
+        actual_key={"PK": "RELEASE#service-a", "SK": "ACTUAL"},
+        expected_version=0,
+        set_values={"status": "active", "previousReleaseId": "rel_001"},
+        event_item=ReleaseStateEvent(
+            pk="RELEASE#service-a",
+            sk="EVENT#1",
+            release_id="rel_002",
+            event_type="promoted",
+        ),
+    )
+
+    client.assert_no_pending()
+
+
+def test_transition_release_state_requires_shared_context_and_blocks_version_set() -> None:
+    actual_table = _actual_table(FakeDynamoDBClient())
+    event_table = _event_table(FakeDynamoDBClient())
+
+    with pytest.raises(ValidationError, match="share one DynamoDB client"):
+        transition_release_state(
+            actual_table,
+            event_table,
+            actual_key={"PK": "RELEASE#service-a", "SK": "ACTUAL"},
+            set_values={"status": "active"},
+            event_item=ReleaseStateEvent(pk="RELEASE#service-a", sk="EVENT#1"),
+        )
+
+    shared = FakeDynamoDBClient()
+    actual_table = _actual_table(shared)
+    event_table = _event_table(shared)
+    with pytest.raises(ValidationError, match="version"):
+        transition_release_state(
+            actual_table,
+            event_table,
+            actual_key={"PK": "RELEASE#service-a", "SK": "ACTUAL"},
+            set_values={"version": 2},
+            event_item=ReleaseStateEvent(pk="RELEASE#service-a", sk="EVENT#1"),
+        )

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -19,5 +19,6 @@ export * from './send-options.js';
 export * from './validation.js';
 export * from './protection.js';
 export * from './write-policy.js';
+export * from './release-state.js';
 export * from './lease.js';
 export * from './facetheory-isr.js';

--- a/ts/src/release-state.ts
+++ b/ts/src/release-state.ts
@@ -2,6 +2,28 @@ import type { TheorydbClient } from './client.js';
 import { TheorydbError } from './errors.js';
 
 const DEFAULT_VERSION_ATTRIBUTE = 'version';
+const RFC3339_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const PROVENANCE_KEYS = new Set([
+  'mode',
+  'system',
+  'kind',
+  'ref',
+  'commit_sha',
+  'observed_at',
+  'recorded_at',
+  'import_run_id',
+  'evidence',
+]);
+const EVIDENCE_KEYS = new Set([
+  'kind',
+  'source',
+  'ref',
+  'observed_at',
+  'digest',
+]);
+const CONFIDENCE_KEYS = new Set(['level', 'reasons']);
+const PROVENANCE_MODES = new Set(['native', 'imported', 'inferred']);
 
 /**
  * Input for a release-state registry transition. The actual-state update and
@@ -105,4 +127,178 @@ function validateTransitionInput(
       'release-state transition set must not mutate version directly',
     );
   }
+}
+
+/**
+ * Validate deterministic provenance/confidence metadata for a
+ * deploy-authoritative release-state actual row.
+ *
+ * Ambiguous/conflicting or low-confidence evidence is rejected so it cannot be
+ * persisted as deploy authority. Preserve that evidence as separate immutable
+ * visibility/event records instead.
+ */
+export function validateDeployAuthorityMetadata(
+  item: Record<string, unknown>,
+): void {
+  const hasProvenance = Object.hasOwn(item, 'provenance');
+  const hasConfidence = Object.hasOwn(item, 'confidence');
+  if (!hasProvenance && !hasConfidence) return;
+  if (!hasProvenance || !hasConfidence) {
+    invalidModel('provenance and confidence must be provided together');
+  }
+
+  const provenance = recordValue(item.provenance, 'provenance');
+  const confidence = recordValue(item.confidence, 'confidence');
+  validateAllowedKeys('provenance', provenance, PROVENANCE_KEYS);
+  validateAllowedKeys('confidence', confidence, CONFIDENCE_KEYS);
+  validateProvenanceShape(provenance);
+
+  const expectedReason = deriveDeployAuthorityReason(provenance);
+  validateConfidence(confidence, expectedReason);
+}
+
+function validateProvenanceShape(provenance: Record<string, unknown>): void {
+  const mode = requiredString(provenance, 'mode');
+  if (!PROVENANCE_MODES.has(mode)) {
+    invalidModel(`unsupported provenance.mode: ${mode}`);
+  }
+  for (const key of ['system', 'kind', 'ref']) {
+    requiredString(provenance, key);
+  }
+  for (const key of ['observed_at', 'recorded_at']) {
+    validateRfc3339(key, requiredString(provenance, key));
+  }
+  for (const key of ['commit_sha', 'import_run_id']) {
+    if (Object.hasOwn(provenance, key) && typeof provenance[key] !== 'string') {
+      invalidModel(`provenance.${key} must be a string`);
+    }
+  }
+}
+
+function deriveDeployAuthorityReason(
+  provenance: Record<string, unknown>,
+): string {
+  const evidence = evidenceValues(provenance.evidence);
+  if (evidence.length === 0) {
+    rejected('deploy authority requires evidence');
+  }
+
+  let signature: string | undefined;
+  let first: Record<string, unknown> | undefined;
+  for (const entry of evidence) {
+    validateAllowedKeys('provenance.evidence', entry, EVIDENCE_KEYS);
+    const kind = requiredString(entry, 'kind');
+    const source = requiredString(entry, 'source');
+    const ref = requiredString(entry, 'ref');
+    validateRfc3339(
+      'evidence.observed_at',
+      requiredString(entry, 'observed_at'),
+    );
+    if (Object.hasOwn(entry, 'digest') && typeof entry.digest !== 'string') {
+      invalidModel('evidence.digest must be a string');
+    }
+
+    const currentSignature = `${kind}|${source}|${ref}`;
+    if (signature === undefined) {
+      signature = currentSignature;
+      first = entry;
+      continue;
+    }
+    if (signature !== currentSignature) {
+      rejected('conflicting deploy authority evidence');
+    }
+  }
+
+  if (!first) rejected('deploy authority requires evidence');
+  const kind = requiredString(first, 'kind');
+  const source = requiredString(first, 'source');
+  if (kind === 'operator_command' && source === 'release-control-plane') {
+    return 'operator_command_authority';
+  }
+  if (kind === 'factory_batch_manifest' && source === 'partner-factory') {
+    return 'unique_factory_manifest_match';
+  }
+  if (kind === 'codepipeline_execution' && source === 'service-ci') {
+    return 'codepipeline_execution_authority';
+  }
+  if (kind === 'submodule_pin' && source === 'service-ci') {
+    return 'unique_submodule_pin_match';
+  }
+  rejected(`unsupported deploy authority evidence: ${source}/${kind}`);
+}
+
+function validateConfidence(
+  confidence: Record<string, unknown>,
+  expectedReason: string,
+): void {
+  const level = requiredString(confidence, 'level');
+  if (level !== 'high') {
+    rejected(`${level} confidence cannot authorize deploy state`);
+  }
+  const reasons = stringArrayValue(confidence.reasons);
+  if (reasons.length !== 1 || reasons[0] !== expectedReason) {
+    rejected('confidence reasons do not match deterministic authority');
+  }
+}
+
+function validateAllowedKeys(
+  label: string,
+  record: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+): void {
+  for (const key of Object.keys(record)) {
+    if (!allowed.has(key)) {
+      invalidModel(`unsupported ${label} key: ${key}`);
+    }
+  }
+}
+
+function requiredString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    invalidModel(`${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function validateRfc3339(label: string, value: string): void {
+  if (!RFC3339_RE.test(value) || Number.isNaN(Date.parse(value))) {
+    invalidModel(`${label} must be RFC3339`);
+  }
+}
+
+function recordValue(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) invalidModel(`${label} must be an object`);
+  return value;
+}
+
+function evidenceValues(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    invalidModel('provenance.evidence must be an array');
+  }
+  return value.map((entry) => recordValue(entry, 'provenance.evidence entry'));
+}
+
+function stringArrayValue(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    invalidModel('confidence.reasons must be a string array');
+  }
+  return value.map((entry) => {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      invalidModel('confidence.reasons must contain strings');
+    }
+    return entry;
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function invalidModel(message: string): never {
+  throw new TheorydbError('ErrInvalidModel', message);
+}
+
+function rejected(message: string): never {
+  throw new TheorydbError('ErrRejectedDeployAuthorityEvidence', message);
 }

--- a/ts/src/release-state.ts
+++ b/ts/src/release-state.ts
@@ -1,0 +1,108 @@
+import type { TheorydbClient } from './client.js';
+import { TheorydbError } from './errors.js';
+
+const DEFAULT_VERSION_ATTRIBUTE = 'version';
+
+/**
+ * Input for a release-state registry transition. The actual-state update and
+ * event-history append are committed through one DynamoDB transaction by the
+ * supplied TableTheory client.
+ *
+ * External side effects such as Lambda alias flips or CodePipeline executions
+ * are intentionally outside this helper's atomicity boundary. Callers should
+ * pair those side effects with explicit retry/reconciliation/outbox behavior.
+ */
+export interface ReleaseStateTransitionInput {
+  actualModel: string;
+  actualKey: Record<string, unknown>;
+  set: Record<string, unknown>;
+  eventModel: string;
+  eventItem: Record<string, unknown>;
+  expectedVersion?: number;
+  versionAttribute?: string;
+}
+
+/**
+ * Transactionally update the release-state actual row and append one immutable
+ * event-history row.
+ */
+export async function transitionReleaseState(
+  client: TheorydbClient,
+  input: ReleaseStateTransitionInput,
+): Promise<void> {
+  validateTransitionInput(client, input);
+  const versionAttribute = input.versionAttribute ?? DEFAULT_VERSION_ATTRIBUTE;
+
+  await client.transactWrite([
+    {
+      kind: 'update',
+      model: input.actualModel,
+      key: input.actualKey,
+      updateFn: (builder) => {
+        for (const [field, value] of Object.entries(input.set)) {
+          builder.set(field, value);
+        }
+        builder.add(versionAttribute, 1);
+        if (input.expectedVersion !== undefined) {
+          builder.conditionVersion(input.expectedVersion);
+        }
+      },
+    },
+    {
+      kind: 'put',
+      model: input.eventModel,
+      item: input.eventItem,
+      ifNotExists: true,
+    },
+  ]);
+}
+
+function validateTransitionInput(
+  client: TheorydbClient,
+  input: ReleaseStateTransitionInput,
+): void {
+  if (!client) {
+    throw new TheorydbError(
+      'ErrInvalidModel',
+      'release-state client is required',
+    );
+  }
+  if (!input.actualModel) {
+    throw new TheorydbError(
+      'ErrInvalidModel',
+      'release-state actualModel is required',
+    );
+  }
+  if (!input.eventModel) {
+    throw new TheorydbError(
+      'ErrInvalidModel',
+      'release-state eventModel is required',
+    );
+  }
+  if (Object.keys(input.actualKey).length === 0) {
+    throw new TheorydbError(
+      'ErrInvalidModel',
+      'release-state actualKey is required',
+    );
+  }
+  if (Object.keys(input.eventItem).length === 0) {
+    throw new TheorydbError(
+      'ErrInvalidModel',
+      'release-state eventItem is required',
+    );
+  }
+  if (Object.keys(input.set).length === 0) {
+    throw new TheorydbError(
+      'ErrInvalidOperator',
+      'release-state transition set is required',
+    );
+  }
+
+  const versionAttribute = input.versionAttribute ?? DEFAULT_VERSION_ATTRIBUTE;
+  if (Object.hasOwn(input.set, versionAttribute)) {
+    throw new TheorydbError(
+      'ErrInvalidModel',
+      'release-state transition set must not mutate version directly',
+    );
+  }
+}

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -21,5 +21,6 @@ await import('./unit/lambda.test.js');
 await import('./unit/multiaccount.test.js');
 await import('./unit/validation.test.js');
 await import('./unit/protection.test.js');
+await import('./unit/release-state.test.js');
 await import('./unit/lease.test.js');
 await import('./unit/facetheory-isr.test.js');

--- a/ts/test/unit/release-state.test.ts
+++ b/ts/test/unit/release-state.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+
+import {
+  TransactWriteItemsCommand,
+  type DynamoDBClient,
+} from '@aws-sdk/client-dynamodb';
+
+import { TheorydbClient } from '../../src/client.js';
+import { TheorydbError } from '../../src/errors.js';
+import { defineModel } from '../../src/model.js';
+import { transitionReleaseState } from '../../src/release-state.js';
+
+const ReleaseStateActual = defineModel({
+  name: 'ReleaseStateActual',
+  table: { name: 'release_state_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort: { attribute: 'SK', type: 'S' },
+  },
+  write_policy: {
+    mode: 'mutable',
+    protected_attributes: ['pinnedReleaseId'],
+  },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'SK', type: 'S', roles: ['sk'] },
+    { attribute: 'status', type: 'S', optional: true },
+    { attribute: 'pinnedReleaseId', type: 'S', optional: true },
+    { attribute: 'previousReleaseId', type: 'S', optional: true },
+    { attribute: 'version', type: 'N', roles: ['version'] },
+  ],
+});
+
+const ReleaseStateEvent = defineModel({
+  name: 'ReleaseStateEvent',
+  table: { name: 'release_state_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort: { attribute: 'SK', type: 'S' },
+  },
+  write_policy: {
+    mode: 'write_once',
+  },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'SK', type: 'S', roles: ['sk'] },
+    { attribute: 'releaseId', type: 'S', optional: true },
+    { attribute: 'eventType', type: 'S', optional: true },
+  ],
+});
+
+class StubDdb {
+  sent: unknown[] = [];
+
+  async send(cmd: unknown): Promise<unknown> {
+    this.sent.push(cmd);
+    return {};
+  }
+}
+
+{
+  const ddb = new StubDdb();
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    ReleaseStateActual,
+    ReleaseStateEvent,
+  );
+
+  await transitionReleaseState(client, {
+    actualModel: 'ReleaseStateActual',
+    actualKey: { PK: 'RELEASE#service-a', SK: 'ACTUAL' },
+    expectedVersion: 0,
+    set: { status: 'active', previousReleaseId: 'rel_001' },
+    eventModel: 'ReleaseStateEvent',
+    eventItem: {
+      PK: 'RELEASE#service-a',
+      SK: 'EVENT#1',
+      releaseId: 'rel_002',
+      eventType: 'promoted',
+    },
+  });
+
+  const cmd = ddb.sent[0];
+  assert.ok(cmd instanceof TransactWriteItemsCommand);
+  assert.equal(cmd.input.TransactItems?.length, 2);
+
+  const update = cmd.input.TransactItems?.[0]?.Update;
+  assert.equal(update?.TableName, 'release_state_contract');
+  assert.ok(update?.UpdateExpression?.includes('SET'));
+  assert.ok(update?.UpdateExpression?.includes('ADD'));
+  assert.ok(update?.ConditionExpression);
+  assert.ok(
+    Object.values(update?.ExpressionAttributeNames ?? {}).includes('version'),
+  );
+
+  const put = cmd.input.TransactItems?.[1]?.Put;
+  assert.equal(put?.TableName, 'release_state_contract');
+  assert.equal(put?.ConditionExpression, 'attribute_not_exists(#pk)');
+}
+
+{
+  const ddb = new StubDdb();
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    ReleaseStateActual,
+    ReleaseStateEvent,
+  );
+
+  await assert.rejects(
+    () =>
+      transitionReleaseState(client, {
+        actualModel: 'ReleaseStateActual',
+        actualKey: { PK: 'RELEASE#service-a', SK: 'ACTUAL' },
+        set: { version: 2 },
+        eventModel: 'ReleaseStateEvent',
+        eventItem: { PK: 'RELEASE#service-a', SK: 'EVENT#1' },
+      }),
+    (e) => e instanceof TheorydbError && e.code === 'ErrInvalidModel',
+  );
+  assert.equal(ddb.sent.length, 0);
+}

--- a/ts/test/unit/release-state.test.ts
+++ b/ts/test/unit/release-state.test.ts
@@ -8,7 +8,10 @@ import {
 import { TheorydbClient } from '../../src/client.js';
 import { TheorydbError } from '../../src/errors.js';
 import { defineModel } from '../../src/model.js';
-import { transitionReleaseState } from '../../src/release-state.js';
+import {
+  transitionReleaseState,
+  validateDeployAuthorityMetadata,
+} from '../../src/release-state.js';
 
 const ReleaseStateActual = defineModel({
   name: 'ReleaseStateActual',
@@ -116,4 +119,79 @@ class StubDdb {
     (e) => e instanceof TheorydbError && e.code === 'ErrInvalidModel',
   );
   assert.equal(ddb.sent.length, 0);
+}
+
+function validDeployAuthorityItem(): Record<string, unknown> {
+  return {
+    provenance: {
+      mode: 'native',
+      system: 'release-control-plane',
+      kind: 'operator_command',
+      ref: 'operator://deploy/service-a/rel_001',
+      observed_at: '2026-04-24T19:00:00Z',
+      recorded_at: '2026-04-24T19:00:01Z',
+      evidence: [
+        {
+          kind: 'operator_command',
+          source: 'release-control-plane',
+          ref: 'operator://deploy/service-a/rel_001',
+          observed_at: '2026-04-24T19:00:00Z',
+        },
+      ],
+    },
+    confidence: {
+      level: 'high',
+      reasons: ['operator_command_authority'],
+    },
+  };
+}
+
+{
+  assert.doesNotThrow(() =>
+    validateDeployAuthorityMetadata(validDeployAuthorityItem()),
+  );
+  assert.doesNotThrow(() => validateDeployAuthorityMetadata({ PK: 'A' }));
+}
+
+{
+  const item = validDeployAuthorityItem();
+  item.provenance = {
+    mode: 'imported',
+    system: 'partner-factory',
+    kind: 'factory_batch_manifest',
+    ref: 's3://factory/manifests/ambiguous.json',
+    observed_at: '2026-04-24T19:10:00Z',
+    recorded_at: '2026-04-24T19:10:01Z',
+    evidence: [
+      {
+        kind: 'factory_batch_manifest',
+        source: 'partner-factory',
+        ref: 's3://factory/manifests/a.json',
+        observed_at: '2026-04-24T19:09:59Z',
+      },
+      {
+        kind: 'submodule_pin',
+        source: 'service-ci',
+        ref: 'https://github.com/acme/service-b/tree/conflicting',
+        observed_at: '2026-04-24T19:09:59Z',
+      },
+    ],
+  };
+  item.confidence = { level: 'low', reasons: ['conflicting_evidence'] };
+
+  assert.throws(
+    () => validateDeployAuthorityMetadata(item),
+    (e) =>
+      e instanceof TheorydbError &&
+      e.code === 'ErrRejectedDeployAuthorityEvidence',
+  );
+}
+
+{
+  const item = validDeployAuthorityItem();
+  (item.provenance as Record<string, unknown>).notes = 'free form';
+  assert.throws(
+    () => validateDeployAuthorityMetadata(item),
+    (e) => e instanceof TheorydbError && e.code === 'ErrInvalidModel',
+  );
 }


### PR DESCRIPTION
## Milestone
tt-release-state-helpers — add transactional release-state transition helpers and deterministic provenance/confidence validation across Go, TypeScript, and Python.

## Linear
https://linear.app/pay-theory/project/tabletheory-release-state-write-policies-0ebbc8f7b4c1 / milestone `tt-release-state-helpers`

## GitHub issue
Closes part of #159.

## Affected runtimes
Go, TypeScript, and Python.

## Contract impact
Additive runtime support for existing capability-gated release-state P0 scenarios:

- `08-release-state-transactional-transition.yml` now executes in all three runners via `release_state.transactional_transition`.
- `09-release-state-provenance-confidence.yml` now executes in all three runners via `release_state.provenance_confidence`.

## Backward compatibility
Additive / opt-in. Existing models without release-state helper use or provenance/confidence metadata keep their current behavior. No persisted data shape changes are required.

## Tasks
- [x] IO-77 Add transactional release-state transition helpers
- [x] IO-78 Validate deterministic provenance and confidence metadata

## Validation
- `bash scripts/verify-branch-version-sync.sh` → PASS/SKIP on non-release branch
- `cd contract-tests/runners/go && go test ./... -v` → PASS
- `npm --prefix contract-tests/runners/ts test` → PASS
- `uv --directory py run pytest -q ../contract-tests/runners/py --import-mode=importlib` → PASS
- `cd py && python -m pytest -q --import-mode=importlib` → PASS
- `cd ts && npm run format:check && npm run lint && npm run typecheck && npm run test:unit` → PASS
- `make test-unit` → PASS
- `make rubric` → PASS

## Cross-repo coordination
No blocking cross-repo change in this PR. Release-control-plane can consume these helpers after the TableTheory release candidate; external side effects such as Lambda alias or CodePipeline changes still require explicit retry/reconciliation/outbox behavior and are not modeled as DynamoDB-atomic.