### PR TITLE
feat(runtime): add lambda timeout buffer parity

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -73,6 +73,41 @@ func LambdaInit(models ...any) (*LambdaDB, error)
   }
   ```
 
+### `LambdaTimeoutConfig`
+
+Configures the buffer TableTheory leaves before the Lambda invocation deadline when `LambdaDB.WithLambdaTimeout`
+derives an invocation-scoped DB.
+
+```go
+type LambdaTimeoutConfig struct {
+    Buffer time.Duration
+}
+```
+
+- **Default**: `WithLambdaTimeout` uses a 1 second buffer when no positive custom buffer is configured.
+- **Custom buffer**: call `WithLambdaTimeoutConfig` once at cold start, then call `WithLambdaTimeout(ctx)` per invocation.
+- **Non-positive buffers**: preserve the default behavior.
+
+```go
+var db *tabletheory.LambdaDB
+
+func init() {
+    base, err := tabletheory.LambdaInit(&User{}, &Order{})
+    if err != nil {
+        panic(err)
+    }
+
+    db = base.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{
+        Buffer: 500 * time.Millisecond,
+    })
+}
+
+func handler(ctx context.Context) error {
+    invocationDB := db.WithLambdaTimeout(ctx)
+    return invocationDB.Model(&User{}).Create()
+}
+```
+
 ---
 
 ## Configuration
@@ -134,6 +169,23 @@ Registers models during initialization to avoid runtime reflection costs.
 #### `WithLambdaTimeout(ctx context.Context) *LambdaDB`
 
 Returns a DB instance that respects Lambda execution time, cancelling requests before a hard timeout occurs.
+By default, TableTheory leaves 1 second before the Lambda deadline for cleanup and response handling. Configure a
+different buffer with `WithLambdaTimeoutConfig` during cold start:
+
+```go
+db = db.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{
+    Buffer: 750 * time.Millisecond,
+})
+```
+
+Use `WithLambdaTimeoutConfig` on `LambdaDB` rather than the lower-level `core.DB.WithLambdaTimeoutBuffer`; this keeps the
+Lambda-specific model cache and cold-start metadata attached to the derived `LambdaDB`.
+
+#### `WithLambdaTimeoutConfig(config LambdaTimeoutConfig) *LambdaDB`
+
+Returns a `LambdaDB` configured with the invocation timeout buffer that subsequent `WithLambdaTimeout(ctx)` calls apply.
+The method is additive and preserves registered model caches, session state, converters, marshaling metadata, and Lambda
+memory/X-Ray configuration.
 
 #### `GetMemoryStats() LambdaMemoryStats`
 

--- a/docs/architecture-patterns.md
+++ b/docs/architecture-patterns.md
@@ -47,7 +47,7 @@ TableTheory is designed with AWS Lambda in mind to leverage its cold start optim
 
 ### AWS Lambda
 -   **Initialization:** Always use `tabletheory.NewLambdaOptimized()` or `tabletheory.LambdaInit()` in the global scope (`init()` function) to ensure connection reuse and minimal cold start latency.
--   **Context Handling:** Use `db.WithLambdaTimeout(ctx)` to wrap your TableTheory instance with Lambda's execution context, enabling automatic cancellation of operations before a timeout occurs.
+-   **Context Handling:** Use `db.WithLambdaTimeout(ctx)` to wrap your TableTheory instance with Lambda's execution context, enabling automatic cancellation of operations before a timeout occurs. Configure custom cleanup windows with `db.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{Buffer: ...})` during cold start; the default buffer is 1 second.
 -   **Memory Sizing:** Tune Lambda memory based on `LambdaDB.GetMemoryStats()` to balance performance and cost.
 
 ### API Gateway

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -29,6 +29,30 @@ func handler(ctx context.Context) error {
 }
 ```
 
+When a function needs a shorter cleanup window than the default 1 second buffer, configure that buffer at cold start and
+derive an invocation-scoped DB from the Lambda context inside the handler:
+
+```go
+// ✅ CORRECT: configure once, derive per invocation
+var db *tabletheory.LambdaDB
+
+func init() {
+    base, err := tabletheory.LambdaInit(&User{})
+    if err != nil {
+        panic(err)
+    }
+
+    db = base.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{
+        Buffer: 500 * time.Millisecond,
+    })
+}
+
+func handler(ctx context.Context) error {
+    invocationDB := db.WithLambdaTimeout(ctx)
+    return invocationDB.Model(&User{}).Create()
+}
+```
+
 ```go
 // ❌ INCORRECT: Handler initialization
 func handler(ctx context.Context) error {
@@ -270,6 +294,7 @@ func handler(ctx context.Context) error {
 
 - **Recommendation:** Always use `tabletheory.NewLambdaOptimized()` or `tabletheory.LambdaInit()` in your `init()` function or global scope.
 - **Details:** TableTheory's `LambdaDB` manages an optimized `http.Client` with appropriate `MaxIdleConns` and `IdleConnTimeout` settings for Lambda's execution model.
+- **Timeout buffer:** Use `LambdaDB.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{Buffer: ...})` during cold start to customize the buffer left before the Lambda hard deadline. Continue to call `db.WithLambdaTimeout(ctx)` per invocation.
 
 **Example:**
 

--- a/docs/development/planning/theorydb-multilang-feature-parity-matrix.md
+++ b/docs/development/planning/theorydb-multilang-feature-parity-matrix.md
@@ -99,6 +99,7 @@ Legend:
 | Aggregates | Sum/Avg/Min/Max + GroupBy helpers | Yes | Yes | Yes | No | In-memory helpers; TS: `ts/src/aggregates.ts`; Py: `py/src/theorydb_py/aggregates.py` |
 | Optimization | Query optimizer/plan cache | Yes | Yes | Yes | No | Advisory-only hints; TS: `ts/src/optimizer.ts`; Py: `py/src/theorydb_py/optimizer.py` |
 | Runtime | Lambda-optimized DB wrapper + cold-start helpers | Yes | Yes | Yes | No | TS: `ts/src/lambda.ts`; Py: `py/src/theorydb_py/runtime.py` |
+| Runtime | Lambda timeout buffer helpers | Yes | Yes | Yes | No | Go: `LambdaDB.WithLambdaTimeoutConfig`; TS: `withLambdaTimeout(..., { bufferMs })`; Py: `Table.with_lambda_timeout(..., buffer_seconds=...)`. Per-runtime unit coverage; no P0 data-contract scenario. |
 | Runtime | Multi-account assume-role wrapper | Yes | Yes | Yes | No | TS: `ts/src/multiaccount.ts`; Py: `py/src/theorydb_py/multiaccount.py` |
 | Security | Field/operator/expression validation & injection hardening | Yes | Yes | Yes | No | TS: `ts/src/validation.ts`; Py: `py/src/theorydb_py/validation.py` |
 | Security | Resource protection (rate limiting, concurrency, memory monitor) | Yes | Yes | Yes | No | TS: `ts/src/protection.ts`; Py: `py/src/theorydb_py/protection.py` |

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -106,6 +106,42 @@ func main() {
 - **Lambda Optimization**: Built-in features for cold-start reduction and connection reuse in serverless environments.
 - **Fluent API**: Chainable methods make queries and transactions more readable and maintainable.
 
+## From split LambdaDB/core.DB timeout workarounds
+
+Some Lambda consumers, including lesser, previously needed to keep both a raw `*tabletheory.LambdaDB` and a lower-level
+`core.DB`/`ExtendedDB` reference so they could combine Lambda model-cache behavior with a custom timeout buffer.
+
+After upgrading to a TableTheory release that includes `LambdaTimeoutConfig`, keep a single `*tabletheory.LambdaDB`:
+
+```go
+var db *tabletheory.LambdaDB
+
+func init() {
+    base, err := tabletheory.LambdaInit(&User{}, &Session{})
+    if err != nil {
+        panic(err)
+    }
+
+    db = base.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{
+        Buffer: 500 * time.Millisecond,
+    })
+}
+
+func handler(ctx context.Context) error {
+    invocationDB := db.WithLambdaTimeout(ctx)
+    var user User
+    return invocationDB.Model(&User{}).Where("PK", "=", "USER#1").First(&user)
+}
+```
+
+Migration checklist:
+
+1. Replace the split raw-`LambdaDB`/`core.DB` holder with one `*tabletheory.LambdaDB`.
+2. Move the custom buffer into cold-start initialization with `WithLambdaTimeoutConfig`.
+3. Keep `WithLambdaTimeout(ctx)` in the handler so every invocation gets its own deadline-derived DB.
+4. Validate against the release candidate before stable promotion; this is an additive migration and should not require a
+   data migration.
+
 ## From Legacy DynamORM
 
 **Problem:** Legacy DynamORM models often used a mixed naming contract: the primary keys were always stored as uppercase `PK` and `SK`, while every other attribute used camelCase. TableTheory historically treated `theorydb:"pk"` and `theorydb:"sk"` as roles only, so a model like `UserID string 'theorydb:"pk"'` would default to the attribute name `userID` instead of `PK`.

--- a/internal/theorydb/lambda.go
+++ b/internal/theorydb/lambda.go
@@ -218,13 +218,13 @@ func (ldb *LambdaDB) WithLambdaTimeout(ctx context.Context) *LambdaDB {
 	ldb.db.mu.RLock()
 	defer ldb.db.mu.RUnlock()
 
-	// Leave the configured buffer for Lambda cleanup. Preserve the existing
-	// LambdaDB default when callers have not configured a custom buffer.
+	// Leave the configured buffer for Lambda cleanup. Store the hard Lambda
+	// deadline and the effective buffer separately so query execution applies
+	// the stop window exactly once.
 	buffer := ldb.db.lambdaTimeoutBuffer
 	if buffer <= 0 {
 		buffer = defaultLambdaDBTimeoutBuffer
 	}
-	adjustedDeadline := deadline.Add(-buffer)
 
 	newDB := &DB{
 		session:             ldb.db.session,
@@ -232,8 +232,8 @@ func (ldb *LambdaDB) WithLambdaTimeout(ctx context.Context) *LambdaDB {
 		converter:           ldb.db.converter,
 		marshaler:           ldb.db.marshaler,
 		ctx:                 ctx,
-		lambdaDeadline:      adjustedDeadline,
-		lambdaTimeoutBuffer: ldb.db.lambdaTimeoutBuffer,
+		lambdaDeadline:      deadline,
+		lambdaTimeoutBuffer: buffer,
 	}
 
 	ldb.db.metadataCache.Range(func(key, value any) bool {

--- a/internal/theorydb/lambda.go
+++ b/internal/theorydb/lambda.go
@@ -74,6 +74,17 @@ type LambdaDB struct {
 	xrayEnabled    bool
 }
 
+const defaultLambdaDBTimeoutBuffer = time.Second
+
+// LambdaTimeoutConfig configures Lambda invocation timeout handling for LambdaDB.
+//
+// A positive Buffer leaves that much time before the Lambda deadline for caller
+// cleanup and error reporting. A zero or negative Buffer preserves the LambdaDB
+// default timeout buffer.
+type LambdaTimeoutConfig struct {
+	Buffer time.Duration
+}
+
 // NewLambdaOptimized creates a Lambda-optimized DB instance
 func NewLambdaOptimized() (*LambdaDB, error) {
 	// Use global instance if available (warm start)
@@ -200,23 +211,77 @@ func (ldb *LambdaDB) WithLambdaTimeout(ctx context.Context) *LambdaDB {
 	if !ok {
 		return ldb
 	}
-
-	// Leave 1 second buffer for Lambda cleanup
-	adjustedDeadline := deadline.Add(-1 * time.Second)
-
-	newDB := &DB{
-		session:        ldb.db.session,
-		registry:       ldb.db.registry,
-		converter:      ldb.db.converter,
-		marshaler:      ldb.db.marshaler,
-		ctx:            ctx,
-		lambdaDeadline: adjustedDeadline,
+	if ldb == nil || ldb.db == nil {
+		return ldb
 	}
 
+	ldb.db.mu.RLock()
+	defer ldb.db.mu.RUnlock()
+
+	// Leave the configured buffer for Lambda cleanup. Preserve the existing
+	// LambdaDB default when callers have not configured a custom buffer.
+	buffer := ldb.db.lambdaTimeoutBuffer
+	if buffer <= 0 {
+		buffer = defaultLambdaDBTimeoutBuffer
+	}
+	adjustedDeadline := deadline.Add(-buffer)
+
+	newDB := &DB{
+		session:             ldb.db.session,
+		registry:            ldb.db.registry,
+		converter:           ldb.db.converter,
+		marshaler:           ldb.db.marshaler,
+		ctx:                 ctx,
+		lambdaDeadline:      adjustedDeadline,
+		lambdaTimeoutBuffer: ldb.db.lambdaTimeoutBuffer,
+	}
+
+	ldb.db.metadataCache.Range(func(key, value any) bool {
+		newDB.metadataCache.Store(key, value)
+		return true
+	})
+
+	return ldb.withDB(newDB)
+}
+
+// WithLambdaTimeoutConfig returns a LambdaDB configured with Lambda invocation
+// timeout settings while preserving Lambda-specific caches and metadata.
+func (ldb *LambdaDB) WithLambdaTimeoutConfig(config LambdaTimeoutConfig) *LambdaDB {
+	if ldb == nil || ldb.db == nil {
+		return ldb
+	}
+
+	buffer := config.Buffer
+	if buffer < 0 {
+		buffer = 0
+	}
+
+	ldb.db.mu.RLock()
+	defer ldb.db.mu.RUnlock()
+
+	newDB := &DB{
+		session:             ldb.db.session,
+		registry:            ldb.db.registry,
+		converter:           ldb.db.converter,
+		marshaler:           ldb.db.marshaler,
+		ctx:                 ldb.db.ctx,
+		lambdaDeadline:      ldb.db.lambdaDeadline,
+		lambdaTimeoutBuffer: buffer,
+	}
+
+	ldb.db.metadataCache.Range(func(key, value any) bool {
+		newDB.metadataCache.Store(key, value)
+		return true
+	})
+
+	return ldb.withDB(newDB)
+}
+
+func (ldb *LambdaDB) withDB(db *DB) *LambdaDB {
 	return &LambdaDB{
-		ExtendedDB:     newDB,
-		db:             newDB,
-		modelCache:     ldb.modelCache, // Share the same model cache pointer
+		ExtendedDB:     db,
+		db:             db,
+		modelCache:     ldb.modelCache, // Share the same model cache pointer.
 		isLambda:       ldb.isLambda,
 		lambdaMemoryMB: ldb.lambdaMemoryMB,
 		xrayEnabled:    ldb.xrayEnabled,

--- a/internal/theorydb/lambda_cov6_test.go
+++ b/internal/theorydb/lambda_cov6_test.go
@@ -143,7 +143,7 @@ func TestLambdaDB_WithLambdaTimeout_NoDeadlineReturnsSame_COV6(t *testing.T) {
 	require.Same(t, ldb, ldb.WithLambdaTimeout(context.Background()))
 }
 
-func TestLambdaDB_WithLambdaTimeout_SetsAdjustedDeadline_COV6(t *testing.T) {
+func TestLambdaDB_WithLambdaTimeout_SetsHardDeadlineAndEffectiveBuffer_COV6(t *testing.T) {
 	httpClient := newCapturingHTTPClient(nil)
 
 	stubSessionConfigLoad(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
@@ -169,8 +169,8 @@ func TestLambdaDB_WithLambdaTimeout_SetsAdjustedDeadline_COV6(t *testing.T) {
 	require.Same(t, ldb.modelCache, newDB.modelCache)
 	require.NotNil(t, newDB.db)
 	require.Equal(t, ctx, newDB.db.ctx)
-	require.WithinDuration(t, deadline.Add(-1*time.Second), newDB.db.lambdaDeadline, 25*time.Millisecond)
-	require.Zero(t, newDB.db.lambdaTimeoutBuffer)
+	require.WithinDuration(t, deadline, newDB.db.lambdaDeadline, 25*time.Millisecond)
+	require.Equal(t, defaultLambdaDBTimeoutBuffer, newDB.db.lambdaTimeoutBuffer)
 }
 
 func TestLambdaDB_WithLambdaTimeoutConfig_PreservesConfiguredBuffer_COV6(t *testing.T) {
@@ -221,12 +221,35 @@ func TestLambdaDB_WithLambdaTimeoutConfig_PreservesConfiguredBuffer_COV6(t *test
 	require.NotNil(t, timed)
 	require.Equal(t, ctx, timed.db.ctx)
 	require.Equal(t, 500*time.Millisecond, timed.db.lambdaTimeoutBuffer)
-	require.WithinDuration(t, deadline.Add(-500*time.Millisecond), timed.db.lambdaDeadline, 25*time.Millisecond)
+	require.WithinDuration(t, deadline, timed.db.lambdaDeadline, 25*time.Millisecond)
 	require.Same(t, configured.modelCache, timed.modelCache)
 	require.True(t, timed.IsModelRegistered(cov4LambdaModel{}))
 	cached, ok = timed.db.metadataCache.Load("cached")
 	require.True(t, ok)
 	require.Equal(t, "value", cached)
+}
+
+func TestLambdaDB_WithLambdaTimeoutConfig_AppliesConfiguredBufferOnce_COV6(t *testing.T) {
+	db := &DB{}
+	ldb := &LambdaDB{ExtendedDB: db, db: db, modelCache: &sync.Map{}}
+	configured := ldb.WithLambdaTimeoutConfig(LambdaTimeoutConfig{Buffer: 500 * time.Millisecond})
+
+	deadline := time.Now().Add(900 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	t.Cleanup(cancel)
+
+	timed := configured.WithLambdaTimeout(ctx)
+	require.NotNil(t, timed)
+	require.Equal(t, 500*time.Millisecond, timed.db.lambdaTimeoutBuffer)
+	require.NoError(t, (&queryExecutor{db: timed.db}).checkLambdaTimeout())
+
+	soonDeadline := time.Now().Add(450 * time.Millisecond)
+	soonCtx, soonCancel := context.WithDeadline(context.Background(), soonDeadline)
+	t.Cleanup(soonCancel)
+
+	soonTimed := configured.WithLambdaTimeout(soonCtx)
+	require.NotNil(t, soonTimed)
+	require.Error(t, (&queryExecutor{db: soonTimed.db}).checkLambdaTimeout())
 }
 
 func TestLambdaDB_WithLambdaTimeoutConfig_NonPositiveBufferUsesDefault_COV6(t *testing.T) {
@@ -243,8 +266,8 @@ func TestLambdaDB_WithLambdaTimeoutConfig_NonPositiveBufferUsesDefault_COV6(t *t
 
 	timed := configured.WithLambdaTimeout(ctx)
 	require.NotNil(t, timed)
-	require.Zero(t, timed.db.lambdaTimeoutBuffer)
-	require.WithinDuration(t, deadline.Add(-defaultLambdaDBTimeoutBuffer), timed.db.lambdaDeadline, 25*time.Millisecond)
+	require.Equal(t, defaultLambdaDBTimeoutBuffer, timed.db.lambdaTimeoutBuffer)
+	require.WithinDuration(t, deadline, timed.db.lambdaDeadline, 25*time.Millisecond)
 }
 
 func TestGetLambdaMemoryMB_HandlesEmptyAndInvalidValues_COV6(t *testing.T) {

--- a/internal/theorydb/lambda_cov6_test.go
+++ b/internal/theorydb/lambda_cov6_test.go
@@ -170,6 +170,81 @@ func TestLambdaDB_WithLambdaTimeout_SetsAdjustedDeadline_COV6(t *testing.T) {
 	require.NotNil(t, newDB.db)
 	require.Equal(t, ctx, newDB.db.ctx)
 	require.WithinDuration(t, deadline.Add(-1*time.Second), newDB.db.lambdaDeadline, 25*time.Millisecond)
+	require.Zero(t, newDB.db.lambdaTimeoutBuffer)
+}
+
+func TestLambdaDB_WithLambdaTimeoutConfig_PreservesConfiguredBuffer_COV6(t *testing.T) {
+	httpClient := newCapturingHTTPClient(nil)
+
+	stubSessionConfigLoad(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return minimalAWSConfig(httpClient), nil
+	})
+
+	dbAny, err := New(session.Config{Region: "us-east-1"})
+	require.NoError(t, err)
+	db := mustDB(t, dbAny)
+	db.metadataCache.Store("cached", "value")
+
+	ldb := &LambdaDB{
+		ExtendedDB:     db,
+		db:             db,
+		modelCache:     &sync.Map{},
+		lambdaMemoryMB: 1024,
+		isLambda:       true,
+		xrayEnabled:    true,
+	}
+	require.NoError(t, ldb.PreRegisterModels(&cov4LambdaModel{}))
+
+	configured := ldb.WithLambdaTimeoutConfig(LambdaTimeoutConfig{Buffer: 500 * time.Millisecond})
+	require.NotNil(t, configured)
+	require.NotSame(t, ldb, configured)
+	require.NotSame(t, db, configured.db)
+	require.Equal(t, 500*time.Millisecond, configured.db.lambdaTimeoutBuffer)
+	require.Same(t, ldb.modelCache, configured.modelCache)
+	require.True(t, configured.IsModelRegistered(cov4LambdaModel{}))
+	require.Same(t, db.session, configured.db.session)
+	require.Same(t, db.registry, configured.db.registry)
+	require.Same(t, db.converter, configured.db.converter)
+	require.Same(t, db.marshaler, configured.db.marshaler)
+	require.Equal(t, ldb.lambdaMemoryMB, configured.lambdaMemoryMB)
+	require.Equal(t, ldb.isLambda, configured.isLambda)
+	require.Equal(t, ldb.xrayEnabled, configured.xrayEnabled)
+	cached, ok := configured.db.metadataCache.Load("cached")
+	require.True(t, ok)
+	require.Equal(t, "value", cached)
+
+	deadline := time.Now().Add(5 * time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	t.Cleanup(cancel)
+
+	timed := configured.WithLambdaTimeout(ctx)
+	require.NotNil(t, timed)
+	require.Equal(t, ctx, timed.db.ctx)
+	require.Equal(t, 500*time.Millisecond, timed.db.lambdaTimeoutBuffer)
+	require.WithinDuration(t, deadline.Add(-500*time.Millisecond), timed.db.lambdaDeadline, 25*time.Millisecond)
+	require.Same(t, configured.modelCache, timed.modelCache)
+	require.True(t, timed.IsModelRegistered(cov4LambdaModel{}))
+	cached, ok = timed.db.metadataCache.Load("cached")
+	require.True(t, ok)
+	require.Equal(t, "value", cached)
+}
+
+func TestLambdaDB_WithLambdaTimeoutConfig_NonPositiveBufferUsesDefault_COV6(t *testing.T) {
+	db := &DB{}
+	ldb := &LambdaDB{ExtendedDB: db, db: db, modelCache: &sync.Map{}}
+
+	configured := ldb.WithLambdaTimeoutConfig(LambdaTimeoutConfig{Buffer: -1})
+	require.NotNil(t, configured)
+	require.Zero(t, configured.db.lambdaTimeoutBuffer)
+
+	deadline := time.Now().Add(5 * time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	t.Cleanup(cancel)
+
+	timed := configured.WithLambdaTimeout(ctx)
+	require.NotNil(t, timed)
+	require.Zero(t, timed.db.lambdaTimeoutBuffer)
+	require.WithinDuration(t, deadline.Add(-defaultLambdaDBTimeoutBuffer), timed.db.lambdaDeadline, 25*time.Millisecond)
 }
 
 func TestGetLambdaMemoryMB_HandlesEmptyAndInvalidValues_COV6(t *testing.T) {

--- a/internal/theorydb/theorydb.go
+++ b/internal/theorydb/theorydb.go
@@ -448,12 +448,13 @@ func (db *DB) WithLambdaTimeout(ctx context.Context) core.DB {
 		return db
 	}
 
-	// Leave a buffer for Lambda cleanup
+	// Leave a buffer for Lambda cleanup. Store the hard Lambda deadline and
+	// the effective buffer separately so query execution applies the stop
+	// window exactly once.
 	buffer := db.lambdaTimeoutBuffer
 	if buffer == 0 {
 		buffer = 500 * time.Millisecond // Default buffer
 	}
-	adjustedDeadline := deadline.Add(-buffer)
 
 	db.mu.RLock()
 	defer db.mu.RUnlock()
@@ -464,8 +465,8 @@ func (db *DB) WithLambdaTimeout(ctx context.Context) core.DB {
 		converter:           db.converter,
 		marshaler:           db.marshaler,
 		ctx:                 ctx,
-		lambdaDeadline:      adjustedDeadline,
-		lambdaTimeoutBuffer: db.lambdaTimeoutBuffer,
+		lambdaDeadline:      deadline,
+		lambdaTimeoutBuffer: buffer,
 	}
 
 	// Copy metadata cache

--- a/internal/theorydb/theorydb_cov5_helpers_test.go
+++ b/internal/theorydb/theorydb_cov5_helpers_test.go
@@ -1,6 +1,7 @@
 package theorydb
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -90,6 +91,28 @@ func TestQueryExecutor_checkLambdaTimeout_CoversDeadlineBranches_COV5(t *testing
 
 	executor = &queryExecutor{db: &DB{lambdaDeadline: time.Now().Add(500 * time.Millisecond), lambdaTimeoutBuffer: 10 * time.Millisecond}}
 	require.NoError(t, executor.checkLambdaTimeout())
+}
+
+func TestDB_WithLambdaTimeoutBuffer_AppliesConfiguredBufferOnce_COV5(t *testing.T) {
+	buffered, ok := (&DB{}).WithLambdaTimeoutBuffer(500 * time.Millisecond).(*DB)
+	require.True(t, ok)
+
+	deadline := time.Now().Add(900 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	t.Cleanup(cancel)
+
+	timed, ok := buffered.WithLambdaTimeout(ctx).(*DB)
+	require.True(t, ok)
+	require.Equal(t, 500*time.Millisecond, timed.lambdaTimeoutBuffer)
+	require.NoError(t, (&queryExecutor{db: timed}).checkLambdaTimeout())
+
+	soonDeadline := time.Now().Add(450 * time.Millisecond)
+	soonCtx, soonCancel := context.WithDeadline(context.Background(), soonDeadline)
+	t.Cleanup(soonCancel)
+
+	soonTimed, ok := buffered.WithLambdaTimeout(soonCtx).(*DB)
+	require.True(t, ok)
+	require.Error(t, (&queryExecutor{db: soonTimed}).checkLambdaTimeout())
 }
 
 func TestErrorBatchGetBuilder_FluentMethodsReturnSelf_COV5(t *testing.T) {

--- a/internal/theorydb/theorydb_cov6_additional_branches_test.go
+++ b/internal/theorydb/theorydb_cov6_additional_branches_test.go
@@ -75,7 +75,8 @@ func TestDB_ContextHelpers_CopyMetadataCache_And_DefaultLambdaBuffer_COV6(t *tes
 	lambdaAny := db.WithLambdaTimeout(deadlineCtx)
 	lambdaDB, ok := lambdaAny.(*DB)
 	require.True(t, ok)
-	require.Equal(t, deadline.Add(-500*time.Millisecond), lambdaDB.lambdaDeadline)
+	require.Equal(t, deadline, lambdaDB.lambdaDeadline)
+	require.Equal(t, 500*time.Millisecond, lambdaDB.lambdaTimeoutBuffer)
 	_, ok = lambdaDB.metadataCache.Load(typ)
 	require.True(t, ok)
 }

--- a/py/docs/api-reference.md
+++ b/py/docs/api-reference.md
@@ -9,6 +9,12 @@
 from theorydb_py import ModelDefinition, Table, theorydb_field
 from theorydb_py import SortKeyCondition
 from theorydb_py import unmarshal_stream_record
+from theorydb_py import (
+    DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS,
+    LambdaTimeoutConfig,
+    check_lambda_timeout,
+    with_lambda_timeout,
+)
 from theorydb_py.mocks import FakeDynamoDBClient, FakeKmsClient
 ```
 
@@ -37,6 +43,49 @@ Common operations:
 - `batch_get(keys, *, consistent_read=False)`
 - `batch_write(puts=None, deletes=None)`
 - `transact_write(operations)`
+- `with_lambda_timeout(context, *, buffer_seconds=DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS)`
+
+## Lambda runtime helpers
+
+### `DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS`
+
+The default buffer, `1.0`, left before the Lambda hard timeout.
+
+### `LambdaTimeoutConfig`
+
+Frozen dataclass shape used by the runtime wrapper:
+
+```python
+LambdaTimeoutConfig(buffer_seconds=1.0)
+```
+
+### `check_lambda_timeout(context, *, buffer_seconds=1.0)`
+
+Checks the AWS Lambda context before work starts. If the remaining invocation time is less than or equal to the buffer,
+the helper raises the built-in `TimeoutError`.
+
+### `with_lambda_timeout(client, context, *, buffer_seconds=1.0)`
+
+Returns a derived client wrapper that checks `check_lambda_timeout` before each non-private callable client method. If no
+Lambda deadline is available, the original client is returned unchanged.
+
+Python cannot cancel an in-flight boto3 call once it has started; this helper is a pre-call guard that prevents starting
+new DynamoDB work when the invocation is already inside the cleanup buffer.
+
+### `Table.with_lambda_timeout(context, *, buffer_seconds=1.0)`
+
+Returns an invocation-scoped `Table` that preserves the model, table name, encryption configuration, KMS client, and
+random-byte source while wrapping the DynamoDB client with the Lambda timeout guard.
+
+```python
+base_table = Table(model, client=client)
+
+
+def handler(event: dict, context: object) -> dict:
+    table = base_table.with_lambda_timeout(context, buffer_seconds=0.5)
+    item = table.get("USER#1", "PROFILE")
+    return {"item": item}
+```
 
 ## Pagination
 
@@ -50,4 +99,3 @@ Query returns a page object with `items` and `next_cursor` (opaque token). Pass 
 
 Encrypted fields are stored as an envelope map. If a model contains encrypted fields, `Table(...)` fails closed unless
 `kms_key_arn` is configured.
-

--- a/py/src/theorydb_py/__init__.py
+++ b/py/src/theorydb_py/__init__.py
@@ -63,13 +63,17 @@ if TYPE_CHECKING:
     from .protection import ConcurrencyLimiter, SimpleLimiter
     from .release_state import transition_release_state, validate_deploy_authority_metadata
     from .runtime import (
+        DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS,
         AwsCallMetric,
+        LambdaTimeoutConfig,
+        check_lambda_timeout,
         create_lambda_boto3_config,
         get_lambda_boto3_client,
         get_lambda_dynamodb_client,
         get_lambda_kms_client,
         instrument_boto3_client,
         is_lambda_environment,
+        with_lambda_timeout,
     )
     from .schema import (
         build_create_table_request,
@@ -169,12 +173,16 @@ def __getattr__(name: str) -> Any:
         return unmarshal_stream_record
     if name in {
         "AwsCallMetric",
+        "DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS",
+        "LambdaTimeoutConfig",
+        "check_lambda_timeout",
         "create_lambda_boto3_config",
         "get_lambda_boto3_client",
         "get_lambda_dynamodb_client",
         "get_lambda_kms_client",
         "instrument_boto3_client",
         "is_lambda_environment",
+        "with_lambda_timeout",
     }:
         from . import runtime
 
@@ -221,6 +229,8 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "AwsError",
     "AwsCallMetric",
+    "DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS",
+    "LambdaTimeoutConfig",
     "assert_model_definition_equivalent_to_dms",
     "AggregateResult",
     "aggregate_field",
@@ -233,6 +243,7 @@ __all__ = [
     "LeaseHeldError",
     "LeaseNotOwnedError",
     "count_distinct",
+    "check_lambda_timeout",
     "create_lambda_boto3_config",
     "create_table",
     "delete_table",
@@ -269,6 +280,7 @@ __all__ = [
     "MaxValueStringLength",
     "instrument_boto3_client",
     "is_lambda_environment",
+    "with_lambda_timeout",
     "AccountConfig",
     "MultiAccountSessions",
     "Page",

--- a/py/src/theorydb_py/runtime.py
+++ b/py/src/theorydb_py/runtime.py
@@ -18,6 +18,14 @@ class AwsCallMetric:
     ok: bool
 
 
+DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS = 1.0
+
+
+@dataclass(frozen=True)
+class LambdaTimeoutConfig:
+    buffer_seconds: float = DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS
+
+
 def is_lambda_environment(environ: Mapping[str, str] = os.environ) -> bool:
     return bool(
         environ.get("AWS_LAMBDA_FUNCTION_NAME") or "AWS_Lambda" in (environ.get("AWS_EXECUTION_ENV") or "")
@@ -83,6 +91,67 @@ def instrument_boto3_client(
     on_call: Callable[[AwsCallMetric], None],
 ) -> Any:
     return _InstrumentedClient(client, service, on_call)
+
+
+def _remaining_time_millis(context: Any) -> int | None:
+    if context is None:
+        return None
+
+    getter = getattr(context, "get_remaining_time_in_millis", None)
+    if getter is None:
+        getter = getattr(context, "getRemainingTimeInMillis", None)
+    if getter is None or not callable(getter):
+        return None
+
+    remaining = getter()
+    if remaining is None:
+        return None
+    return int(remaining)
+
+
+def check_lambda_timeout(
+    context: Any, *, buffer_seconds: float = DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS
+) -> None:
+    remaining_ms = _remaining_time_millis(context)
+    if remaining_ms is None:
+        return
+
+    buffer_ms = max(0, int(buffer_seconds * 1000))
+    if remaining_ms <= buffer_ms:
+        raise TimeoutError(f"lambda timeout imminent: only {remaining_ms}ms remaining")
+
+
+class _LambdaTimeoutClient:
+    def __init__(self, client: Any, context: Any, config: LambdaTimeoutConfig) -> None:
+        self._client = client
+        self._context = context
+        self._config = config
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._client, name)
+        if name.startswith("_") or not callable(attr):
+            return attr
+
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            check_lambda_timeout(self._context, buffer_seconds=self._config.buffer_seconds)
+            return attr(*args, **kwargs)
+
+        return wrapped
+
+
+def with_lambda_timeout(
+    client: Any,
+    context: Any,
+    *,
+    buffer_seconds: float = DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS,
+) -> Any:
+    if context is None or _remaining_time_millis(context) is None:
+        return client
+    return _LambdaTimeoutClient(
+        client,
+        context,
+        LambdaTimeoutConfig(buffer_seconds=max(0.0, buffer_seconds)),
+    )
 
 
 _lambda_clients: dict[tuple[str, str | None], Any] = {}

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -30,6 +30,8 @@ from .query import (
     decode_cursor,
     encode_cursor,
 )
+from .runtime import DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS
+from .runtime import with_lambda_timeout as with_lambda_timeout_client
 from .transaction import (
     TransactConditionCheck,
     TransactDelete,
@@ -126,6 +128,24 @@ class Table[T]:
                     "model has encrypted fields but kms_key_arn is not configured"
                 )
             self._kms_client = self._kms_client or boto3.client("kms")
+
+    def with_lambda_timeout(
+        self,
+        context: Any,
+        *,
+        buffer_seconds: float = DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS,
+    ) -> Table[T]:
+        client = with_lambda_timeout_client(self._client, context, buffer_seconds=buffer_seconds)
+        if client is self._client:
+            return self
+        return Table(
+            self._model,
+            client=client,
+            table_name=self._table_name,
+            kms_key_arn=self._kms_key_arn,
+            kms_client=self._kms_client,
+            rand_bytes=self._rand_bytes,
+        )
 
     def _attribute_storage_type(self, attr_def: AttributeDefinition) -> str:
         if attr_def.storage_type is not None:

--- a/py/tests/unit/test_init_exports.py
+++ b/py/tests/unit/test_init_exports.py
@@ -10,6 +10,10 @@ def test_init_exposes_lazy_exports_via_getattr() -> None:
     assert callable(theorydb.aggregate_field)
     assert callable(theorydb.QueryOptimizer)
     assert callable(theorydb.is_lambda_environment)
+    assert theorydb.DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS == 1.0
+    assert callable(theorydb.LambdaTimeoutConfig)
+    assert callable(theorydb.check_lambda_timeout)
+    assert callable(theorydb.with_lambda_timeout)
     assert callable(theorydb.MultiAccountSessions)
     assert callable(theorydb.SimpleLimiter)
     assert callable(theorydb.validate_expression)

--- a/py/tests/unit/test_runtime.py
+++ b/py/tests/unit/test_runtime.py
@@ -1,17 +1,47 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 import pytest
 
 from theorydb_py.mocks import FakeDynamoDBClient
+from theorydb_py.model import ModelDefinition, theorydb_field
 from theorydb_py.runtime import (
+    DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS,
+    LambdaTimeoutConfig,
     _reset_lambda_clients_for_tests,
+    check_lambda_timeout,
     create_lambda_boto3_config,
     get_lambda_boto3_client,
     instrument_boto3_client,
     is_lambda_environment,
+    with_lambda_timeout,
 )
+from theorydb_py.table import Table
+
+
+@dataclass(frozen=True)
+class RuntimeItem:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    value: int = theorydb_field(name="value")
+
+
+class _LambdaContext:
+    def __init__(self, remaining_ms: int | None) -> None:
+        self.remaining_ms = remaining_ms
+
+    def get_remaining_time_in_millis(self) -> int | None:
+        return self.remaining_ms
+
+
+class _CamelLambdaContext:
+    def __init__(self, remaining_ms: int) -> None:
+        self.remaining_ms = remaining_ms
+
+    def getRemainingTimeInMillis(self) -> int:
+        return self.remaining_ms
 
 
 def test_is_lambda_environment() -> None:
@@ -25,6 +55,53 @@ def test_create_lambda_boto3_config() -> None:
     assert cfg.connect_timeout == 2.0
     assert cfg.read_timeout == 4.0
     assert cfg.retries["max_attempts"] == 3
+
+
+def test_check_lambda_timeout_ignores_contexts_without_deadlines() -> None:
+    check_lambda_timeout(None)
+    check_lambda_timeout(object())
+    check_lambda_timeout(_LambdaContext(None))
+
+
+def test_check_lambda_timeout_respects_default_and_custom_buffers() -> None:
+    assert LambdaTimeoutConfig().buffer_seconds == DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS
+
+    check_lambda_timeout(_LambdaContext(1_001))
+    check_lambda_timeout(_CamelLambdaContext(600), buffer_seconds=0.5)
+
+    with pytest.raises(TimeoutError, match="lambda timeout imminent: only 1000ms remaining"):
+        check_lambda_timeout(_LambdaContext(1_000))
+
+    with pytest.raises(TimeoutError, match="lambda timeout imminent: only 500ms remaining"):
+        check_lambda_timeout(_CamelLambdaContext(500), buffer_seconds=0.5)
+
+
+def test_with_lambda_timeout_wraps_client_when_deadline_is_available() -> None:
+    client = FakeDynamoDBClient()
+    assert with_lambda_timeout(client, None) is client
+    assert with_lambda_timeout(client, object()) is client
+
+    context = _LambdaContext(750)
+    wrapped = with_lambda_timeout(client, context, buffer_seconds=0.5)
+    assert wrapped is not client
+
+    client.expect("get_item", response={})
+    wrapped.get_item(TableName="tbl", Key={})
+    client.assert_no_pending()
+
+    context.remaining_ms = 500
+    with pytest.raises(TimeoutError, match="lambda timeout imminent"):
+        wrapped.get_item(TableName="tbl", Key={})
+    assert len(client.calls) == 1
+
+
+def test_with_lambda_timeout_clamps_negative_buffer_seconds() -> None:
+    client = FakeDynamoDBClient()
+    wrapped = with_lambda_timeout(client, _LambdaContext(0), buffer_seconds=-5)
+
+    with pytest.raises(TimeoutError, match="lambda timeout imminent: only 0ms remaining"):
+        wrapped.get_item(TableName="tbl", Key={})
+    assert client.calls == []
 
 
 def test_instrument_boto3_client_records_calls() -> None:
@@ -61,3 +138,32 @@ def test_get_lambda_boto3_client_caches() -> None:
     c2 = get_lambda_boto3_client("dynamodb", region="us-east-1", session=sess)
     assert c1 is c2
     assert sess.calls == 1
+
+
+def test_table_with_lambda_timeout_preserves_table_state_and_guards_calls() -> None:
+    model = ModelDefinition.from_dataclass(RuntimeItem, table_name="runtime_items")
+    client = FakeDynamoDBClient()
+    table: Table[RuntimeItem] = Table(model, client=client)
+
+    assert table.with_lambda_timeout(None) is table
+
+    context = _LambdaContext(1_500)
+    wrapped = table.with_lambda_timeout(context, buffer_seconds=0.5)
+    assert wrapped is not table
+    assert wrapped._model is table._model
+    assert wrapped._table_name == table._table_name
+    assert wrapped._kms_key_arn == table._kms_key_arn
+    assert wrapped._kms_client is table._kms_client
+    assert wrapped._rand_bytes is table._rand_bytes
+
+    client.expect(
+        "get_item",
+        response={"Item": {"PK": {"S": "A"}, "SK": {"S": "1"}, "value": {"N": "7"}}},
+    )
+    assert wrapped.get("A", "1") == RuntimeItem(pk="A", sk="1", value=7)
+    client.assert_no_pending()
+
+    context.remaining_ms = 500
+    with pytest.raises(TimeoutError, match="lambda timeout imminent"):
+        wrapped.get("A", "1")
+    assert len(client.calls) == 1

--- a/tabletheory.go
+++ b/tabletheory.go
@@ -20,10 +20,11 @@ import (
 )
 
 type (
-	DB                = internaltheorydb.DB
-	LambdaDB          = internaltheorydb.LambdaDB
-	LambdaMemoryStats = internaltheorydb.LambdaMemoryStats
-	ColdStartMetrics  = internaltheorydb.ColdStartMetrics
+	DB                  = internaltheorydb.DB
+	LambdaDB            = internaltheorydb.LambdaDB
+	LambdaTimeoutConfig = internaltheorydb.LambdaTimeoutConfig
+	LambdaMemoryStats   = internaltheorydb.LambdaMemoryStats
+	ColdStartMetrics    = internaltheorydb.ColdStartMetrics
 
 	MultiAccountDB = internaltheorydb.MultiAccountDB
 	AccountConfig  = internaltheorydb.AccountConfig

--- a/ts/docs/api-reference.md
+++ b/ts/docs/api-reference.md
@@ -7,7 +7,15 @@
 ## Imports
 
 ```ts
-import { defineModel, TheorydbClient } from '@theory-cloud/tabletheory-ts';
+import {
+  DEFAULT_LAMBDA_TIMEOUT_BUFFER_MS,
+  type LambdaContextLike,
+  TheorydbClient,
+  createLambdaDynamoDBClient,
+  createLambdaTimeoutSignal,
+  defineModel,
+  withLambdaTimeout,
+} from '@theory-cloud/tabletheory-ts';
 import { createMockDynamoDBClient } from '@theory-cloud/tabletheory-ts/testkit';
 ```
 
@@ -52,6 +60,46 @@ Common write options (conceptual):
 
 - `ifNotExists` / `ifExists`
 - `conditionExpression`, `expressionAttributeNames`, `expressionAttributeValues`
+
+## Lambda runtime helpers
+
+### `createLambdaDynamoDBClient(options?)`
+
+Creates an AWS SDK v3 `DynamoDBClient` configured for Lambda-friendly connection reuse and timeout defaults.
+
+### `DEFAULT_LAMBDA_TIMEOUT_BUFFER_MS`
+
+The default buffer, `1000`, left before the Lambda hard timeout when deriving an invocation-scoped client.
+
+### `createLambdaTimeoutSignal(ctx, options?)`
+
+Creates an `AbortSignal` that aborts before the Lambda deadline.
+
+```ts
+const { signal, cleanup } = createLambdaTimeoutSignal(ctx, {
+  bufferMs: 500,
+});
+```
+
+### `withLambdaTimeout(client, ctx, options?)`
+
+Returns `{ client, cleanup }`, where the derived `TheorydbClient` preserves the registered models and send options while
+adding an invocation-scoped `abortSignal`. Always call `cleanup()` before the handler returns.
+
+```ts
+const baseDb = new TheorydbClient(createLambdaDynamoDBClient()).register(User);
+
+export async function handler(event: unknown, ctx: LambdaContextLike) {
+  const { client: db, cleanup } = withLambdaTimeout(baseDb, ctx, {
+    bufferMs: 500,
+  });
+  try {
+    return await db.get('User', { PK: 'USER#1', SK: 'PROFILE' });
+  } finally {
+    cleanup();
+  }
+}
+```
 
 ## Query
 

--- a/ts/src/lambda.ts
+++ b/ts/src/lambda.ts
@@ -44,6 +44,14 @@ export function createLambdaTimeoutSignal(
   const remainingMs = Math.max(0, ctx.getRemainingTimeInMillis() - bufferMs);
 
   const controller = new AbortController();
+  if (remainingMs <= 0) {
+    controller.abort();
+    return {
+      signal: controller.signal,
+      cleanup: () => undefined,
+    };
+  }
+
   const timer = setTimeout(() => controller.abort(), remainingMs);
   timer.unref?.();
 

--- a/ts/src/lambda.ts
+++ b/ts/src/lambda.ts
@@ -21,6 +21,12 @@ export type LambdaMetric = {
   ok: boolean;
 };
 
+export type LambdaTimeoutOptions = {
+  bufferMs?: number;
+};
+
+export const DEFAULT_LAMBDA_TIMEOUT_BUFFER_MS = 1_000;
+
 export function isLambdaEnvironment(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -32,9 +38,9 @@ export function isLambdaEnvironment(
 
 export function createLambdaTimeoutSignal(
   ctx: LambdaContextLike,
-  opts: { bufferMs?: number } = {},
+  opts: LambdaTimeoutOptions = {},
 ): { signal: AbortSignal; cleanup: () => void } {
-  const bufferMs = opts.bufferMs ?? 1_000;
+  const bufferMs = opts.bufferMs ?? DEFAULT_LAMBDA_TIMEOUT_BUFFER_MS;
   const remainingMs = Math.max(0, ctx.getRemainingTimeInMillis() - bufferMs);
 
   const controller = new AbortController();
@@ -50,7 +56,7 @@ export function createLambdaTimeoutSignal(
 export function withLambdaTimeout(
   client: TheorydbClient,
   ctx: LambdaContextLike,
-  opts: { bufferMs?: number } = {},
+  opts: LambdaTimeoutOptions = {},
 ): { client: TheorydbClient; cleanup: () => void } {
   const { signal, cleanup } = createLambdaTimeoutSignal(ctx, opts);
   return { client: client.withSendOptions({ abortSignal: signal }), cleanup };

--- a/ts/test/unit/lambda.test.ts
+++ b/ts/test/unit/lambda.test.ts
@@ -29,7 +29,6 @@ test('createLambdaTimeoutSignal aborts and supports cleanup', async () => {
       { getRemainingTimeInMillis: () => 0 },
       { bufferMs: 0 },
     );
-    await new Promise((r) => setTimeout(r, 0));
     assert.equal(signal.aborted, true);
   }
 
@@ -49,7 +48,6 @@ test('createLambdaTimeoutSignal applies default and custom buffers', async () =>
     const { signal } = createLambdaTimeoutSignal({
       getRemainingTimeInMillis: () => DEFAULT_LAMBDA_TIMEOUT_BUFFER_MS,
     });
-    await new Promise((r) => setTimeout(r, 0));
     assert.equal(signal.aborted, true);
   }
 
@@ -102,5 +100,6 @@ test('withLambdaTimeout returns a derived TheorydbClient', async () => {
   await client.create('T', { PK: 'A' });
   assert.equal(sendOptions.length, 1);
   assert.equal(sendOptions[0]?.abortSignal instanceof AbortSignal, true);
+  assert.equal(sendOptions[0]?.abortSignal?.aborted, true);
   cleanup();
 });

--- a/ts/test/unit/lambda.test.ts
+++ b/ts/test/unit/lambda.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  DEFAULT_LAMBDA_TIMEOUT_BUFFER_MS,
   createLambdaTimeoutSignal,
   createLambdaDynamoDBClient,
   getLambdaDynamoDBClient,
@@ -10,8 +11,8 @@ import {
 } from '../../src/lambda.js';
 import { TheorydbClient } from '../../src/client.js';
 import { defineModel } from '../../src/model.js';
-import { createMockDynamoDBClient } from '../../src/testkit/index.js';
-import { PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import type { SendOptions } from '../../src/send-options.js';
 
 test('isLambdaEnvironment detects lambda env vars', () => {
   assert.equal(isLambdaEnvironment({}), false);
@@ -43,6 +44,26 @@ test('createLambdaTimeoutSignal aborts and supports cleanup', async () => {
   }
 });
 
+test('createLambdaTimeoutSignal applies default and custom buffers', async () => {
+  {
+    const { signal } = createLambdaTimeoutSignal({
+      getRemainingTimeInMillis: () => DEFAULT_LAMBDA_TIMEOUT_BUFFER_MS,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    assert.equal(signal.aborted, true);
+  }
+
+  {
+    const { signal, cleanup } = createLambdaTimeoutSignal(
+      { getRemainingTimeInMillis: () => 20 },
+      { bufferMs: 5 },
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    assert.equal(signal.aborted, false);
+    cleanup();
+  }
+});
+
 test('createLambdaDynamoDBClient and getLambdaDynamoDBClient build clients', () => {
   createLambdaDynamoDBClient({ region: 'us-east-1' });
   createLambdaDynamoDBClient({ region: 'us-east-1', metrics: () => {} });
@@ -53,8 +74,17 @@ test('createLambdaDynamoDBClient and getLambdaDynamoDBClient build clients', () 
 });
 
 test('withLambdaTimeout returns a derived TheorydbClient', async () => {
-  const mock = createMockDynamoDBClient();
-  mock.when(PutItemCommand, async () => ({ $metadata: {} }));
+  const sendOptions: (SendOptions | undefined)[] = [];
+  const ddb = {
+    send: async (
+      command: PutItemCommand,
+      options?: SendOptions,
+    ): Promise<unknown> => {
+      assert.equal(command instanceof PutItemCommand, true);
+      sendOptions.push(options);
+      return { $metadata: {} };
+    },
+  } as unknown as DynamoDBClient;
 
   const model = defineModel({
     name: 'T',
@@ -63,12 +93,14 @@ test('withLambdaTimeout returns a derived TheorydbClient', async () => {
     attributes: [{ attribute: 'PK', type: 'S', roles: ['pk'] }],
   });
 
-  const base = new TheorydbClient(mock.client).register(model);
+  const base = new TheorydbClient(ddb).register(model);
   const { client, cleanup } = withLambdaTimeout(
     base,
     { getRemainingTimeInMillis: () => 0 },
     { bufferMs: 0 },
   );
   await client.create('T', { PK: 'A' });
+  assert.equal(sendOptions.length, 1);
+  assert.equal(sendOptions[0]?.abortSignal instanceof AbortSignal, true);
   cleanup();
 });


### PR DESCRIPTION
## Milestone
lambda-timeout-buffer-parity — complete additive Lambda timeout buffer support across Go, TypeScript, Python, plus docs and release-readiness evidence.

## Linear
Project: https://linear.app/theorycloud/project/tabletheory-lambda-timeout-buffer-parity-9205ce91d15c

Issues:
- THE-450 — Add Go LambdaDB timeout configuration
- THE-451 — Cover TypeScript Lambda timeout buffer options
- THE-452 — Add Python Lambda timeout helper
- THE-453 — Document Lambda timeout parity and lesser migration
- THE-454 — Validate Lambda timeout parity release candidate (pre-PR validation green; RC artifact + lesser confirmation remain post-merge/premain)

## Affected runtimes
Go, TypeScript, Python, docs.

## What changed
- Go: adds `LambdaTimeoutConfig` and `LambdaDB.WithLambdaTimeoutConfig`, preserving `LambdaDB` model caches/session/converters/metadata while applying custom invocation timeout buffers through `WithLambdaTimeout(ctx)`.
- TypeScript: formalizes `LambdaTimeoutOptions` and `DEFAULT_LAMBDA_TIMEOUT_BUFFER_MS`, with unit coverage for default/custom buffers and derived-client preservation.
- Python: adds `DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS`, `LambdaTimeoutConfig`, `check_lambda_timeout`, `with_lambda_timeout`, and `Table.with_lambda_timeout` as a pre-call Lambda guard that preserves table/model/encryption/KMS/random-byte state.
- Docs: updates Go/TS/Py API docs, Go patterns/architecture docs, the multilang feature parity matrix, and migration guidance for removing lesser's split raw-`LambdaDB`/`core.DB` workaround.

## Contract impact
Additive runtime API only. No DMS change. No P0 data-contract scenario change. Coverage starts as per-runtime unit tests plus feature matrix documentation, as scoped.

## Backward compatibility
Additive. Existing defaults are preserved:
- Go `LambdaDB.WithLambdaTimeout(ctx)` still uses the 1s default when no positive custom buffer is configured.
- TS `bufferMs` remains optional and defaults to 1000ms.
- Python helpers return the original client/table when no Lambda deadline is available and only guard before new calls.

## Tasks
- [x] THE-450 Add Go LambdaDB timeout configuration
- [x] THE-451 Cover TypeScript Lambda timeout buffer options
- [x] THE-452 Add Python Lambda timeout helper
- [x] THE-453 Document Lambda timeout parity and lesser migration
- [ ] THE-454 Validate Lambda timeout parity release candidate — pre-PR branch validation is green; final RC artifact and lesser confirmation require the normal `staging` → `premain` prerelease flow after this PR lands.

## Validation
- `go test ./internal/theorydb -run 'TestLambdaDB_WithLambdaTimeout|TestDB_ContextAndTimeoutHelpers' -count=1 -v` — PASS
- `make test-unit` — PASS
- `cd ts && npm run typecheck && npm run lint && npm run test:unit && npm run build` — PASS
- `cd py && python -m pytest tests/unit/test_runtime.py tests/unit/test_init_exports.py` — PASS
- `cd py && python -m pytest tests/unit` — PASS
- `cd py && python -m ruff check src tests/unit/test_runtime.py tests/unit/test_init_exports.py` — PASS
- `git diff --check` — PASS
- `make rubric` — PASS (36 pass, 0 fail)
- `bash scripts/verify-branch-release-supply-chain.sh` — PASS
- `bash scripts/verify-branch-version-sync.sh` — SKIP on feature branch

Note: `cd py && python -m unittest` / `python -m unittest discover -s tests -p 'test_*.py'` currently discovers no tests and exits 5 in this repo; pytest is the effective Python unit gate.

## Cross-repo coordination
lesser should validate the `v1.8.0-rc.N` prerelease artifact after promotion to `premain` and confirm removal of its split raw-`LambdaDB`/`core.DB` timeout workaround before stable promotion.
