### PR TITLE
docs(releasestate): add release-state docs and examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ TheoryCloud TableTheory subtree.
 |---|---|
 | **Go Guides** | [Getting Started](./getting-started.md) &#124; [API Reference](./api-reference.md) &#124; [Core Patterns](./core-patterns.md) &#124; [Testing](./testing-guide.md) &#124; [Troubleshooting](./troubleshooting.md) |
 | **Schema** | [Struct Definition Guide](./struct-definition-guide.md) &#124; DMS v0.1 remains a repo-local planning document and is not published to TheoryCloud |
+| **Release State** | [Release-State Safety Patterns](./release-state-patterns.md) |
 | **FaceTheory** | [ISR Cache Schema](./facetheory/isr-cache-schema.md) &#124; [ISR Transaction Recipes](./facetheory/isr-transaction-recipes.md) &#124; [TTL Cache Patterns](./facetheory/ttl-cache-patterns.md) &#124; [ISR Idempotency](./facetheory/isr-idempotency.md) |
 | **CDK** | [CDK Integration](./cdk/README.md) |
 | **Migration** | [Migration Guide](./migration-guide.md) |
@@ -36,6 +37,8 @@ TheoryCloud TableTheory subtree.
 
 - [API Reference (Go)](./api-reference.md) – Go SDK public API (DB, Query, Transactions)
 - [Core Patterns (Go)](./core-patterns.md) – Go SDK canonical usage patterns (Lambda, Batch, Streams)
+- [Release-State Safety Patterns](./release-state-patterns.md) – Immutable event history, protected registry fields,
+  transactional transitions, outbox/reconciliation, and deterministic provenance/confidence
 - [FaceTheory ISR Cache Schema](./facetheory/isr-cache-schema.md) – Recommended cache metadata + regeneration lease item shapes
 - [FaceTheory ISR Transaction Recipes](./facetheory/isr-transaction-recipes.md) – Correctness-first patterns for publishing metadata under lease
 - [FaceTheory TTL Cache Patterns](./facetheory/ttl-cache-patterns.md) – Freshness vs expiry, TTL lag, and operational guidance for ISR tables

--- a/docs/_concepts.yaml
+++ b/docs/_concepts.yaml
@@ -117,6 +117,23 @@ concepts:
       - Delete: "Add delete operation to tx"
       - Execute: "Commit transaction"
 
+  release_state:
+    type: pattern
+    language: multi
+    purpose: "Model release/deploy authority with mutable actual-state rows and immutable event history"
+    provides:
+      - model_level_write_policy
+      - protected_registry_fields
+      - transactional_transition_event_append
+      - deterministic_provenance_confidence
+      - outbox_reconciliation_guidance
+    requires:
+      - dynamodb_transactions
+      - explicit_external_side_effect_reconciliation
+    dont_use_when:
+      - attempting_to_make_external_systems_dynamodb_atomic
+      - storing_ambiguous_evidence_as_deploy_authority
+
   struct_tags:
     type: mechanism
     purpose: "Map Go structs to DynamoDB attributes"

--- a/docs/_decisions.yaml
+++ b/docs/_decisions.yaml
@@ -93,6 +93,25 @@ decisions:
           example: |
             db.Transact().ConditionCheck(item, tabletheory.Condition("Status", "=", "ACTIVE")).Execute()
 
+  release_state_modeling:
+    question: "How should I model release or deploy authority?"
+    decision_tree:
+      - condition: "You need to answer what release is currently authoritative"
+        choice: "Use a mutable actual-state row with model-level protected pin fields"
+        reason: "The row can transition while generic helpers cannot mutate protected registry pins"
+      - condition: "You need an audit/event record"
+        choice: "Use a write_once event-history model"
+        reason: "Generic update/save/delete APIs reject mutation of immutable history"
+      - condition: "Actual-state transition and event append are both DynamoDB writes in one account/region/table context"
+        choice: "Use the release-state transition helper"
+        reason: "It commits the actual update and event append in one DynamoDB transaction"
+      - condition: "The transition also needs Lambda alias, CodePipeline, DNS, or another external side effect"
+        choice: "Use outbox/retry/reconciliation around the external side effect"
+        reason: "DynamoDB cannot make external systems atomic"
+      - condition: "Evidence is ambiguous, conflicting, or low confidence"
+        choice: "Reject it as deploy authority and store it only as immutable visibility/audit evidence"
+        reason: "Low confidence is visibility-only and must not authorize deployment state"
+
   gsi_design:
     question: "How should I design Global Secondary Indexes (GSIs)?"
     decision_tree:

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -127,6 +127,36 @@ patterns:
           - unexpected_data_states
           - difficult_to_debug_consistency_issues
 
+  release_state:
+    name: "Release-State Actual/Event Split"
+    problem: "Release/deploy authority can drift when mutable state, audit history, and external side effects are mixed"
+    solution: "Keep one mutable actual-state row with protected fields, append immutable write-once event rows, and use a DynamoDB transaction for the internal transition"
+    correct_example: |
+      # ✅ CORRECT: actual-state update and event append share one transaction.
+      # External side effects are handled by outbox/reconciliation.
+      transitionReleaseState(client, {
+        actualModel: "ReleaseStateActual",
+        actualKey: { PK: "RELEASE#service-a", SK: "ACTUAL" },
+        set: { status: "active", previousReleaseId: "rel_001" },
+        eventModel: "ReleaseStateEvent",
+        eventItem: { PK: "RELEASE#service-a", SK: "EVENT#rel_002" },
+      })
+    anti_patterns:
+      - name: "Helper-only immutability"
+        why: "Generic update/save APIs can still mutate safety-critical release records"
+        incorrect_example: |
+          # ❌ INCORRECT: event model is mutable and relies on callers never updating it.
+        consequences:
+          - mutable_audit_history
+          - release_authority_corruption
+      - name: "External side effect hidden as atomic"
+        why: "Lambda alias and CodePipeline changes are outside DynamoDB's transaction boundary"
+        incorrect_example: |
+          # ❌ INCORRECT: update DynamoDB and flip Lambda alias without outbox/reconciliation.
+        consequences:
+          - split_brain_release_state
+          - unreconciled_external_drift
+
   stream_processing:
     name: "DynamoDB Stream Processing"
     problem: "Manually parsing `events.DynamoDBAttributeValue` to Go structs is tedious and error-prone"

--- a/docs/release-state-patterns.md
+++ b/docs/release-state-patterns.md
@@ -241,6 +241,6 @@ Before promoting a TableTheory release candidate that includes release-state saf
 
 ## Runtime docs
 
-- Go examples live under `examples/`.
+- Go examples live under `examples/release-state/`.
 - TypeScript package docs live under `ts/docs/`.
 - Python package docs live under `py/docs/`.

--- a/docs/release-state-patterns.md
+++ b/docs/release-state-patterns.md
@@ -1,0 +1,246 @@
+# Release-State Safety Patterns
+
+<!-- AI Training: TableTheory release-state guardrails are DynamoDB-first, opt-in, and cross-runtime. -->
+
+Release-state records describe what release, artifact, alias, or deployment pin is authoritative for a service.
+Those records are safety-critical: a generic helper should not be able to mutate immutable history, loosen protected
+fields, or store ambiguous evidence as deploy authority. TableTheory exposes the release-state contract as an
+opt-in DynamoDB pattern that works the same way in Go, TypeScript, and Python.
+
+Use this guide when modeling release registries, deployment pin stores, factory import state, or similar records that
+need a mutable actual-state row plus immutable event history.
+
+## Contract summary
+
+| Concern | TableTheory pattern |
+| --- | --- |
+| Actual-state registry row | Mutable model with protected pin fields |
+| Event-history row | `write_once` model |
+| Generic mutation guard | Model-level `write_policy` metadata |
+| Per-call tightening | Additional protected attributes for that operation only |
+| Transition + event append | One DynamoDB transaction when rows share a transaction boundary |
+| External side effects | Outbox/retry/reconciliation; never represented as DynamoDB-atomic |
+| Deploy authority | Deterministic `provenance` + `confidence` metadata |
+| Ambiguous evidence | Rejected for deploy authority; store only as immutable visibility/audit events |
+
+The default remains unchanged for existing models: a model without `write_policy` is mutable and has no protected
+attributes.
+
+## Actual state vs. event history
+
+Release-state systems should separate **current authority** from **history**:
+
+- **Actual-state row**: one mutable registry row per deployable scope. It answers "what is current?"
+- **Event-history row**: append-only facts about how state changed, what was observed, or why a transition was
+  attempted. It answers "what happened?"
+
+✅ Correct single-table shape:
+
+```text
+PK = RELEASE#service-a, SK = ACTUAL
+PK = RELEASE#service-a, SK = EVENT#2026-04-24T19:00:00Z#rel_002
+PK = RELEASE#service-a, SK = EVIDENCE#factory#batch-2026-04-24
+PK = RELEASE#service-a, SK = OUTBOX#lambda-alias#rel_002
+```
+
+❌ Incorrect shape:
+
+```text
+PK = RELEASE#service-a, SK = ACTUAL
+notes = "operator thought this probably came from manifest A"
+```
+
+Free-form notes are not deploy authority. Store structured evidence in event/evidence rows and put only deterministic
+authority metadata on actual-state rows.
+
+## Model-level write policy
+
+Use model metadata to make immutability enforceable by generic TableTheory APIs.
+
+### Actual-state row
+
+Actual-state rows are usually mutable, but fields that identify the registry pin should be protected at the model
+level.
+
+```yaml
+write_policy:
+  mode: mutable
+  protected_attributes: ["pinnedReleaseId"]
+```
+
+Model-level protected fields cannot be loosened by a helper call. A helper may protect additional fields for one
+operation, but it cannot make `pinnedReleaseId` mutable for that operation.
+
+### Event-history row
+
+Event-history rows should be write-once.
+
+```yaml
+write_policy:
+  mode: write_once
+```
+
+`write_once` allows initial creation and rejects generic high-level update, save/upsert, and delete flows. That makes
+event history append-only by default. Low-level raw DynamoDB usage remains the escape hatch when an operator is doing
+explicit migration or repair work outside the high-level TableTheory contract.
+
+## Transaction boundary
+
+When the actual-state row and event-history row are in DynamoDB under the same transaction boundary, perform the state
+transition and event append in one DynamoDB transaction:
+
+1. Update the actual-state row.
+2. Increment the `version` field.
+3. Check the expected version when supplied.
+4. Create the event-history row with a not-exists condition.
+
+That gives consumers one observable outcome: both internal rows commit, or neither commits.
+
+✅ Correct:
+
+```text
+TransactWriteItems:
+  - Update RELEASE#service-a / ACTUAL
+  - Put    RELEASE#service-a / EVENT#...
+```
+
+❌ Incorrect:
+
+```text
+Update ACTUAL
+Put EVENT
+```
+
+Two separate calls can leave current state without its audit/event record.
+
+## External side effects are not DynamoDB-atomic
+
+External systems such as Lambda aliases, CodePipeline executions, container image promotions, or DNS updates cannot be
+made atomic by a DynamoDB transaction. Do not document or implement a transition as if those systems commit inside the
+same transaction.
+
+Use one of these patterns:
+
+### Internal transition before side effect
+
+1. Write the intended internal state and an outbox row in one DynamoDB transaction.
+2. A worker reads the outbox row and performs the external side effect.
+3. The worker appends success/failure event rows.
+4. A reconciler retries or repairs incomplete side effects.
+
+### Side effect before authoritative state
+
+1. Perform the external side effect with an idempotency key.
+2. Observe the external system state.
+3. Write the actual-state row and event append transaction with deterministic evidence.
+4. If the transaction fails, reconcile from the idempotency key and observed external state.
+
+Choose the direction based on the real authority boundary for your system. In both directions, use explicit
+idempotency keys and reconciliation. Do not hide external side effects behind a helper that appears to be atomic.
+
+## Outbox records
+
+Outbox records should be immutable event-like rows. They represent work to attempt, not deploy authority by
+themselves.
+
+Recommended fields:
+
+| Field | Purpose |
+| --- | --- |
+| `PK` / `SK` | Scope and stable outbox ID |
+| `operation` | External side effect to attempt |
+| `idempotencyKey` | Stable key reused on retry |
+| `requestedState` | Target release/status snapshot |
+| `attempts` | Retry visibility |
+| `nextAttemptAt` | Backoff scheduling |
+| `lastError` | Redacted error summary |
+| `createdAt` / `updatedAt` | Lifecycle timestamps |
+
+Never store secrets, KMS key material, AWS credentials, or encrypted plaintext in outbox records.
+
+## Reconciliation
+
+Every release-state system that touches an external side effect needs a reconciler. A reconciler should:
+
+- query pending outbox rows;
+- compare actual-state rows with event history;
+- observe external systems through their native APIs;
+- append immutable reconciliation events;
+- retry idempotently when safe;
+- reject conflicting evidence rather than lowering deploy authority confidence.
+
+Low confidence is visibility-only. It is useful for dashboards and investigation, but it must not authorize deployment
+state.
+
+## Provenance and confidence metadata
+
+Actual-state rows that claim deploy authority should carry deterministic metadata:
+
+```json
+{
+  "provenance": {
+    "mode": "native",
+    "system": "release-control-plane",
+    "kind": "operator_command",
+    "ref": "operator://deploy/service-a/rel_002",
+    "observed_at": "2026-04-24T19:00:00Z",
+    "recorded_at": "2026-04-24T19:00:01Z",
+    "evidence": [
+      {
+        "kind": "operator_command",
+        "source": "release-control-plane",
+        "ref": "operator://deploy/service-a/rel_002",
+        "observed_at": "2026-04-24T19:00:00Z"
+      }
+    ]
+  },
+  "confidence": {
+    "level": "high",
+    "reasons": ["operator_command_authority"]
+  }
+}
+```
+
+The helper validation accepts deterministic high-confidence evidence and rejects:
+
+- missing `provenance`/`confidence` pairings;
+- unsupported free-form provenance keys;
+- non-RFC3339 timestamps;
+- conflicting evidence signatures;
+- unsupported evidence kinds/sources;
+- `medium` or `low` confidence as deploy authority;
+- confidence reasons that do not match the deterministic evidence mapping.
+
+If import evidence is ambiguous, preserve it as immutable evidence/event rows. Do not write it to the actual-state row
+as deploy authority.
+
+## DynamoDB Streams audit/archive
+
+DynamoDB Streams are the right integration point for secondary audit archives, search indexes, or compliance sinks.
+Streams are not the primary authority for release-state correctness; the write policy and transaction are. Use Streams
+to mirror committed facts after the DynamoDB transaction succeeds.
+
+Recommended stream handling:
+
+- treat stream delivery as at-least-once;
+- make archive writes idempotent by event row key;
+- redact encrypted/sensitive fields before logging;
+- alert on stream lag, but reconcile from DynamoDB state rather than assuming the stream archive is authoritative.
+
+## Release/RC verification checklist
+
+Before promoting a TableTheory release candidate that includes release-state safety support:
+
+1. Verify Go, TypeScript, and Python contract runners execute release-state scenarios 06–09.
+2. Run `make rubric`.
+3. Run `bash scripts/verify-branch-release-supply-chain.sh`.
+4. Run `bash scripts/verify-branch-version-sync.sh`.
+5. Confirm release notes classify the feature as additive/opt-in.
+6. Validate downstream release-control-plane models against the RC asset.
+7. Confirm distribution remains GitHub Releases only. Do not publish to npm or PyPI.
+
+## Runtime docs
+
+- Go examples live under `examples/`.
+- TypeScript package docs live under `ts/docs/`.
+- Python package docs live under `py/docs/`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -58,6 +58,18 @@ AWS Lambda integration examples:
 
 **What you'll learn:** Serverless architecture, Lambda optimization, event handling
 
+### 🛡️ [Release-State Registry](release-state/)
+**Safety-critical release/deploy authority patterns**
+
+Release-state registry example showing:
+- Mutable actual-state rows with protected registry pin fields
+- Immutable write-once event-history rows
+- Transactional actual-state transition plus event append
+- Deterministic provenance/confidence metadata
+- Outbox rows for external side effects such as Lambda alias updates
+
+**What you'll learn:** Release-state write policies, deploy authority validation, audit/outbox reconciliation
+
 ### ✨ Feature Spotlights
 - **[feature_spotlight.go](feature_spotlight.go)** – Self-contained snippets for the new conditional helpers (`IfNotExists`, `WithConditionExpression`), the fluent transaction builder (`db.Transact()`/`TransactWrite()`), and the retry-aware `BatchGetBuilder` with custom `core.RetryPolicy`, progress callbacks, and chunk-level error handling.
 
@@ -149,7 +161,8 @@ EOF
 
 ### Advanced Path
 7. **[Multi-Tenant SaaS](multi-tenant/)** - Enterprise architecture patterns
-8. **[Feature Spotlights](feature_spotlight.go)** - Deep dives on transactions, conditionals, and BatchGet builder
+8. **[Release-State Registry](release-state/)** - Safety-critical actual/event/outbox patterns
+9. **[Feature Spotlights](feature_spotlight.go)** - Deep dives on transactions, conditionals, and BatchGet builder
 
 ## Common Patterns Demonstrated
 

--- a/examples/release-state/README.md
+++ b/examples/release-state/README.md
@@ -1,0 +1,15 @@
+# Release-State Registry Example
+
+This example shows the Go shape for a safety-critical release-state registry:
+
+- a mutable actual-state row with protected registry pin fields;
+- immutable write-once event-history rows;
+- immutable outbox rows for external side effects;
+- deterministic provenance/confidence metadata;
+- a transactional actual-state transition plus event append.
+
+The example does not perform a Lambda alias or CodePipeline side effect. Those systems are outside DynamoDB's
+transaction boundary and must be handled with explicit outbox, retry, and reconciliation behavior.
+
+See the shared [release-state safety patterns](../../docs/release-state-patterns.md) guide for the full rationale and
+the TypeScript/Python companion examples.

--- a/examples/release-state/main.go
+++ b/examples/release-state/main.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/theory-cloud/tabletheory/pkg/model"
+	"github.com/theory-cloud/tabletheory/pkg/releasestate"
+)
+
+// ReleaseStateActual is the mutable current-state row for one deployable
+// scope. Registry pin fields are protected at the model level, so generic
+// update/save helpers cannot mutate them accidentally.
+type ReleaseStateActual struct {
+	PK                string         `theorydb:"pk" json:"PK"`
+	SK                string         `theorydb:"sk" json:"SK"`
+	Service           string         `json:"service"`
+	Status            string         `json:"status"`
+	PinnedReleaseID   string         `json:"pinnedReleaseId"`
+	PreviousReleaseID string         `json:"previousReleaseId,omitempty"`
+	Provenance        map[string]any `json:"provenance,omitempty"`
+	Confidence        map[string]any `json:"confidence,omitempty"`
+	Version           int64          `theorydb:"version" json:"version"`
+}
+
+func (ReleaseStateActual) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{
+		Mode:                model.WritePolicyModeMutable,
+		ProtectedAttributes: []string{"pinnedReleaseId"},
+	}
+}
+
+// ReleaseStateEvent is immutable audit history. TableTheory's write_once
+// policy lets callers create this row but rejects generic update/save/delete.
+type ReleaseStateEvent struct {
+	PK        string         `theorydb:"pk" json:"PK"`
+	SK        string         `theorydb:"sk" json:"SK"`
+	Service   string         `json:"service"`
+	ReleaseID string         `json:"releaseId"`
+	EventType string         `json:"eventType"`
+	At        string         `json:"at"`
+	Actor     string         `json:"actor"`
+	Evidence  map[string]any `json:"evidence,omitempty"`
+}
+
+func (ReleaseStateEvent) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{Mode: model.WritePolicyModeWriteOnce}
+}
+
+// ReleaseStateOutbox is also immutable. Workers consume these rows to perform
+// non-DynamoDB side effects, then append success/failure events.
+type ReleaseStateOutbox struct {
+	PK             string `theorydb:"pk" json:"PK"`
+	SK             string `theorydb:"sk" json:"SK"`
+	Operation      string `json:"operation"`
+	IdempotencyKey string `json:"idempotencyKey"`
+	RequestedState string `json:"requestedState"`
+	NextAttemptAt  string `json:"nextAttemptAt"`
+}
+
+func (ReleaseStateOutbox) WritePolicy() model.WritePolicy {
+	return model.WritePolicy{Mode: model.WritePolicyModeWriteOnce}
+}
+
+type PromoteCommand struct {
+	Service         string
+	ReleaseID       string
+	PreviousRelease string
+	Actor           string
+	ExpectedVersion int64
+	ObservedAt      time.Time
+}
+
+func main() {
+	cmd := PromoteCommand{
+		Service:         "service-a",
+		ReleaseID:       "rel_002",
+		PreviousRelease: "rel_001",
+		Actor:           "operator@example.com",
+		ExpectedVersion: 7,
+		ObservedAt:      time.Date(2026, 4, 24, 19, 0, 0, 0, time.UTC),
+	}
+
+	provenance, confidence := deployAuthorityMetadata(cmd)
+	if err := releasestate.ValidateDeployAuthorityMetadata(map[string]any{
+		"provenance": provenance,
+		"confidence": confidence,
+	}); err != nil {
+		panic(err)
+	}
+
+	actual := actualKey(cmd.Service)
+	event := releaseEvent(cmd, provenance)
+	outbox := aliasOutbox(cmd)
+
+	fmt.Printf("actual=%s/%s event=%s outbox=%s\n", actual.PK, actual.SK, event.SK, outbox.SK)
+}
+
+// promoteRelease shows the transactional TableTheory write. The actual-state
+// update and event append commit together; Lambda alias or CodePipeline side
+// effects must be driven separately from outbox/reconciliation.
+func promoteRelease(ctx context.Context, db releasestate.TransactionWriter, cmd PromoteCommand) error {
+	provenance, confidence := deployAuthorityMetadata(cmd)
+	if err := releasestate.ValidateDeployAuthorityMetadata(map[string]any{
+		"provenance": provenance,
+		"confidence": confidence,
+	}); err != nil {
+		return err
+	}
+
+	expected := cmd.ExpectedVersion
+	return releasestate.TransitionAppendEvent(ctx, db, releasestate.TransitionAppendEventInput{
+		Actual:          actualKey(cmd.Service),
+		Event:           releaseEvent(cmd, provenance),
+		ExpectedVersion: &expected,
+		Set: map[string]any{
+			"status":            "active",
+			"previousReleaseId": cmd.PreviousRelease,
+			"provenance":        provenance,
+			"confidence":        confidence,
+		},
+	})
+}
+
+func actualKey(service string) ReleaseStateActual {
+	return ReleaseStateActual{PK: "RELEASE#" + service, SK: "ACTUAL", Service: service}
+}
+
+func releaseEvent(cmd PromoteCommand, provenance map[string]any) ReleaseStateEvent {
+	return ReleaseStateEvent{
+		PK:        "RELEASE#" + cmd.Service,
+		SK:        "EVENT#" + cmd.ObservedAt.Format(time.RFC3339) + "#" + cmd.ReleaseID,
+		Service:   cmd.Service,
+		ReleaseID: cmd.ReleaseID,
+		EventType: "promoted",
+		At:        cmd.ObservedAt.Format(time.RFC3339),
+		Actor:     cmd.Actor,
+		Evidence:  provenance,
+	}
+}
+
+func aliasOutbox(cmd PromoteCommand) ReleaseStateOutbox {
+	return ReleaseStateOutbox{
+		PK:             "RELEASE#" + cmd.Service,
+		SK:             "OUTBOX#lambda-alias#" + cmd.ReleaseID,
+		Operation:      "lambda_alias_update",
+		IdempotencyKey: cmd.Service + ":" + cmd.ReleaseID,
+		RequestedState: "active",
+		NextAttemptAt:  cmd.ObservedAt.Format(time.RFC3339),
+	}
+}
+
+func deployAuthorityMetadata(cmd PromoteCommand) (map[string]any, map[string]any) {
+	ref := "operator://deploy/" + cmd.Service + "/" + cmd.ReleaseID
+	observedAt := cmd.ObservedAt.Format(time.RFC3339)
+	recordedAt := cmd.ObservedAt.Add(time.Second).Format(time.RFC3339)
+
+	provenance := map[string]any{
+		"mode":        "native",
+		"system":      "release-control-plane",
+		"kind":        "operator_command",
+		"ref":         ref,
+		"observed_at": observedAt,
+		"recorded_at": recordedAt,
+		"evidence": []any{
+			map[string]any{
+				"kind":        "operator_command",
+				"source":      "release-control-plane",
+				"ref":         ref,
+				"observed_at": observedAt,
+			},
+		},
+	}
+	confidence := map[string]any{
+		"level":   "high",
+		"reasons": []any{"operator_command_authority"},
+	}
+	return provenance, confidence
+}

--- a/py/docs/README.md
+++ b/py/docs/README.md
@@ -11,6 +11,8 @@
 ### 📚 Core Documentation
 - [API Reference](./api-reference.md) – Public API (`ModelDefinition`, `Table`, query, batch, transactions, encryption, streams)
 - [Core Patterns](./core-patterns.md) – Canonical recipes (CRUD, pagination, batch, transactions, streams, encryption)
+- [Release-State Patterns](./release-state.md) – Write policies, protected registry pins, transactional transitions,
+  and deterministic provenance/confidence helpers
 - [Testing Guide](./testing-guide.md) – Unit tests with strict fakes, integration tests with DynamoDB Local
 - [Troubleshooting](./troubleshooting.md) – Verified fixes for common runtime and configuration errors
 - [Migration Guide](./migration-guide.md) – Migrating from raw boto3 DynamoDB usage

--- a/py/docs/release-state.md
+++ b/py/docs/release-state.md
@@ -1,8 +1,8 @@
 # Release-State Patterns for Python
 
 Use release-state helpers when a Python service needs an authoritative registry row plus immutable event history.
-The shared contract is described in the root [release-state safety patterns](../../docs/release-state-patterns.md)
-guide; this page names the Python API surface.
+The shared contract is described in the root `docs/release-state-patterns.md` guide; this page names the Python API
+surface.
 
 ## APIs
 

--- a/py/docs/release-state.md
+++ b/py/docs/release-state.md
@@ -1,0 +1,41 @@
+# Release-State Patterns for Python
+
+Use release-state helpers when a Python service needs an authoritative registry row plus immutable event history.
+The shared contract is described in the root [release-state safety patterns](../../docs/release-state-patterns.md)
+guide; this page names the Python API surface.
+
+## APIs
+
+```python
+from theorydb_py import (
+    ModelDefinition,
+    Table,
+    WritePolicy,
+    transition_release_state,
+    validate_deploy_authority_metadata,
+)
+```
+
+- Declare model-level mutation rules through `WritePolicy` when building a `ModelDefinition`.
+- Use `transition_release_state(...)` to update the actual-state row and append an event row in one DynamoDB
+  transaction.
+- Use `validate_deploy_authority_metadata(...)` before persisting deploy-authoritative `provenance`/`confidence`
+  metadata.
+
+## Guardrails
+
+✅ Correct:
+
+- `WritePolicy(mode="write_once")` for event-history models.
+- `WritePolicy(mode="mutable", protected_attributes=[...])` for registry pin fields.
+- A single `transition_release_state(...)` call when actual/event rows share the same DynamoDB client/table context.
+- Explicit outbox/retry/reconciliation for Lambda alias, CodePipeline, or other external side effects.
+
+❌ Incorrect:
+
+- Mutating event history through generic update/save APIs.
+- Using separate DynamoDB calls for the actual transition and event append.
+- Treating external side effects as DynamoDB-atomic.
+- Persisting low-confidence or conflicting evidence as deploy authority.
+
+See `py/examples/release_state.py` for a cross-runtime-aligned example.

--- a/py/examples/release_state.py
+++ b/py/examples/release_state.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from theorydb_py import (
+    ModelDefinition,
+    Table,
+    WritePolicy,
+    theorydb_field,
+    transition_release_state,
+    validate_deploy_authority_metadata,
+)
+from theorydb_py.mocks import FakeDynamoDBClient
+
+
+@dataclass(frozen=True)
+class ReleaseStateActual:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    service: str = theorydb_field(default="")
+    status: str = theorydb_field(default="")
+    pinned_release_id: str = theorydb_field(name="pinnedReleaseId", default="")
+    previous_release_id: str = theorydb_field(name="previousReleaseId", default="")
+    provenance: dict[str, Any] | None = theorydb_field(json=True, default=None)
+    confidence: dict[str, Any] | None = theorydb_field(json=True, default=None)
+    version: int = theorydb_field(roles=["version"], default=0)
+
+
+@dataclass(frozen=True)
+class ReleaseStateEvent:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    service: str = theorydb_field(default="")
+    release_id: str = theorydb_field(name="releaseId", default="")
+    event_type: str = theorydb_field(name="eventType", default="")
+    at: str = theorydb_field(default="")
+    actor: str = theorydb_field(default="")
+    evidence: dict[str, Any] | None = theorydb_field(json=True, default=None)
+
+
+@dataclass(frozen=True)
+class ReleaseStateOutbox:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    operation: str = theorydb_field(default="")
+    idempotency_key: str = theorydb_field(name="idempotencyKey", default="")
+    requested_state: str = theorydb_field(name="requestedState", default="")
+    next_attempt_at: str = theorydb_field(name="nextAttemptAt", default="")
+
+
+def main() -> None:
+    table_name = "release_state_contract"
+    client = FakeDynamoDBClient()
+
+    actual_table = Table(
+        ModelDefinition.from_dataclass(
+            ReleaseStateActual,
+            table_name=table_name,
+            write_policy=WritePolicy(mode="mutable", protected_attributes=["pinnedReleaseId"]),
+        ),
+        client=client,
+    )
+    event_table = Table(
+        ModelDefinition.from_dataclass(
+            ReleaseStateEvent,
+            table_name=table_name,
+            write_policy=WritePolicy(mode="write_once"),
+        ),
+        client=client,
+    )
+    _outbox_model = ModelDefinition.from_dataclass(
+        ReleaseStateOutbox,
+        table_name=table_name,
+        write_policy=WritePolicy(mode="write_once"),
+    )
+
+    observed_at = "2026-04-24T19:00:00Z"
+    recorded_at = "2026-04-24T19:00:01Z"
+    service = "service-a"
+    release_id = "rel_002"
+    ref = f"operator://deploy/{service}/{release_id}"
+
+    provenance: dict[str, Any] = {
+        "mode": "native",
+        "system": "release-control-plane",
+        "kind": "operator_command",
+        "ref": ref,
+        "observed_at": observed_at,
+        "recorded_at": recorded_at,
+        "evidence": [
+            {
+                "kind": "operator_command",
+                "source": "release-control-plane",
+                "ref": ref,
+                "observed_at": observed_at,
+            }
+        ],
+    }
+    confidence: dict[str, Any] = {"level": "high", "reasons": ["operator_command_authority"]}
+    validate_deploy_authority_metadata({"provenance": provenance, "confidence": confidence})
+
+    def validate_transaction(req: dict[str, Any]) -> None:
+        items = req["TransactItems"]
+        assert len(items) == 2
+        assert items[0]["Update"]["TableName"] == table_name
+        assert items[1]["Put"]["TableName"] == table_name
+
+    client.expect("transact_write_items", validate_transaction, response={})
+    transition_release_state(
+        actual_table,
+        event_table,
+        actual_key={"PK": f"RELEASE#{service}", "SK": "ACTUAL"},
+        expected_version=7,
+        set_values={
+            "status": "active",
+            "previousReleaseId": "rel_001",
+            "provenance": provenance,
+            "confidence": confidence,
+        },
+        event_item=ReleaseStateEvent(
+            pk=f"RELEASE#{service}",
+            sk=f"EVENT#{observed_at}#{release_id}",
+            service=service,
+            release_id=release_id,
+            event_type="promoted",
+            at=observed_at,
+            actor="operator@example.com",
+            evidence=provenance,
+        ),
+    )
+    client.assert_no_pending()
+
+    outbox = ReleaseStateOutbox(
+        pk=f"RELEASE#{service}",
+        sk=f"OUTBOX#lambda-alias#{release_id}",
+        operation="lambda_alias_update",
+        idempotency_key=f"{service}:{release_id}",
+        requested_state="active",
+        next_attempt_at=observed_at,
+    )
+    print(f"transaction_items=2 outbox={outbox.sk}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ts/docs/README.md
+++ b/ts/docs/README.md
@@ -14,6 +14,8 @@
 
 - [API Reference](./api-reference.md) – Public exports (`defineModel`, `TheorydbClient`, queries, transactions, encryption)
 - [Core Patterns](./core-patterns.md) – Canonical recipes (CRUD, query/cursor, batch, transactions, streams, encryption)
+- [Release-State Patterns](./release-state.md) – Write policies, protected registry pins, transactional transitions,
+  and deterministic provenance/confidence helpers
 - [Testing Guide](./testing-guide.md) – Unit tests with `testkit`, integration tests with DynamoDB Local
 - [Troubleshooting](./troubleshooting.md) – Verified fixes for common runtime and configuration errors
 - [Migration Guide](./migration-guide.md) – Migrating from raw AWS SDK v3 usage

--- a/ts/docs/release-state.md
+++ b/ts/docs/release-state.md
@@ -1,8 +1,8 @@
 # Release-State Patterns for TypeScript
 
 Use release-state helpers when a Node.js service needs an authoritative registry row plus immutable event history.
-The shared contract is described in the root [release-state safety patterns](../../docs/release-state-patterns.md)
-guide; this page names the TypeScript API surface.
+The shared contract is described in the root `docs/release-state-patterns.md` guide; this page names the TypeScript
+API surface.
 
 ## APIs
 

--- a/ts/docs/release-state.md
+++ b/ts/docs/release-state.md
@@ -1,0 +1,40 @@
+# Release-State Patterns for TypeScript
+
+Use release-state helpers when a Node.js service needs an authoritative registry row plus immutable event history.
+The shared contract is described in the root [release-state safety patterns](../../docs/release-state-patterns.md)
+guide; this page names the TypeScript API surface.
+
+## APIs
+
+```ts
+import {
+  TheorydbClient,
+  defineModel,
+  transitionReleaseState,
+  validateDeployAuthorityMetadata,
+} from '@theory-cloud/tabletheory-ts';
+```
+
+- Declare model-level mutation rules through `write_policy` in `defineModel(...)`.
+- Use `transitionReleaseState(...)` to update the actual-state row and append an event row in one DynamoDB
+  transaction.
+- Use `validateDeployAuthorityMetadata(...)` before persisting deploy-authoritative `provenance`/`confidence`
+  metadata.
+
+## Guardrails
+
+✅ Correct:
+
+- `write_policy.mode: "write_once"` for event-history models.
+- `write_policy.protected_attributes` for registry pin fields.
+- A single `transitionReleaseState(...)` call for actual-state update + event append.
+- Explicit outbox/retry/reconciliation for Lambda alias, CodePipeline, or other external side effects.
+
+❌ Incorrect:
+
+- Mutating event history through generic update/save APIs.
+- Loosening model-level protected attributes in a helper call.
+- Treating Lambda alias or CodePipeline changes as if they were part of the DynamoDB transaction.
+- Persisting low-confidence or conflicting evidence as deploy authority.
+
+See `ts/examples/release-state.ts` for a cross-runtime-aligned example.

--- a/ts/examples/release-state.ts
+++ b/ts/examples/release-state.ts
@@ -1,0 +1,162 @@
+import {
+  TransactWriteItemsCommand,
+  type DynamoDBClient,
+} from '@aws-sdk/client-dynamodb';
+
+import {
+  TheorydbClient,
+  defineModel,
+  transitionReleaseState,
+  validateDeployAuthorityMetadata,
+} from '../src/index.js';
+
+const tableName = 'release_state_contract';
+
+const ReleaseStateActual = defineModel({
+  name: 'ReleaseStateActual',
+  table: { name: tableName },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort: { attribute: 'SK', type: 'S' },
+  },
+  write_policy: {
+    mode: 'mutable',
+    protected_attributes: ['pinnedReleaseId'],
+  },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'SK', type: 'S', roles: ['sk'] },
+    { attribute: 'service', type: 'S', optional: true },
+    { attribute: 'status', type: 'S', optional: true },
+    { attribute: 'pinnedReleaseId', type: 'S', optional: true },
+    { attribute: 'previousReleaseId', type: 'S', optional: true },
+    { attribute: 'provenance', type: 'M', optional: true, json: true },
+    { attribute: 'confidence', type: 'M', optional: true, json: true },
+    { attribute: 'version', type: 'N', roles: ['version'] },
+  ],
+});
+
+const ReleaseStateEvent = defineModel({
+  name: 'ReleaseStateEvent',
+  table: { name: tableName },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort: { attribute: 'SK', type: 'S' },
+  },
+  write_policy: { mode: 'write_once' },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'SK', type: 'S', roles: ['sk'] },
+    { attribute: 'service', type: 'S', optional: true },
+    { attribute: 'releaseId', type: 'S', optional: true },
+    { attribute: 'eventType', type: 'S', optional: true },
+    { attribute: 'at', type: 'S', optional: true },
+    { attribute: 'actor', type: 'S', optional: true },
+    { attribute: 'evidence', type: 'M', optional: true, json: true },
+  ],
+});
+
+const ReleaseStateOutbox = defineModel({
+  name: 'ReleaseStateOutbox',
+  table: { name: tableName },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort: { attribute: 'SK', type: 'S' },
+  },
+  write_policy: { mode: 'write_once' },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'SK', type: 'S', roles: ['sk'] },
+    { attribute: 'operation', type: 'S', optional: true },
+    { attribute: 'idempotencyKey', type: 'S', optional: true },
+    { attribute: 'requestedState', type: 'S', optional: true },
+    { attribute: 'nextAttemptAt', type: 'S', optional: true },
+  ],
+});
+
+class RecordingDdb {
+  sent: unknown[] = [];
+
+  async send(cmd: unknown): Promise<Record<string, never>> {
+    this.sent.push(cmd);
+    return {};
+  }
+}
+
+const observedAt = '2026-04-24T19:00:00Z';
+const recordedAt = '2026-04-24T19:00:01Z';
+const service = 'service-a';
+const releaseId = 'rel_002';
+const ref = `operator://deploy/${service}/${releaseId}`;
+
+const provenance = {
+  mode: 'native',
+  system: 'release-control-plane',
+  kind: 'operator_command',
+  ref,
+  observed_at: observedAt,
+  recorded_at: recordedAt,
+  evidence: [
+    {
+      kind: 'operator_command',
+      source: 'release-control-plane',
+      ref,
+      observed_at: observedAt,
+    },
+  ],
+};
+
+const confidence = {
+  level: 'high',
+  reasons: ['operator_command_authority'],
+};
+
+validateDeployAuthorityMetadata({ provenance, confidence });
+
+const ddb = new RecordingDdb();
+const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+  ReleaseStateActual,
+  ReleaseStateEvent,
+  ReleaseStateOutbox,
+);
+
+await transitionReleaseState(client, {
+  actualModel: 'ReleaseStateActual',
+  actualKey: { PK: `RELEASE#${service}`, SK: 'ACTUAL' },
+  expectedVersion: 7,
+  set: {
+    status: 'active',
+    previousReleaseId: 'rel_001',
+    provenance,
+    confidence,
+  },
+  eventModel: 'ReleaseStateEvent',
+  eventItem: {
+    PK: `RELEASE#${service}`,
+    SK: `EVENT#${observedAt}#${releaseId}`,
+    service,
+    releaseId,
+    eventType: 'promoted',
+    at: observedAt,
+    actor: 'operator@example.com',
+    evidence: provenance,
+  },
+});
+
+const outbox = {
+  PK: `RELEASE#${service}`,
+  SK: `OUTBOX#lambda-alias#${releaseId}`,
+  operation: 'lambda_alias_update',
+  idempotencyKey: `${service}:${releaseId}`,
+  requestedState: 'active',
+  nextAttemptAt: observedAt,
+};
+
+const command = ddb.sent[0];
+if (!(command instanceof TransactWriteItemsCommand)) {
+  throw new Error('expected release-state helper to emit TransactWriteItems');
+}
+
+console.log(
+  `transactionItems=${command.input.TransactItems?.length ?? 0} outbox=${outbox.SK}`,
+);


### PR DESCRIPTION
## Milestone
tt-release-state-docs-release — add release-state docs/examples and complete verification/RC rollout preparation.

## Linear
https://linear.app/pay-theory/project/tabletheory-release-state-write-policies-0ebbc8f7b4c1 / milestone `tt-release-state-docs-release`

## GitHub issue
Closes the remaining documentation/example slice of #159.

## Affected runtimes
Docs/examples for Go, TypeScript, and Python. No runtime implementation changes.

## Contract impact
Docs/examples only. No DMS, P0 scenario, or public API behavior changes.

## Backward compatibility
Additive documentation/examples. Existing consumers and persisted data are unchanged.

## Tasks
- [x] IO-79 Document release-state audit outbox and reconciliation patterns
- [x] IO-80 Add cross-runtime release-state examples

## What changed
- Added `docs/release-state-patterns.md` covering actual-state vs event-history rows, model-level write policies, protected registry fields, DynamoDB-only transaction boundaries, external side-effect outbox/retry/reconciliation, deterministic provenance/confidence, Streams audit/archive, and RC verification.
- Added TypeScript and Python package docs for release-state helper APIs.
- Added AI-facing concept/pattern/decision entries for release-state modeling.
- Added cross-runtime examples:
  - Go: `examples/release-state/`
  - TypeScript: `ts/examples/release-state.ts`
  - Python: `py/examples/release_state.py`

## Validation
- `bash scripts/verify-branch-release-supply-chain.sh` → PASS
- `bash scripts/verify-branch-version-sync.sh` → SKIP on non-release branch
- `python` YAML parse for docs knowledge files → PASS
- `go test ./examples/release-state` → PASS
- `cd ts && npm run format:check && npm run lint && npm run typecheck && npm run test:unit` → PASS
- `cd py && python -m ruff format --check src tests examples/release_state.py && python -m ruff check src tests examples/release_state.py && python -m pytest -q --import-mode=importlib` → PASS
- `cd contract-tests/runners/go && go test ./... -v` → PASS
- `npm --prefix contract-tests/runners/ts test` → PASS
- `uv --directory py run pytest -q ../contract-tests/runners/py --import-mode=importlib` → PASS
- `cd ts && npm exec -- tsx examples/release-state.ts` → PASS
- `PYTHONPATH=py/src python py/examples/release_state.py` → PASS
- `make test-unit` → PASS
- `make rubric` → PASS

## Cross-repo coordination
No blocking cross-repo code change. Release-control-plane should use these docs/examples while validating the TableTheory RC assets for issue #159.