### PR TITLE
fix(docs): replace invented APIs with the real public surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * harden npm audit allowlist handling so audit service errors fail closed
 * update Python lockfile security baseline and remove stale pip-audit exception
 * prevent Python Lambda timeout guards from being retried by query and scan helpers
+* align Python lifecycle and optimistic-lock writes with the shared P0 contract fixtures
 
 ## [1.8.4](https://github.com/theory-cloud/TableTheory/compare/v1.8.3...v1.8.4) (2026-05-26)
 

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ make test          # full suite incl. integration
 For multi-language work:
 
 ```bash
-cd ts && npm run check        # TS lint + typecheck + tests
-cd py && python -m unittest   # Py unit tests
+cd ts && npm run lint && npm run typecheck && npm run test:unit
+uv --directory py run pytest -q
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full contributor docs, including the [Authoring documentation](CONTRIBUTING.md#authoring-documentation) section if you're updating the docs site.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Use TableTheory when you want DynamoDB-backed systems that are:
 - **Cross-language consistent** — one table, multiple services, multiple runtimes — without schema or behavior drift. Verified on every commit by the [P0 contract scenarios](https://theory-cloud.github.io/tabletheory/reference/contract-scenarios/).
 - **Generative-coding friendly** — explicit schema, canonical patterns, and strict verification so AI-generated code stays correct and maintainable.
 
-✅ Treat schema + semantics as a contract  
+✅ Treat schema + semantics as a contract
 ❌ Don't redefine "the same" table shape independently per service/language
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ TableTheory is distributed exclusively through immutable **[GitHub Releases](htt
 
 | | |
 |---|---|
-| **P0 contract scenarios** | 5 — CRUD, omit-empty, lifecycle timestamps, optimistic locking, TTL |
+| **P0 contract scenarios** | 9 — CRUD, omit-empty, lifecycle, locking, TTL, and release-state fixtures |
 | **Runtimes** | Go · TypeScript · Python (peers, not ports) |
 | **Distribution** | Immutable GitHub Releases — version-aligned across all runtimes |
 | **License** | Apache-2.0 — open source, production use |

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ The full documentation site lives at **[theory-cloud.github.io/tabletheory](http
 - **TypeScript** — [theory-cloud.github.io/tabletheory/runtimes/typescript/](https://theory-cloud.github.io/tabletheory/runtimes/typescript/)
 - **Python** — [theory-cloud.github.io/tabletheory/runtimes/python/](https://theory-cloud.github.io/tabletheory/runtimes/python/)
 
-**P0 contract surface — one page per scenario:**
+**P0 contract reference and related feature pages:**
 
+- [Contract Scenarios](https://theory-cloud.github.io/tabletheory/reference/contract-scenarios/) — the current 9-fixture P0 surface
 - [CRUD & Marshaling](https://theory-cloud.github.io/tabletheory/features/crud/)
 - [Optimistic Locking](https://theory-cloud.github.io/tabletheory/features/optimistic-locking/)
 - [Lifecycle Timestamps](https://theory-cloud.github.io/tabletheory/features/lifecycle-timestamps/)
@@ -170,7 +171,7 @@ For multi-language work:
 
 ```bash
 cd ts && npm run lint && npm run typecheck && npm run test:unit
-uv --directory py run pytest -q
+uv --directory py run pytest -q tests/unit
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full contributor docs, including the [Authoring documentation](CONTRIBUTING.md#authoring-documentation) section if you're updating the docs site.

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -1,0 +1,624 @@
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import asdict, dataclass, is_dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, cast
+
+import boto3
+import pytest
+import yaml
+from boto3.dynamodb.types import TypeSerializer
+from botocore.exceptions import ClientError, EndpointConnectionError
+
+from theorydb_py import (
+    ConditionFailedError,
+    ImmutableModelMutationError,
+    ModelDefinition,
+    NotFoundError,
+    Projection,
+    ProtectedFieldMutationError,
+    RejectedDeployAuthorityEvidenceError,
+    Table,
+    ValidationError,
+    WritePolicy,
+    gsi,
+    theorydb_field,
+    transition_release_state,
+    validate_deploy_authority_metadata,
+)
+
+
+def _repo_root() -> Path:
+    # contract-tests/runners/py/test_*.py -> repo root is 4 levels up
+    return Path(__file__).resolve().parents[3]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return cast(dict[str, Any], data)
+
+
+def _load_models() -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for path in sorted((_repo_root() / "contract-tests" / "dms" / "v0.1" / "models").glob("*.yml")):
+        doc = _load_yaml(path)
+        for model in doc.get("models", []):
+            out[model["name"]] = model
+    assert out
+    return out
+
+
+def _load_scenarios() -> list[dict[str, Any]]:
+    scenario_dir = _repo_root() / "contract-tests" / "scenarios" / "p0"
+    scenarios = [_load_yaml(path) for path in sorted(scenario_dir.glob("*.yml"))]
+    assert len(scenarios) == 9
+    return scenarios
+
+
+@dataclass(frozen=True)
+class _User:
+    PK: str = theorydb_field(name="PK", roles=["pk"])
+    SK: str = theorydb_field(name="SK", roles=["sk"])
+    emailHash: str | None = theorydb_field(omitempty=True, default=None)
+    nickname: str | None = theorydb_field(omitempty=True, default=None)
+    tags: set[str] | None = theorydb_field(set_=True, omitempty=True, default=None)
+    createdAt: str = theorydb_field(roles=["created_at"], default="")
+    updatedAt: str = theorydb_field(roles=["updated_at"], default="")
+    version: int | None = theorydb_field(roles=["version"], default=None)
+    ttl: int | None = theorydb_field(roles=["ttl"], omitempty=True, default=None)
+
+
+@dataclass(frozen=True)
+class _Order:
+    PK: str = theorydb_field(name="PK", roles=["pk"])
+    SK: str = theorydb_field(name="SK", roles=["sk"])
+    status: str | None = theorydb_field(omitempty=True, default=None)
+    amount: int | None = theorydb_field(omitempty=True, default=None)
+    createdAt: str = theorydb_field(roles=["created_at"], default="")
+    updatedAt: str = theorydb_field(roles=["updated_at"], default="")
+    version: int | None = theorydb_field(roles=["version"], default=None)
+    ttl: int | None = theorydb_field(roles=["ttl"], omitempty=True, default=None)
+
+
+@dataclass(frozen=True)
+class _ReleaseStateActual:
+    PK: str = theorydb_field(name="PK", roles=["pk"])
+    SK: str = theorydb_field(name="SK", roles=["sk"])
+    status: str | None = theorydb_field(omitempty=True, default=None)
+    pinnedReleaseId: str | None = theorydb_field(omitempty=True, default=None)
+    previousReleaseId: str | None = theorydb_field(omitempty=True, default=None)
+    provenance: dict[str, Any] | None = theorydb_field(json=True, omitempty=True, default=None)
+    confidence: dict[str, Any] | None = theorydb_field(json=True, omitempty=True, default=None)
+    updatedAt: str = theorydb_field(roles=["updated_at"], default="")
+    version: int | None = theorydb_field(roles=["version"], default=None)
+
+
+@dataclass(frozen=True)
+class _ReleaseStateEvent:
+    PK: str = theorydb_field(name="PK", roles=["pk"])
+    SK: str = theorydb_field(name="SK", roles=["sk"])
+    releaseId: str | None = theorydb_field(omitempty=True, default=None)
+    eventType: str | None = theorydb_field(omitempty=True, default=None)
+    provenance: dict[str, Any] | None = theorydb_field(json=True, omitempty=True, default=None)
+    confidence: dict[str, Any] | None = theorydb_field(json=True, omitempty=True, default=None)
+    recordedAt: str | None = theorydb_field(omitempty=True, default=None)
+    ttl: int | None = theorydb_field(roles=["ttl"], omitempty=True, default=None)
+
+
+class _TheorydbPyDriver:
+    def __init__(self, client: Any) -> None:
+        self.client = client
+        self.tables: dict[str, Table[Any]] = {
+            "User": Table(
+                ModelDefinition.from_dataclass(
+                    _User,
+                    table_name="users_contract",
+                    indexes=[gsi("gsi-email", partition="emailHash", projection=Projection.all())],
+                ),
+                client=client,
+            ),
+            "Order": Table(
+                ModelDefinition.from_dataclass(
+                    _Order,
+                    table_name="orders_contract",
+                    indexes=[
+                        gsi("gsi-status", partition="status", sort="createdAt", projection=Projection.all())
+                    ],
+                ),
+                client=client,
+            ),
+            "ReleaseStateActual": Table(
+                ModelDefinition.from_dataclass(
+                    _ReleaseStateActual,
+                    table_name="release_state_contract",
+                    write_policy=WritePolicy(mode="mutable", protected_attributes=["pinnedReleaseId"]),
+                ),
+                client=client,
+            ),
+            "ReleaseStateEvent": Table(
+                ModelDefinition.from_dataclass(
+                    _ReleaseStateEvent,
+                    table_name="release_state_contract",
+                    write_policy=WritePolicy(mode="write_once"),
+                ),
+                client=client,
+            ),
+        }
+
+    def create(self, model: str, item: dict[str, Any], *, if_not_exists: bool = False) -> None:
+        self._validate_release_state_metadata_if_present(model, item)
+        table = self.tables[model]
+        kwargs: dict[str, Any] = {}
+        if if_not_exists:
+            kwargs = {
+                "condition_expression": "attribute_not_exists(#pk)",
+                "expression_attribute_names": {"#pk": table._model.pk.attribute_name},
+            }
+        table.put(self._item(model, item), **kwargs)
+
+    def get(self, model: str, key: dict[str, Any]) -> dict[str, Any]:
+        table = self.tables[model]
+        return _contract_item(table.get(key["PK"], key["SK"], consistent_read=True))
+
+    def update(
+        self,
+        model: str,
+        item: dict[str, Any],
+        fields: list[str],
+        *,
+        protected_attributes: list[str] | None = None,
+    ) -> None:
+        table = self.tables[model]
+        updates = {field: item[field] for field in fields if field in item}
+        expected_version = _expected_version(table, item)
+        table.update(
+            item["PK"],
+            item["SK"],
+            updates,
+            expected_version=expected_version,
+            protected_attributes=protected_attributes or [],
+        )
+
+    def save(self, model: str, item: dict[str, Any]) -> None:
+        self._validate_release_state_metadata_if_present(model, item)
+        self.tables[model].save(self._item(model, item))
+
+    def delete(self, model: str, key: dict[str, Any]) -> None:
+        self.tables[model].delete(key["PK"], key["SK"])
+
+    def transition_append_event(self, actual: dict[str, Any], event: dict[str, Any]) -> None:
+        transition_release_state(
+            self.tables[actual["model"]],
+            self.tables[event["model"]],
+            actual_key=actual["key"],
+            expected_version=actual.get("expected_version"),
+            set_values=actual["set"],
+            event_item=self._item(event["model"], event["item"]),
+        )
+
+    def validate_provenance(self, model: str, item: dict[str, Any]) -> None:
+        if model != "ReleaseStateActual":
+            raise ValidationError(f"validate_provenance unsupported for {model}")
+        validate_deploy_authority_metadata(item)
+
+    @staticmethod
+    def _validate_release_state_metadata_if_present(model: str, item: dict[str, Any]) -> None:
+        if model != "ReleaseStateActual":
+            return
+        if "provenance" in item or "confidence" in item:
+            validate_deploy_authority_metadata(item)
+
+    @staticmethod
+    def _item(model: str, item: dict[str, Any]) -> Any:
+        kwargs = dict(item)
+        if model == "User":
+            if "tags" in kwargs and kwargs["tags"] is not None:
+                kwargs["tags"] = set(cast(list[str], kwargs["tags"]))
+            return _User(**kwargs)
+        if model == "Order":
+            return _Order(**kwargs)
+        if model == "ReleaseStateActual":
+            return _ReleaseStateActual(**kwargs)
+        if model == "ReleaseStateEvent":
+            return _ReleaseStateEvent(**kwargs)
+        raise AssertionError(f"unknown model: {model}")
+
+
+@pytest.mark.parametrize("scenario", _load_scenarios(), ids=lambda scenario: str(scenario["name"]))
+def test_p0_contract_scenarios_execute_for_python(scenario: dict[str, Any]) -> None:
+    models = _load_models()
+    missing = _missing_capabilities(scenario, _supported_capabilities())
+    if missing:
+        pytest.skip(f"scenario requires unsupported capabilities: {', '.join(missing)}")
+
+    client = _dynamodb_client()
+    try:
+        client.list_tables(Limit=1)
+    except EndpointConnectionError:
+        if os.environ.get("SKIP_INTEGRATION") in {"1", "true"}:
+            pytest.skip("DynamoDB Local not reachable and SKIP_INTEGRATION is set")
+        raise
+
+    driver = _TheorydbPyDriver(client)
+    _run_scenario(client, driver, scenario, models)
+
+
+def _supported_capabilities() -> list[str]:
+    return [
+        "crud",
+        "omitempty",
+        "lifecycle.timestamps",
+        "optimistic_lock.version",
+        "ttl.epoch_seconds",
+        "release_state.write_policy",
+        "release_state.transactional_transition",
+        "release_state.provenance_confidence",
+    ]
+
+
+def _missing_capabilities(scenario: dict[str, Any], supported: list[str]) -> list[str]:
+    supported_set = set(supported)
+    return [
+        capability
+        for capability in scenario.get("requires_capabilities", [])
+        if capability not in supported_set
+    ]
+
+
+def _dynamodb_client() -> Any:
+    endpoint = os.environ.get("DYNAMODB_ENDPOINT", "http://localhost:8000")
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+    return boto3.client(
+        "dynamodb",
+        endpoint_url=endpoint,
+        region_name=region,
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "dummy"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "dummy"),
+    )
+
+
+def _run_scenario(
+    client: Any,
+    driver: _TheorydbPyDriver,
+    scenario: dict[str, Any],
+    models: dict[str, dict[str, Any]],
+) -> None:
+    model = models[scenario["model"]]
+    table_name = scenario.get("table", {}).get("name") or model["table"]["name"]
+    _recreate_table(client, table_name, model)
+    variables: dict[str, Any] = {}
+
+    for step in scenario["steps"]:
+        _run_step(client, driver, step, scenario, models, table_name, variables)
+
+
+def _run_step(
+    client: Any,
+    driver: _TheorydbPyDriver,
+    step: dict[str, Any],
+    scenario: dict[str, Any],
+    models: dict[str, dict[str, Any]],
+    table_name: str,
+    variables: dict[str, Any],
+) -> None:
+    if step["op"] == "sleep":
+        if step.get("ms", 0) > 0:
+            time.sleep(step["ms"] / 1000.0)
+        return
+
+    model_name = step.get("model") or scenario["model"]
+    model = models[model_name]
+
+    if step["op"] == "create":
+        error = _capture_error(
+            lambda: driver.create(model_name, step["item"], if_not_exists=step.get("if_not_exists", False))
+        )
+        _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
+        return
+
+    if step["op"] == "update":
+        error = _capture_error(
+            lambda: driver.update(
+                model_name,
+                step["item"],
+                step.get("fields", []),
+                protected_attributes=step.get("protected_attributes", []),
+            )
+        )
+        _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
+        return
+
+    if step["op"] == "save":
+        error = _capture_error(lambda: driver.save(model_name, step["item"]))
+        _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
+        return
+
+    if step["op"] == "delete":
+        error = _capture_error(lambda: driver.delete(model_name, step["key"]))
+        _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
+        return
+
+    if step["op"] == "get":
+        item, error = _capture_result(lambda: driver.get(model_name, step["key"]))
+        raw = None if error is not None else _get_raw_item(client, table_name, model, step["key"])
+        if error is None:
+            for variable_name, attr in step.get("save", {}).items():
+                variables[variable_name] = item[attr]
+        _assert_expectation(
+            step.get("expect", {}), error=error, item=item, raw=raw, model=model, variables=variables
+        )
+        return
+
+    if step["op"] == "transition_append_event":
+        error = _capture_error(lambda: driver.transition_append_event(step["actual"], step["event"]))
+        _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
+        return
+
+    if step["op"] == "validate_provenance":
+        error = _capture_error(lambda: driver.validate_provenance(model_name, step["item"]))
+        _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
+        return
+
+    raise AssertionError(f"unsupported op: {step['op']}")
+
+
+def _capture_error(fn: Any) -> Exception | None:
+    try:
+        fn()
+    except Exception as err:  # noqa: BLE001 - scenario runner maps expected runtime errors.
+        return err
+    return None
+
+
+def _capture_result(fn: Any) -> tuple[dict[str, Any], Exception | None]:
+    try:
+        return fn(), None
+    except Exception as err:  # noqa: BLE001 - scenario runner maps expected runtime errors.
+        return {}, err
+
+
+def _assert_expectation(
+    expect: dict[str, Any],
+    *,
+    error: Exception | None,
+    model: dict[str, Any],
+    variables: dict[str, Any],
+    item: dict[str, Any] | None = None,
+    raw: dict[str, Any] | None = None,
+) -> None:
+    if "error" in expect:
+        assert error is not None
+        assert _map_error(error) == expect["error"]
+        return
+
+    if "ok" in expect:
+        if expect["ok"]:
+            assert error is None
+        else:
+            assert error is not None
+    if error is not None:
+        return
+
+    if "item_contains" in expect:
+        assert item is not None
+        for attr, want in expect["item_contains"].items():
+            assert attr in item
+            attr_def = _attribute_by_name(model, attr)
+            assert attr_def is not None
+            _assert_value_matches(attr_def["type"], want, item[attr])
+
+    if "item_has_fields" in expect:
+        assert item is not None
+        for attr in expect["item_has_fields"]:
+            assert attr in item
+
+    if "item_missing_fields" in expect:
+        assert raw is not None
+        for attr in expect["item_missing_fields"]:
+            assert attr not in raw
+
+    if "raw_attribute_types" in expect:
+        assert raw is not None
+        for attr, want_type in expect["raw_attribute_types"].items():
+            assert attr in raw
+            assert _attribute_value_type_name(raw[attr]) == want_type
+
+    if "item_field_equals_var" in expect:
+        assert item is not None
+        for attr, variable_name in expect["item_field_equals_var"].items():
+            assert item[attr] == variables[variable_name]
+
+    if "item_field_not_equals_var" in expect:
+        assert item is not None
+        for attr, variable_name in expect["item_field_not_equals_var"].items():
+            assert item[attr] != variables[variable_name]
+
+
+def _map_error(error: Exception) -> str:
+    if isinstance(error, NotFoundError):
+        return "ErrItemNotFound"
+    if isinstance(error, ConditionFailedError):
+        return "ErrConditionFailed"
+    if isinstance(error, ImmutableModelMutationError):
+        return "ErrImmutableModelMutation"
+    if isinstance(error, ProtectedFieldMutationError):
+        return "ErrProtectedFieldMutation"
+    if isinstance(error, RejectedDeployAuthorityEvidenceError):
+        return "ErrRejectedDeployAuthorityEvidence"
+    if isinstance(error, ValidationError):
+        return "ErrInvalidModel"
+    return ""
+
+
+def _expected_version(table: Table[Any], item: dict[str, Any]) -> int | None:
+    for attr in table._model.attributes.values():
+        if "version" in attr.roles:
+            value = item.get(attr.python_name, item.get(attr.attribute_name))
+            return None if value is None else int(value)
+    return None
+
+
+def _contract_item(value: Any) -> dict[str, Any]:
+    if is_dataclass(value):
+        return _normalize_contract_value(asdict(value))
+    assert isinstance(value, dict)
+    return _normalize_contract_value(value)
+
+
+def _normalize_contract_value(value: Any) -> Any:
+    if isinstance(value, set):
+        return sorted(str(item) for item in value)
+    if isinstance(value, Decimal):
+        return int(value) if value == value.to_integral_value() else float(value)
+    if isinstance(value, dict):
+        return {key: _normalize_contract_value(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_normalize_contract_value(item) for item in value]
+    return value
+
+
+def _assert_value_matches(attr_type: str, want: Any, have: Any) -> None:
+    if attr_type == "S":
+        assert str(have) == str(want)
+        return
+    if attr_type == "N":
+        assert Decimal(str(have)) == Decimal(str(want))
+        return
+    if attr_type == "SS":
+        assert sorted(str(item) for item in have) == sorted(str(item) for item in want)
+        return
+    assert have == want
+
+
+def _attribute_by_name(model: dict[str, Any], name: str) -> dict[str, Any] | None:
+    for attr in model.get("attributes", []):
+        if attr["attribute"] == name:
+            return cast(dict[str, Any], attr)
+    return None
+
+
+def _get_raw_item(
+    client: Any,
+    table_name: str,
+    model: dict[str, Any],
+    key: dict[str, Any],
+) -> dict[str, Any]:
+    out = client.get_item(TableName=table_name, Key=_marshal_key(model, key), ConsistentRead=True)
+    item = out.get("Item")
+    if item is None:
+        raise AssertionError("raw GetItem returned no Item")
+    return cast(dict[str, Any], item)
+
+
+def _marshal_key(model: dict[str, Any], key: dict[str, Any]) -> dict[str, Any]:
+    serializer = TypeSerializer()
+    out: dict[str, Any] = {}
+    partition = model["keys"]["partition"]
+    out[partition["attribute"]] = serializer.serialize(key[partition["attribute"]])
+    sort = model["keys"].get("sort")
+    if sort is not None:
+        out[sort["attribute"]] = serializer.serialize(key[sort["attribute"]])
+    return out
+
+
+def _attribute_value_type_name(value: dict[str, Any]) -> str:
+    for name in ("S", "N", "B", "BOOL", "NULL", "SS", "NS", "BS", "L", "M"):
+        if name in value:
+            return name
+    return "UNKNOWN"
+
+
+def _recreate_table(client: Any, table_name: str, model: dict[str, Any]) -> None:
+    try:
+        client.delete_table(TableName=table_name)
+    except ClientError as err:
+        if err.response.get("Error", {}).get("Code") != "ResourceNotFoundException":
+            raise
+    _wait_table_not_exists(client, table_name)
+    client.create_table(**_create_table_input(table_name, model))
+    _wait_table_exists(client, table_name)
+
+
+def _wait_table_exists(client: Any, table_name: str) -> None:
+    for _ in range(60):
+        try:
+            resp = client.describe_table(TableName=table_name)
+        except ClientError as err:
+            if err.response.get("Error", {}).get("Code") != "ResourceNotFoundException":
+                raise
+        else:
+            if resp.get("Table", {}).get("TableStatus") == "ACTIVE":
+                return
+        time.sleep(0.5)
+    raise AssertionError(f"timeout waiting for table exists: {table_name}")
+
+
+def _wait_table_not_exists(client: Any, table_name: str) -> None:
+    for _ in range(40):
+        try:
+            client.describe_table(TableName=table_name)
+        except ClientError as err:
+            if err.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
+                return
+            raise
+        time.sleep(0.25)
+
+
+def _create_table_input(table_name: str, model: dict[str, Any]) -> dict[str, Any]:
+    definitions: dict[str, str] = {}
+
+    def add_def(attr: dict[str, str]) -> None:
+        definitions[attr["attribute"]] = attr["type"]
+
+    add_def(model["keys"]["partition"])
+    if model["keys"].get("sort") is not None:
+        add_def(model["keys"]["sort"])
+    for index in model.get("indexes", []):
+        add_def(index["partition"])
+        if index.get("sort") is not None:
+            add_def(index["sort"])
+
+    key_schema = [{"AttributeName": model["keys"]["partition"]["attribute"], "KeyType": "HASH"}]
+    if model["keys"].get("sort") is not None:
+        key_schema.append({"AttributeName": model["keys"]["sort"]["attribute"], "KeyType": "RANGE"})
+
+    input_value: dict[str, Any] = {
+        "TableName": table_name,
+        "AttributeDefinitions": [
+            {"AttributeName": name, "AttributeType": type_} for name, type_ in sorted(definitions.items())
+        ],
+        "KeySchema": key_schema,
+        "BillingMode": "PAY_PER_REQUEST",
+    }
+
+    global_secondary_indexes: list[dict[str, Any]] = []
+    local_secondary_indexes: list[dict[str, Any]] = []
+    for index in model.get("indexes", []):
+        index_key_schema = [{"AttributeName": index["partition"]["attribute"], "KeyType": "HASH"}]
+        if index.get("sort") is not None:
+            index_key_schema.append({"AttributeName": index["sort"]["attribute"], "KeyType": "RANGE"})
+        projection = {
+            "ProjectionType": index.get("projection", {}).get("type", "ALL"),
+        }
+        fields = index.get("projection", {}).get("fields")
+        if fields:
+            projection["NonKeyAttributes"] = fields
+        index_input = {
+            "IndexName": index["name"],
+            "KeySchema": index_key_schema,
+            "Projection": projection,
+        }
+        if index["type"] == "LSI":
+            local_secondary_indexes.append(index_input)
+        else:
+            global_secondary_indexes.append(index_input)
+
+    if global_secondary_indexes:
+        input_value["GlobalSecondaryIndexes"] = global_secondary_indexes
+    if local_secondary_indexes:
+        input_value["LocalSecondaryIndexes"] = local_secondary_indexes
+    return input_value

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -110,7 +110,7 @@ tabletheory:
       docs_path: runtimes/typescript
     - id: python
       label: Python
-      install: "pip install https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theorydb_py-X.Y.Z-py3-none-any.whl"
+      install: "pip install https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/tabletheory_py-X.Y.Z-py3-none-any.whl"
       docs_path: runtimes/python
   surfaces:
     - id: core

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -102,15 +102,15 @@ tabletheory:
   runtimes:
     - id: go
       label: Go
-      install: "go get github.com/theory-cloud/tabletheory"
-      docs_path: getting-started
+      install: "go get github.com/theory-cloud/tabletheory@vX.Y.Z"
+      docs_path: runtimes/go
     - id: ts
       label: TypeScript
-      install: "npm install --save-dev @theory-cloud/tabletheory-ts"
+      install: "npm install --save-exact https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theory-cloud-tabletheory-ts-X.Y.Z.tgz"
       docs_path: runtimes/typescript
     - id: python
       label: Python
-      install: "pip install tabletheory-py"
+      install: "pip install https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theorydb_py-X.Y.Z-py3-none-any.whl"
       docs_path: runtimes/python
   surfaces:
     - id: core

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -133,8 +133,8 @@ tabletheory:
       cta: See the Autheory integration
   stats:
     - label: P0 contract scenarios
-      value: "5"
-      sub: CRUD · omit-empty · timestamps · locking · TTL
+      value: "9"
+      sub: CRUD · lifecycle · TTL · release-state
     - label: Runtimes
       value: "3"
       sub: Go · TypeScript · Python

--- a/docs/_data/runtimes.yml
+++ b/docs/_data/runtimes.yml
@@ -83,7 +83,7 @@
 - id: python
   label: Python
   icon: py-mark
-  install: "pip install https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theorydb_py-X.Y.Z-py3-none-any.whl"
+  install: "pip install https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/tabletheory_py-X.Y.Z-py3-none-any.whl"
   lang: python
   snippet: |
     from dataclasses import dataclass

--- a/docs/_data/runtimes.yml
+++ b/docs/_data/runtimes.yml
@@ -1,103 +1,107 @@
 # =============================================================
 # Landing-page runtime tabs — Go / TypeScript / Python snippets.
-# Each block is rendered inside the .runtime-block UI on the home
-# page. `lang` matches the Rouge highlighter id.
+# Each snippet uses the actual exported API surface. Distribution
+# is GitHub Releases only — no npm, no PyPI.
 # =============================================================
 
 - id: go
   label: Go
   icon: go-mark
-  install: "go get github.com/theory-cloud/tabletheory"
+  install: "go get github.com/theory-cloud/tabletheory@vX.Y.Z"
   lang: go
   snippet: |
     package main
 
     import (
-        "context"
+        "log"
+
+        "github.com/aws/aws-lambda-go/lambda"
         "github.com/theory-cloud/tabletheory"
     )
 
+    // Models are plain Go structs with theorydb: + json: struct tags.
     type Note struct {
-        _  struct{} `theorydb:"naming:snake_case"`
-        PK string   `theorydb:"pk"       json:"pk"`
-        SK string   `theorydb:"sk"       json:"sk"`
-
-        Body      string `theorydb:"omitempty"   json:"body,omitempty"`
-        Version   int64  `theorydb:"version"     json:"version"`
-        CreatedAt int64  `theorydb:"created_at"  json:"created_at"`
-        UpdatedAt int64  `theorydb:"updated_at"  json:"updated_at"`
+        PK    string `theorydb:"pk" json:"pk"`
+        SK    string `theorydb:"sk" json:"sk"`
+        Body  string `json:"body"`
     }
 
-    func main() {
-        db := tabletheory.LambdaInit(context.Background(),
-            tabletheory.WithTable("notes"),
-            tabletheory.WithModels(&Note{}),
-        )
+    var db *tabletheory.LambdaDB
 
-        _ = db.Put(context.Background(), &Note{
-            PK:   "user#42",
-            SK:   "note#welcome",
+    func init() {
+        // Cold-start initialization — reused across invocations.
+        var err error
+        db, err = tabletheory.NewLambdaOptimized()
+        if err != nil {
+            log.Fatal(err)
+        }
+    }
+
+    func handler() error {
+        return db.Model(&Note{
+            PK:   "USER#42",
+            SK:   "NOTE#welcome",
             Body: "Hello, Theory Cloud.",
-        })
+        }).Create()
     }
+
+    func main() { lambda.Start(handler) }
 
 - id: ts
   label: TypeScript
   icon: ts-mark
-  install: "npm install --save-dev @theory-cloud/tabletheory-ts"
+  install: "npm install --save-exact https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theory-cloud-tabletheory-ts-X.Y.Z.tgz"
   lang: typescript
   snippet: |
-    import { TableTheory, model, field } from "@theory-cloud/tabletheory-ts";
+    import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+    import { TheorydbClient, defineModel } from '@theory-cloud/tabletheory-ts';
 
-    @model({ naming: "snake_case", table: "notes" })
-    class Note {
-      @field({ role: "pk" }) pk!: string;
-      @field({ role: "sk" }) sk!: string;
-
-      @field({ omitempty: true }) body?: string;
-
-      @field({ role: "version" })    version!: number;
-      @field({ role: "created_at" }) created_at!: number;
-      @field({ role: "updated_at" }) updated_at!: number;
-    }
-
-    const db = await TableTheory.lambdaInit({
-      table:  "notes",
-      models: [Note],
+    // Models are declared explicitly via defineModel.
+    const Note = defineModel({
+      name: 'Note',
+      table: { name: 'notes' },
+      keys: {
+        partition: { attribute: 'PK', type: 'S' },
+        sort:      { attribute: 'SK', type: 'S' },
+      },
+      attributes: [
+        { attribute: 'PK',   type: 'S', roles: ['pk'] },
+        { attribute: 'SK',   type: 'S', roles: ['sk'] },
+        { attribute: 'body', type: 'S', optional: true },
+      ],
     });
 
-    await db.put(new Note({
-      pk:   "user#42",
-      sk:   "note#welcome",
-      body: "Hello, Theory Cloud.",
-    }));
+    const ddb = new DynamoDBClient({ region: 'us-east-1' });
+    const db  = new TheorydbClient(ddb).register(Note);
+
+    await db.create('Note', {
+      PK:   'USER#42',
+      SK:   'NOTE#welcome',
+      body: 'Hello, Theory Cloud.',
+    });
 
 - id: python
   label: Python
   icon: py-mark
-  install: "pip install tabletheory-py"
+  install: "pip install https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theorydb_py-X.Y.Z-py3-none-any.whl"
   lang: python
   snippet: |
-    from tabletheory_py import TableTheory, model, field
+    from dataclasses import dataclass
 
-    @model(naming="snake_case", table="notes")
+    import boto3
+    from theorydb_py import ModelDefinition, Table, theorydb_field
+
+
+    # Models are plain dataclasses with theorydb_field roles.
+    @dataclass(frozen=True)
     class Note:
-        pk: str = field(role="pk")
-        sk: str = field(role="sk")
+        pk:   str = theorydb_field(roles=["pk"])
+        sk:   str = theorydb_field(roles=["sk"])
+        body: str = theorydb_field()
 
-        body: str | None = field(omitempty=True, default=None)
 
-        version:    int = field(role="version")
-        created_at: int = field(role="created_at")
-        updated_at: int = field(role="updated_at")
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    model  = ModelDefinition.from_dataclass(Note, table_name="notes")
+    table  = Table(model, client=client)
 
-    db = TableTheory.lambda_init(
-        table="notes",
-        models=[Note],
-    )
-
-    db.put(Note(
-        pk="user#42",
-        sk="note#welcome",
-        body="Hello, Theory Cloud.",
-    ))
+    table.put(Note(pk="USER#42", sk="NOTE#welcome", body="Hello, Theory Cloud."))

--- a/docs/assets/svg/icon-mono-light.svg
+++ b/docs/assets/svg/icon-mono-light.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Theory Cloud">
   <title>Theory Cloud (monochrome, light on dark)</title>
-  
+
   <g fill="#F4F8FF" transform="translate(15.006 4) scale(0.2866)">
     <path d="M118.58,0v115.18H.13C3.65,52.64,55.02,2.51,118.58,0Z"></path>
     <path d="M65.28,125.01v70.09C29.48,190.73,1.46,161.18,0,125.01h65.28Z"></path>

--- a/docs/assets/svg/icon.svg
+++ b/docs/assets/svg/icon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Theory Cloud">
   <title>Theory Cloud</title>
-  
+
   <defs>
     <linearGradient id="tc-grad-top" x1="43.78" y1="39.57" x2="131.39" y2="140.96" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#2EA7FF"></stop>

--- a/docs/assets/svg/wordmark-theory-cloud.svg
+++ b/docs/assets/svg/wordmark-theory-cloud.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 566.3 195.38">
   <defs>
-    
+
     <linearGradient id="New_Gradient_Swatch_1" data-name="New Gradient Swatch 1" x1="43.78" y1="39.57" x2="131.39" y2="140.96" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#2EA7FF"></stop>
       <stop offset="1" stop-color="#7A5CFF"></stop>

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -60,7 +60,7 @@ See [TypeScript Development Guidelines](../ts/docs/development-guidelines.md).
 - Must pass:
   - `uv --directory py run mypy src` (strict)
   - `uv --directory py run ruff check`
-  - `uv --directory py run pytest -q`
+  - `uv --directory py run pytest -q tests/unit`
 - Prefer dataclasses with explicit roles via `theorydb_field(...)`.
 - Do not weaken strict fakes (`theorydb_py.mocks`); unit tests must not call real AWS.
 

--- a/docs/features/crud.md
+++ b/docs/features/crud.md
@@ -11,67 +11,89 @@ The canonical scenario lives at [`contract-tests/scenarios/crud/`](https://githu
 
 ## The contract
 
-Given a model with `pk`, `sk`, one user attribute, and a naming strategy:
+Given a model with `pk`, `sk`, one user attribute, and the same DMS shape across runtimes:
 
 | Behavior                                  | Required across Go / TS / Python |
 |-------------------------------------------|----------------------------------|
-| `Put` writes all populated attributes      | yes                              |
-| Zero values without `omitempty` are written | yes                              |
-| Attribute names follow the naming strategy | yes                              |
-| `Get` returns identical field values       | yes                              |
-| `Update` mutates only changed attributes   | yes                              |
-| `Delete` removes the item                  | yes                              |
-| Missing item on `Get` returns a typed "not found" error, never `nil`/`None` silently | yes |
+| Create writes all populated attributes     | yes                              |
+| Zero values without `omit_empty` are written | yes                            |
+| Attribute names match the DMS shape        | yes                              |
+| Read returns identical field values        | yes                              |
+| Update mutates only the named fields       | yes                              |
+| Delete removes the item                    | yes                              |
+| Missing item on Get raises a typed not-found error, never returns silent nil/None | yes |
 
 ## Go
 
 ```go
 type Note struct {
-    _  struct{} `theorydb:"naming:snake_case"`
-    PK string   `theorydb:"pk"  json:"pk"`
-    SK string   `theorydb:"sk"  json:"sk"`
-
-    Body string `theorydb:"omitempty" json:"body,omitempty"`
+    PK   string `theorydb:"pk" json:"pk"`
+    SK   string `theorydb:"sk" json:"sk"`
+    Body string `json:"body"`
 }
 
-_ = db.Put(ctx, &Note{PK: "user#1", SK: "note#welcome", Body: "Hi."})
+// Create
+db.Model(&Note{PK: "USER#1", SK: "NOTE#welcome", Body: "Hi."}).Create()
 
-var n Note
-_ = db.Get(ctx, &n, "user#1", "note#welcome")
+// Read
+var got Note
+db.Model(&Note{PK: "USER#1", SK: "NOTE#welcome"}).First(&got)
+
+// Update specific fields
+db.Model(&Note{PK: "USER#1", SK: "NOTE#welcome", Body: "Edited."}).Update("body")
+
+// Delete
+db.Model(&Note{PK: "USER#1", SK: "NOTE#welcome"}).Delete()
 ```
 
 ## TypeScript
 
 ```typescript
-@model({ naming: "snake_case", table: "notes" })
-class Note {
-  @field({ role: "pk" }) pk!: string;
-  @field({ role: "sk" }) sk!: string;
-  @field({ omitempty: true }) body?: string;
-}
+const Note = defineModel({
+  name: 'Note',
+  table: { name: 'notes_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort:      { attribute: 'SK', type: 'S' },
+  },
+  attributes: [
+    { attribute: 'PK',   type: 'S', roles: ['pk'] },
+    { attribute: 'SK',   type: 'S', roles: ['sk'] },
+    { attribute: 'body', type: 'S', optional: true, omit_empty: true },
+  ],
+});
 
-await db.put(new Note({ pk: "user#1", sk: "note#welcome", body: "Hi." }));
-const n = await db.get(Note, "user#1", "note#welcome");
+const db = new TheorydbClient(ddb).register(Note);
+
+await db.create('Note', { PK: 'USER#1', SK: 'NOTE#welcome', body: 'Hi.' });
+const item = await db.get('Note', { PK: 'USER#1', SK: 'NOTE#welcome' });
+await db.update('Note', { PK: 'USER#1', SK: 'NOTE#welcome', body: 'Edited.' }, ['body']);
+await db.delete('Note', { PK: 'USER#1', SK: 'NOTE#welcome' });
 ```
 
 ## Python
 
 ```python
-@model(naming="snake_case", table="notes")
+@dataclass(frozen=True)
 class Note:
-    pk: str
-    sk: str
-    body: str | None = field(omitempty=True, default=None)
+    pk:   str = theorydb_field(roles=["pk"])
+    sk:   str = theorydb_field(roles=["sk"])
+    body: str = theorydb_field(omit_empty=True)
 
-db.put(Note(pk="user#1", sk="note#welcome", body="Hi."))
-n = db.get(Note, "user#1", "note#welcome")
+model = ModelDefinition.from_dataclass(Note, table_name="notes_contract")
+table = Table(model, client=client)
+
+table.put(Note(pk="USER#1", sk="NOTE#welcome", body="Hi."))
+note = table.get("USER#1", "NOTE#welcome")
+table.update("USER#1", "NOTE#welcome", body="Edited.")
+table.delete("USER#1", "NOTE#welcome")
 ```
 
 ## Omit-empty subtlety
 
-Without `omitempty`, **zero values are written**: `""`, `0`, `False`/`false`, empty slices, empty maps. With `omitempty`, the attribute is *omitted entirely* from the DynamoDB item.
+Without `omit_empty`, **zero values are written**: `""`, `0`, `False`/`false`, empty slices, empty maps. With `omit_empty`, the attribute is *omitted entirely* from the DynamoDB item.
 
-This matters because DynamoDB distinguishes "attribute present with empty string" from "attribute absent" in queries and conditional expressions. The contract pins which behavior each tag combination produces, and every runtime must agree.
+This matters because DynamoDB distinguishes "attribute present with empty string" from "attribute absent" in queries and conditional expressions. The contract pins which behavior each combination produces, and every runtime must agree.
 
 The dedicated [omit-empty scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios) exercises every type variant in the matrix.
 

--- a/docs/features/crud.md
+++ b/docs/features/crud.md
@@ -49,6 +49,9 @@ db.Model(&Note{PK: "USER#1", SK: "NOTE#welcome"}).Delete()
 ## TypeScript
 
 ```typescript
+// TheorydbClient.update requires a version role on the model and the
+// current version in the item payload. Most "real" TableTheory models
+// declare version anyway; show it here so the CRUD flow is complete.
 const Note = defineModel({
   name: 'Note',
   table: { name: 'notes_contract' },
@@ -57,9 +60,10 @@ const Note = defineModel({
     sort:      { attribute: 'SK', type: 'S' },
   },
   attributes: [
-    { attribute: 'PK',   type: 'S', roles: ['pk'] },
-    { attribute: 'SK',   type: 'S', roles: ['sk'] },
-    { attribute: 'body', type: 'S', optional: true, omit_empty: true },
+    { attribute: 'PK',      type: 'S', roles: ['pk'] },
+    { attribute: 'SK',      type: 'S', roles: ['sk'] },
+    { attribute: 'body',    type: 'S', optional: true, omit_empty: true },
+    { attribute: 'version', type: 'N', roles: ['version'] },
   ],
 });
 
@@ -67,7 +71,12 @@ const db = new TheorydbClient(ddb).register(Note);
 
 await db.create('Note', { PK: 'USER#1', SK: 'NOTE#welcome', body: 'Hi.' });
 const item = await db.get('Note', { PK: 'USER#1', SK: 'NOTE#welcome' });
-await db.update('Note', { PK: 'USER#1', SK: 'NOTE#welcome', body: 'Edited.' }, ['body']);
+// Pass the current version through; the runtime asserts it matches.
+await db.update(
+  'Note',
+  { PK: 'USER#1', SK: 'NOTE#welcome', body: 'Edited.', version: item.version },
+  ['body'],
+);
 await db.delete('Note', { PK: 'USER#1', SK: 'NOTE#welcome' });
 ```
 
@@ -78,14 +87,14 @@ await db.delete('Note', { PK: 'USER#1', SK: 'NOTE#welcome' });
 class Note:
     pk:   str = theorydb_field(roles=["pk"])
     sk:   str = theorydb_field(roles=["sk"])
-    body: str = theorydb_field(omit_empty=True)
+    body: str = theorydb_field(omitempty=True)
 
 model = ModelDefinition.from_dataclass(Note, table_name="notes_contract")
 table = Table(model, client=client)
 
 table.put(Note(pk="USER#1", sk="NOTE#welcome", body="Hi."))
 note = table.get("USER#1", "NOTE#welcome")
-table.update("USER#1", "NOTE#welcome", body="Edited.")
+table.update("USER#1", "NOTE#welcome", {"body": "Edited."})  # third arg is a Mapping
 table.delete("USER#1", "NOTE#welcome")
 ```
 

--- a/docs/features/crud.md
+++ b/docs/features/crud.md
@@ -7,7 +7,7 @@ description: How TableTheory marshals models to DynamoDB attributes — the foun
 
 The CRUD scenario is the foundation of the P0 contract: every TableTheory runtime must produce **identical DynamoDB items** for identical inputs and read them back identically. If Go writes a `Note` and Python reads it, the two runtimes see the same field values, the same attribute names, and the same DynamoDB types.
 
-The canonical scenario lives at [`contract-tests/scenarios/crud/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios) and is exercised by every runtime on every commit.
+The canonical scenario lives at [`contract-tests/scenarios/p0/01-crud-basic.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/01-crud-basic.yml) and is exercised by every runtime on every commit.
 
 ## The contract
 
@@ -104,7 +104,7 @@ Without `omit_empty`, **zero values are written**: `""`, `0`, `False`/`false`, e
 
 This matters because DynamoDB distinguishes "attribute present with empty string" from "attribute absent" in queries and conditional expressions. The contract pins which behavior each combination produces, and every runtime must agree.
 
-The dedicated [omit-empty scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios) exercises every type variant in the matrix.
+The dedicated [omit-empty scenario](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/02-omitempty.yml) exercises every type variant in the matrix.
 
 ## Related
 

--- a/docs/features/encryption.md
+++ b/docs/features/encryption.md
@@ -5,7 +5,7 @@ description: KMS-backed field encryption — fail-closed, no fallbacks, identica
 
 # Encryption
 
-`theorydb:"encrypted"` marks a field for KMS-backed encryption. The behavior is **fail-closed** and that property is load-bearing across the entire Theory Cloud stack.
+`encrypted` marks a field for KMS-backed encryption. The behavior is **fail-closed** and that property is load-bearing across the entire Theory Cloud stack.
 
 If the KMS key is not configured, encrypted reads return an error. The runtime does **not**:
 
@@ -18,8 +18,8 @@ Every Theory Cloud consumer that stores sensitive data — Autheory's credential
 
 ## How it works
 
-1. At `lambda_init` time, a KMS key id (or alias) is bound to the client.
-2. On write, fields tagged `encrypted` are run through KMS `Encrypt` and stored as ciphertext blobs.
+1. The KMS key id (or alias) is bound to the client at construction.
+2. On write, fields with the `encrypted` role/flag are run through KMS `Encrypt` and stored as ciphertext blobs.
 3. On read, the ciphertext is run through KMS `Decrypt`. Failure to decrypt = the read fails.
 4. Encrypted values are **never logged** — the redaction layer suppresses them at logging sites.
 
@@ -29,55 +29,46 @@ Every Theory Cloud consumer that stores sensitive data — Autheory's credential
 type Credential struct {
     PK     string `theorydb:"pk"        json:"pk"`
     SK     string `theorydb:"sk"        json:"sk"`
-
     Secret string `theorydb:"encrypted" json:"secret"`
 }
 
-db := tabletheory.LambdaInit(ctx,
-    tabletheory.WithTable("credentials"),
-    tabletheory.WithModels(&Credential{}),
-    tabletheory.WithKMSKey("alias/tabletheory/encryption"),
-)
+// Provide KMS configuration via the standard Config / environment
+// surface (see api-reference.md for the full set). The runtime fails
+// closed when an encrypted field is touched without configured KMS.
 ```
 
 ## TypeScript
 
 ```typescript
-@model({ naming: "snake_case", table: "credentials" })
-class Credential {
-  @field({ role: "pk" }) pk!: string;
-  @field({ role: "sk" }) sk!: string;
-
-  @field({ encrypted: true }) secret!: string;
-}
-
-const db = await TableTheory.lambdaInit({
-  table:    "credentials",
-  models:   [Credential],
-  kmsKeyId: "alias/tabletheory/encryption",
+const Credential = defineModel({
+  name: 'Credential',
+  table: { name: 'credentials_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort:      { attribute: 'SK', type: 'S' },
+  },
+  attributes: [
+    { attribute: 'PK',     type: 'S', roles: ['pk'] },
+    { attribute: 'SK',     type: 'S', roles: ['sk'] },
+    { attribute: 'secret', type: 'S', encrypted: true },
+  ],
 });
 ```
 
 ## Python
 
 ```python
-@model(naming="snake_case", table="credentials")
+@dataclass(frozen=True)
 class Credential:
-    pk: str
-    sk: str
-    secret: str = field(encrypted=True)
-
-db = TableTheory.lambda_init(
-    table="credentials",
-    models=[Credential],
-    kms_key_id="alias/tabletheory/encryption",
-)
+    pk:     str = theorydb_field(roles=["pk"])
+    sk:     str = theorydb_field(roles=["sk"])
+    secret: str = theorydb_field(encrypted=True)
 ```
 
 ## What "fail-closed" actually means
 
 - **No KMS key configured + encrypted field write**: write fails before touching DynamoDB.
-- **KMS key revoked / inaccessible + encrypted field read**: read fails, returning a typed `EncryptionError`.
+- **KMS key revoked / inaccessible + encrypted field read**: read fails, returning a typed encryption error.
 - **Decryption fails (wrong key, corrupted ciphertext)**: read fails. The plaintext is never inferred or guessed.
 - **Cross-region replication**: the consumer must configure the encryption key in the target region; otherwise reads from that region fail closed.
 

--- a/docs/features/encryption.md
+++ b/docs/features/encryption.md
@@ -50,7 +50,7 @@ const Credential = defineModel({
   attributes: [
     { attribute: 'PK',     type: 'S', roles: ['pk'] },
     { attribute: 'SK',     type: 'S', roles: ['sk'] },
-    { attribute: 'secret', type: 'S', encrypted: true },
+    { attribute: 'secret', type: 'S', encryption: { v: 1 } },
   ],
 });
 ```

--- a/docs/features/lifecycle-timestamps.md
+++ b/docs/features/lifecycle-timestamps.md
@@ -5,75 +5,78 @@ description: Automatic created_at and updated_at on every write — clock-ordere
 
 # Lifecycle Timestamps
 
-`theorydb:"created_at"` and `theorydb:"updated_at"` are the canonical lifecycle timestamp tags. The runtime owns them — your code never sets them by hand.
+`created_at` and `updated_at` are the canonical lifecycle timestamp roles. The runtime owns them — your code never sets them by hand.
 
 The [lifecycle-timestamps P0 scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios) verifies that all three runtimes:
 
 - Set `created_at` on the **first write only**; subsequent writes leave it intact.
 - Update `updated_at` on **every write** (including the first).
-- Use the same clock source and same unit (epoch milliseconds, UTC).
+- Use a consistent clock source and unit across runtimes.
 - Preserve clock ordering: a write that follows another write produces an `updated_at` value strictly greater than the predecessor's.
 
 ## Go
 
 ```go
 type Note struct {
-    PK        string `theorydb:"pk"          json:"pk"`
-    SK        string `theorydb:"sk"          json:"sk"`
-    Body      string `json:"body"`
-
-    CreatedAt int64  `theorydb:"created_at"  json:"created_at"`
-    UpdatedAt int64  `theorydb:"updated_at"  json:"updated_at"`
+    PK        string    `theorydb:"pk"          json:"pk"`
+    SK        string    `theorydb:"sk"          json:"sk"`
+    Body      string    `json:"body"`
+    CreatedAt time.Time `theorydb:"created_at"  json:"created_at"`
+    UpdatedAt time.Time `theorydb:"updated_at"  json:"updated_at"`
 }
 
-n := &Note{PK: "user#1", SK: "note#welcome", Body: "Hi."}
-_ = db.Put(ctx, n)
+n := &Note{PK: "USER#1", SK: "NOTE#welcome", Body: "Hi."}
+db.Model(n).Create()
 // n.CreatedAt and n.UpdatedAt are now populated by the runtime.
 ```
 
 ## TypeScript
 
 ```typescript
-@model({ naming: "snake_case", table: "notes" })
-class Note {
-  @field({ role: "pk" }) pk!: string;
-  @field({ role: "sk" }) sk!: string;
-  @field() body!: string;
-
-  @field({ role: "created_at" }) created_at!: number;
-  @field({ role: "updated_at" }) updated_at!: number;
-}
+const Note = defineModel({
+  name: 'Note',
+  table: { name: 'notes_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort:      { attribute: 'SK', type: 'S' },
+  },
+  attributes: [
+    { attribute: 'PK',        type: 'S', roles: ['pk'] },
+    { attribute: 'SK',        type: 'S', roles: ['sk'] },
+    { attribute: 'body',      type: 'S' },
+    { attribute: 'createdAt', type: 'S', roles: ['created_at'] },
+    { attribute: 'updatedAt', type: 'S', roles: ['updated_at'] },
+  ],
+});
 ```
 
 ## Python
 
 ```python
-@model(naming="snake_case", table="notes")
+@dataclass(frozen=True)
 class Note:
-    pk: str
-    sk: str
-    body: str
-
-    created_at: int = field(role="created_at")
-    updated_at: int = field(role="updated_at")
+    pk:         str = theorydb_field(roles=["pk"])
+    sk:         str = theorydb_field(roles=["sk"])
+    body:       str = theorydb_field()
+    created_at: str = theorydb_field(roles=["created_at"])
+    updated_at: str = theorydb_field(roles=["updated_at"])
 ```
 
 ## Composes with optimistic locking
 
-`updated_at` is populated alongside `version` on every successful write. A version conflict aborts the write — neither `version` nor `updated_at` advances. This guarantees `updated_at` is monotonic for any item that ever loaded successfully.
+`updated_at` is populated alongside the `version` role on every successful write. A version conflict aborts the write — neither version nor `updated_at` advances. This guarantees `updated_at` is monotonic for any item that ever loaded successfully.
 
 ## Composes with TTL
 
-`updated_at` does **not** influence the TTL attribute. TTL is computed from the field tagged `theorydb:"ttl"`, independent of when the item was last touched. If you want "extend TTL on every write," update the TTL field explicitly in your write path.
+`updated_at` does **not** influence the TTL attribute. TTL is computed from the field with the `ttl` role, independent of when the item was last touched. If you want "extend TTL on every write," update the TTL field explicitly in your write path.
 
 ## Anti-patterns
 
-- **Don't set `created_at` or `updated_at` in your application code.** The runtime overwrites them; manual values are silently lost.
-- **Don't store these as strings.** The tag implies epoch-millisecond integers across all runtimes.
-- **Don't rely on `created_at` for tie-breaking equal-version writes.** Use the version field; that's what it's for.
+- **Don't set `created_at` or `updated_at` in your application code.** The runtime owns them; manual values are overwritten or rejected per the contract.
+- **Don't rely on `created_at` for tie-breaking equal-version writes.** Use the version role; that's what it's for.
 
 ## Related
 
 - [Optimistic Locking](optimistic-locking.md) — the `version` field that composes with these timestamps
-- [TTL](ttl.md) — separate timestamp axis governed by its own tag
+- [TTL](ttl.md) — separate timestamp axis governed by its own role
 - [Contract Scenarios](../reference/contract-scenarios.md) — the full lifecycle-timestamps specification

--- a/docs/features/lifecycle-timestamps.md
+++ b/docs/features/lifecycle-timestamps.md
@@ -1,27 +1,22 @@
 ---
 title: Lifecycle Timestamps
-description: created_at and updated_at roles for lifecycle attributes, with runtime-specific automation notes.
+description: created_at and updated_at roles for lifecycle attributes across Go, TypeScript, and Python.
 ---
 
 # Lifecycle Timestamps
 
 `created_at` and `updated_at` are the canonical lifecycle timestamp roles. They
-identify the creation and last-update attributes in the model contract.
+identify the creation and last-update attributes in the model contract. Go,
+TypeScript, and Python populate these fields in their shared P0 write paths:
 
-Current public-runtime behavior is not identical across all generic CRUD APIs:
-
-- **Go** populates lifecycle fields on create and updates `updated_at` on update
-  through the query-builder write paths.
-- **TypeScript** populates `created_at` / `updated_at` on create/save and updates
-  `updated_at` during `TheorydbClient.update`.
-- **Python** currently treats the roles as schema/attribute metadata. `Table.put`
-  serializes the dataclass values supplied by the caller, and `Table.update` does
-  not automatically set `updated_at`.
+- create/save writes populate `created_at` and `updated_at` with the same write
+  timestamp;
+- update writes preserve `created_at` and advance `updated_at`;
+- a failed conditional update does not advance `updated_at`.
 
 The [lifecycle P0 fixture](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/03-lifecycle-created-updated.yml)
-tracks the shared contract shape and expected timestamp ordering, but consumers
-should follow the runtime-specific notes below until Python lifecycle automation
-is implemented in the public `Table` API.
+tracks the shared contract shape and expected timestamp ordering across all
+three runtimes.
 
 ## Go
 
@@ -64,47 +59,40 @@ await db.create('Note', { PK: 'USER#1', SK: 'NOTE#welcome', body: 'Hi.' });
 
 ## Python
 
-Python's `theorydb_field(roles=[...])` maps the lifecycle attributes into the
-model definition, but callers currently provide the values they want stored.
-
 ```python
-from datetime import datetime, timezone
-
-
-def now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
 @dataclass(frozen=True)
 class Note:
-    pk:         str = theorydb_field(roles=["pk"])
-    sk:         str = theorydb_field(roles=["sk"])
+    pk:         str = theorydb_field(name="PK", roles=["pk"])
+    sk:         str = theorydb_field(name="SK", roles=["sk"])
     body:       str = theorydb_field()
-    created_at: str = theorydb_field(roles=["created_at"])
-    updated_at: str = theorydb_field(roles=["updated_at"])
+    created_at: str = theorydb_field(name="createdAt", roles=["created_at"], default="")
+    updated_at: str = theorydb_field(name="updatedAt", roles=["updated_at"], default="")
+    version:    int = theorydb_field(roles=["version"], default=0)
 
 model = ModelDefinition.from_dataclass(Note, table_name="notes_contract")
 table = Table(model, client=client)
 
-created = now_iso()
 table.put(Note(
     pk="USER#1",
     sk="NOTE#welcome",
     body="Hi.",
-    created_at=created,
-    updated_at=created,
 ))
 
-table.update("USER#1", "NOTE#welcome", {"body": "Edited.", "updated_at": now_iso()})
+note = table.get("USER#1", "NOTE#welcome")
+table.update(
+    "USER#1",
+    "NOTE#welcome",
+    {"body": "Edited."},
+    expected_version=note.version,
+)
 ```
 
 ## Composes with optimistic locking
 
-In Go and TypeScript update paths, `updated_at` is populated alongside the
-`version` role on successful versioned writes. A version conflict aborts the
-write — neither version nor `updated_at` advances. In Python, use
-`update_builder(...).add("version", 1).condition_version(...)` and set
-`updated_at` explicitly if you need both fields to advance together.
+On successful versioned writes, `updated_at` advances alongside the `version`
+role. A version conflict aborts the write — neither version nor `updated_at`
+advances. In Python, pass `expected_version=` to `Table.update` for this
+high-level guarded update shape.
 
 ## Composes with TTL
 
@@ -112,8 +100,7 @@ write — neither version nor `updated_at` advances. In Python, use
 
 ## Anti-patterns
 
-- **Don't set `created_at` or `updated_at` manually in Go or TypeScript create/update paths.** Those runtimes own lifecycle fields on those paths.
-- **Don't assume Python `Table.put` or `Table.update` generates lifecycle values today.** Supply explicit values in Python until lifecycle automation is added there.
+- **Don't set `created_at` or `updated_at` manually in high-level create/update paths.** The runtime owns lifecycle fields on those paths.
 - **Don't rely on `created_at` for tie-breaking equal-version writes.** Use the version role; that's what it's for.
 
 ## Related

--- a/docs/features/lifecycle-timestamps.md
+++ b/docs/features/lifecycle-timestamps.md
@@ -1,18 +1,27 @@
 ---
 title: Lifecycle Timestamps
-description: Automatic created_at and updated_at on every write — clock-ordered across all three runtimes.
+description: created_at and updated_at roles for lifecycle attributes, with runtime-specific automation notes.
 ---
 
 # Lifecycle Timestamps
 
-`created_at` and `updated_at` are the canonical lifecycle timestamp roles. The runtime owns them — your code never sets them by hand.
+`created_at` and `updated_at` are the canonical lifecycle timestamp roles. They
+identify the creation and last-update attributes in the model contract.
 
-The [lifecycle-timestamps P0 scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios) verifies that all three runtimes:
+Current public-runtime behavior is not identical across all generic CRUD APIs:
 
-- Set `created_at` on the **first write only**; subsequent writes leave it intact.
-- Update `updated_at` on **every write** (including the first).
-- Use a consistent clock source and unit across runtimes.
-- Preserve clock ordering: a write that follows another write produces an `updated_at` value strictly greater than the predecessor's.
+- **Go** populates lifecycle fields on create and updates `updated_at` on update
+  through the query-builder write paths.
+- **TypeScript** populates `created_at` / `updated_at` on create/save and updates
+  `updated_at` during `TheorydbClient.update`.
+- **Python** currently treats the roles as schema/attribute metadata. `Table.put`
+  serializes the dataclass values supplied by the caller, and `Table.update` does
+  not automatically set `updated_at`.
+
+The [lifecycle P0 fixture](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/03-lifecycle-created-updated.yml)
+tracks the shared contract shape and expected timestamp ordering, but consumers
+should follow the runtime-specific notes below until Python lifecycle automation
+is implemented in the public `Table` API.
 
 ## Go
 
@@ -27,7 +36,7 @@ type Note struct {
 
 n := &Note{PK: "USER#1", SK: "NOTE#welcome", Body: "Hi."}
 db.Model(n).Create()
-// n.CreatedAt and n.UpdatedAt are now populated by the runtime.
+// n.CreatedAt and n.UpdatedAt are populated by the Go runtime.
 ```
 
 ## TypeScript
@@ -48,11 +57,24 @@ const Note = defineModel({
     { attribute: 'updatedAt', type: 'S', roles: ['updated_at'] },
   ],
 });
+
+await db.create('Note', { PK: 'USER#1', SK: 'NOTE#welcome', body: 'Hi.' });
+// createdAt and updatedAt are written by the TypeScript runtime.
 ```
 
 ## Python
 
+Python's `theorydb_field(roles=[...])` maps the lifecycle attributes into the
+model definition, but callers currently provide the values they want stored.
+
 ```python
+from datetime import datetime, timezone
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
 @dataclass(frozen=True)
 class Note:
     pk:         str = theorydb_field(roles=["pk"])
@@ -60,11 +82,29 @@ class Note:
     body:       str = theorydb_field()
     created_at: str = theorydb_field(roles=["created_at"])
     updated_at: str = theorydb_field(roles=["updated_at"])
+
+model = ModelDefinition.from_dataclass(Note, table_name="notes_contract")
+table = Table(model, client=client)
+
+created = now_iso()
+table.put(Note(
+    pk="USER#1",
+    sk="NOTE#welcome",
+    body="Hi.",
+    created_at=created,
+    updated_at=created,
+))
+
+table.update("USER#1", "NOTE#welcome", {"body": "Edited.", "updated_at": now_iso()})
 ```
 
 ## Composes with optimistic locking
 
-`updated_at` is populated alongside the `version` role on every successful write. A version conflict aborts the write — neither version nor `updated_at` advances. This guarantees `updated_at` is monotonic for any item that ever loaded successfully.
+In Go and TypeScript update paths, `updated_at` is populated alongside the
+`version` role on successful versioned writes. A version conflict aborts the
+write — neither version nor `updated_at` advances. In Python, use
+`update_builder(...).add("version", 1).condition_version(...)` and set
+`updated_at` explicitly if you need both fields to advance together.
 
 ## Composes with TTL
 
@@ -72,7 +112,8 @@ class Note:
 
 ## Anti-patterns
 
-- **Don't set `created_at` or `updated_at` in your application code.** The runtime owns them; manual values are overwritten or rejected per the contract.
+- **Don't set `created_at` or `updated_at` manually in Go or TypeScript create/update paths.** Those runtimes own lifecycle fields on those paths.
+- **Don't assume Python `Table.put` or `Table.update` generates lifecycle values today.** Supply explicit values in Python until lifecycle automation is added there.
 - **Don't rely on `created_at` for tie-breaking equal-version writes.** Use the version role; that's what it's for.
 
 ## Related

--- a/docs/features/optimistic-locking.md
+++ b/docs/features/optimistic-locking.md
@@ -5,9 +5,9 @@ description: Version-conditional writes — populated on read, incremented on wr
 
 # Optimistic Locking
 
-The `version` field is TableTheory's optimistic concurrency control. The semantics are simple and pinned by the [optimistic-locking P0 scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios):
+The version role is TableTheory's optimistic concurrency control. The semantics are simple and pinned by the [optimistic-locking P0 scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios):
 
-1. A field tagged `theorydb:"version"` is **populated on read**.
+1. A field tagged with the `version` role is **populated on read**.
 2. On write, the runtime emits a conditional expression: `version = :expected_version` where `:expected_version` is the value loaded on the most recent read.
 3. On a successful write, the runtime **increments the field** in the persisted item.
 4. On a version mismatch (another writer raced ahead), the runtime returns a **typed conflict error** — never a silent overwrite.
@@ -27,15 +27,14 @@ type Counter struct {
 }
 
 var c Counter
-if err := db.Get(ctx, &c, "tenant#42", "counter#impressions"); err != nil {
+if err := db.Model(&Counter{PK: "TENANT#42", SK: "COUNTER#impressions"}).First(&c); err != nil {
     return err
 }
+
 c.Value++
-if err := db.Put(ctx, &c); err != nil {
-    if tabletheory.IsVersionConflict(err) {
-        // Reload, recompute, retry.
-        return retry()
-    }
+if err := db.Model(&c).Update("value"); err != nil {
+    // Version-mismatch is surfaced as a typed error; check via the
+    // pkg/errors helpers (see api-reference.md).
     return err
 }
 ```
@@ -43,34 +42,47 @@ if err := db.Put(ctx, &c); err != nil {
 ## TypeScript
 
 ```typescript
-const c = await db.get(Counter, "tenant#42", "counter#impressions");
-c.value += 1;
+const Counter = defineModel({
+  name: 'Counter',
+  table: { name: 'counters_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort:      { attribute: 'SK', type: 'S' },
+  },
+  attributes: [
+    { attribute: 'PK',      type: 'S', roles: ['pk'] },
+    { attribute: 'SK',      type: 'S', roles: ['sk'] },
+    { attribute: 'value',   type: 'N' },
+    { attribute: 'version', type: 'N', roles: ['version'] },
+  ],
+});
 
-try {
-  await db.put(c);
-} catch (err) {
-  if (TableTheory.isVersionConflict(err)) {
-    return retry();
-  }
-  throw err;
-}
+const key = { PK: 'TENANT#42', SK: 'COUNTER#impressions' };
+const c   = await db.get('Counter', key);
+
+await db.update('Counter', { ...key, value: (c.value as number) + 1 }, ['value']);
 ```
 
 ## Python
 
 ```python
-c = db.get(Counter, "tenant#42", "counter#impressions")
-c.value += 1
+@dataclass(frozen=True)
+class Counter:
+    pk:      str = theorydb_field(roles=["pk"])
+    sk:      str = theorydb_field(roles=["sk"])
+    value:   int = theorydb_field()
+    version: int = theorydb_field(roles=["version"])
 
-try:
-    db.put(c)
-except TableTheory.VersionConflict:
-    return retry()
+model = ModelDefinition.from_dataclass(Counter, table_name="counters_contract")
+table = Table(model, client=client)
+
+c = table.get("TENANT#42", "COUNTER#impressions")
+table.update("TENANT#42", "COUNTER#impressions", value=c.value + 1)
 ```
 
 ## Versioning a newly-created item
 
-The first `Put` of an item that does not yet exist starts at `version = 1`. Subsequent writes increment. A `Put` that asserts `version = 0` against a non-existent item is the contract-defined "create if absent" form.
+The first write of an item that does not yet exist starts at `version = 1`. Subsequent writes increment. A create that asserts `version = 0` against a non-existent item is the contract-defined "create if absent" form.
 
 ## Versioning under transactions
 
@@ -78,9 +90,9 @@ Optimistic locking composes with DynamoDB transactions. A transactional write gr
 
 ## Anti-patterns
 
-- **Don't read with one runtime, write with another, and modify the version field manually in between.** TableTheory is the only thing that should mutate `version`.
+- **Don't read with one runtime, write with another, and mutate the version field manually in between.** TableTheory is the only thing that should mutate the version role.
 - **Don't catch the conflict error and retry indefinitely.** Bound the retry loop. The contract guarantees deterministic loss, not deterministic eventual success.
-- **Don't omit the `version` field from your model and expect "best effort" concurrency.** No `version` tag means no locking — the field is required to opt in.
+- **Don't omit the version role from your model and expect "best effort" concurrency.** No version role means no locking — you opt in by declaring the role on a field.
 
 ## Related
 

--- a/docs/features/optimistic-locking.md
+++ b/docs/features/optimistic-locking.md
@@ -60,7 +60,13 @@ const Counter = defineModel({
 const key = { PK: 'TENANT#42', SK: 'COUNTER#impressions' };
 const c   = await db.get('Counter', key);
 
-await db.update('Counter', { ...key, value: (c.value as number) + 1 }, ['value']);
+// Pass the just-read version through; TheorydbClient.update asserts it
+// matches the persisted item before mutating, and bumps it on success.
+await db.update(
+  'Counter',
+  { ...key, value: (c.value as number) + 1, version: c.version },
+  ['value'],
+);
 ```
 
 ## Python
@@ -77,7 +83,7 @@ model = ModelDefinition.from_dataclass(Counter, table_name="counters_contract")
 table = Table(model, client=client)
 
 c = table.get("TENANT#42", "COUNTER#impressions")
-table.update("TENANT#42", "COUNTER#impressions", value=c.value + 1)
+table.update("TENANT#42", "COUNTER#impressions", {"value": c.value + 1})
 ```
 
 ## Versioning a newly-created item

--- a/docs/features/optimistic-locking.md
+++ b/docs/features/optimistic-locking.md
@@ -1,20 +1,30 @@
 ---
 title: Optimistic Locking
-description: Version-conditional writes — populated on read, incremented on write, guarded across all three runtimes.
+description: Version-conditional writes and update-builder patterns for optimistic concurrency.
 ---
 
 # Optimistic Locking
 
-The version role is TableTheory's optimistic concurrency control. The semantics are simple and pinned by the [optimistic-locking P0 scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios):
+The version role is TableTheory's optimistic concurrency field. The [optimistic-locking P0 scenario](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/04-version-optimistic-lock.yml)
+pins the portable behavior: a write with the current version succeeds and moves
+the persisted item to the next version; a stale-version write fails with a typed
+condition error.
 
-1. A field tagged with the `version` role is **populated on read**.
-2. On write, the runtime emits a conditional expression: `version = :expected_version` where `:expected_version` is the value loaded on the most recent read.
-3. On a successful write, the runtime **increments the field** in the persisted item.
-4. On a version mismatch (another writer raced ahead), the runtime returns a **typed conflict error** — never a silent overwrite.
+Public runtime ergonomics differ slightly:
+
+1. Go and TypeScript high-level update paths add the version condition and bump.
+2. Python callers currently use
+   `update_builder(...).add("version", 1).condition_version(current)` for the
+   same guarded update shape.
+3. On a version mismatch (another writer raced ahead), the write fails — never a silent overwrite.
 
 ## Why this matters
 
-Every Theory Cloud consumer that ships versioned writes — AppTheory's idempotency state, Autheory's session refreshes, theory-mcp-server's agent memory cursor — depends on this behavior being identical across runtimes. A Go writer racing a Python writer must see one of them lose deterministically.
+Every Theory Cloud consumer that ships versioned writes — AppTheory's
+idempotency state, Autheory's session refreshes, theory-mcp-server's agent
+memory cursor — depends on guarded updates being expressed consistently. A Go
+writer racing a Python writer must use the same expected-version value and see
+one of the writes fail deterministically.
 
 ## Go
 
@@ -108,6 +118,6 @@ Optimistic locking composes with DynamoDB transactions. A transactional write gr
 
 ## Related
 
-- [Lifecycle Timestamps](lifecycle-timestamps.md) — automatic `updated_at` populated on every versioned write
+- [Lifecycle Timestamps](lifecycle-timestamps.md) — lifecycle roles and runtime-specific timestamp automation notes
 - [Transactions](transactions.md) — composing versioned writes into atomic groups
 - [Contract Scenarios](../reference/contract-scenarios.md) — the full optimistic-locking specification

--- a/docs/features/optimistic-locking.md
+++ b/docs/features/optimistic-locking.md
@@ -83,12 +83,18 @@ model = ModelDefinition.from_dataclass(Counter, table_name="counters_contract")
 table = Table(model, client=client)
 
 c = table.get("TENANT#42", "COUNTER#impressions")
-table.update("TENANT#42", "COUNTER#impressions", {"value": c.value + 1})
+table.update_builder("TENANT#42", "COUNTER#impressions") \
+    .set("value", c.value + 1) \
+    .add("version", 1) \
+    .condition_version(c.version) \
+    .execute()
 ```
 
 ## Versioning a newly-created item
 
-The first write of an item that does not yet exist starts at `version = 1`. Subsequent writes increment. A create that asserts `version = 0` against a non-existent item is the contract-defined "create if absent" form.
+The first write of an item that does not yet exist starts at `version = 0`.
+Subsequent versioned writes increment the value, so the first successful update
+moves it to `version = 1`.
 
 ## Versioning under transactions
 

--- a/docs/features/optimistic-locking.md
+++ b/docs/features/optimistic-locking.md
@@ -10,13 +10,10 @@ pins the portable behavior: a write with the current version succeeds and moves
 the persisted item to the next version; a stale-version write fails with a typed
 condition error.
 
-Public runtime ergonomics differ slightly:
-
-1. Go and TypeScript high-level update paths add the version condition and bump.
-2. Python callers currently use
-   `update_builder(...).add("version", 1).condition_version(current)` for the
-   same guarded update shape.
-3. On a version mismatch (another writer raced ahead), the write fails — never a silent overwrite.
+Public runtime ergonomics differ slightly, but the shared contract is the same:
+the high-level versioned update path adds the version condition and increments
+the version on success. On a version mismatch (another writer raced ahead), the
+write fails — never a silent overwrite.
 
 ## Why this matters
 
@@ -93,11 +90,12 @@ model = ModelDefinition.from_dataclass(Counter, table_name="counters_contract")
 table = Table(model, client=client)
 
 c = table.get("TENANT#42", "COUNTER#impressions")
-table.update_builder("TENANT#42", "COUNTER#impressions") \
-    .set("value", c.value + 1) \
-    .add("version", 1) \
-    .condition_version(c.version) \
-    .execute()
+table.update(
+    "TENANT#42",
+    "COUNTER#impressions",
+    {"value": c.value + 1},
+    expected_version=c.version,
+)
 ```
 
 ## Versioning a newly-created item

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -30,38 +30,56 @@ TableTheory **does not auto-chunk** transactions across multiple `TransactWriteI
 ## Go
 
 ```go
-// Conditional write composed with peer writes inside a transaction.
-err := db.Transaction(func(tx *core.Tx) error {
-    if err := tx.Model(&fromAcct).Update("balance"); err != nil {
-        return err
-    }
-    if err := tx.Model(&toAcct).Update("balance"); err != nil {
-        return err
-    }
-    return tx.Model(&audit).Create()
+// Conditional writes composed with a peer create inside one TransactWriteItems call.
+err := db.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
+    tx.UpdateWithBuilder(&fromAcct, func(u core.UpdateBuilder) error {
+        u.Set("Balance", fromBal)
+        u.Add("Version", int64(1))
+        u.ConditionVersion(fromVersion)
+        return nil
+    })
+
+    tx.UpdateWithBuilder(&toAcct, func(u core.UpdateBuilder) error {
+        u.Set("Balance", toBal)
+        u.Add("Version", int64(1))
+        u.ConditionVersion(toVersion)
+        return nil
+    })
+
+    tx.Create(&audit)
+    return nil
 })
 ```
 
-> The transaction helper signature is `db.Transaction(func(tx *core.Tx) error) error`. See [`pkg/transaction/`](https://github.com/theory-cloud/tabletheory/tree/main/pkg/transaction) for the canonical Tx API.
+> Use `db.TransactWrite(ctx, func(core.TransactionBuilder) error)` or the
+> fluent `db.Transact()` builder followed by `Execute()` for DynamoDB
+> transactions. The older `db.Transaction(func(*core.Tx) error)` helper is only
+> a compatibility wrapper and is not the canonical full-transaction API.
 
 ## TypeScript
 
 `TheorydbClient.transactWrite(actions: TransactAction[])` accepts a list of
-`{ kind: 'put' | 'update' | 'delete' | 'conditionCheck', model, ... }` actions.
+`{ kind: 'put' | 'update' | 'delete' | 'condition', model, ... }` actions.
+Update actions provide `key` plus either a raw `updateExpression` or an `updateFn`
+that uses the `UpdateBuilder` DSL.
 
 ```typescript
 await db.transactWrite([
   {
     kind: 'update',
     model: 'Account',
-    item: { ...fromKey, balance: fromBal, version: fromVersion },
-    fields: ['balance'],
+    key: fromKey,
+    updateFn: (u) => {
+      u.set('balance', fromBal).add('version', 1).conditionVersion(fromVersion);
+    },
   },
   {
     kind: 'update',
     model: 'Account',
-    item: { ...toKey, balance: toBal, version: toVersion },
-    fields: ['balance'],
+    key: toKey,
+    updateFn: (u) => {
+      u.set('balance', toBal).add('version', 1).conditionVersion(toVersion);
+    },
   },
   {
     kind: 'put',

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -30,39 +30,50 @@ TableTheory **does not auto-chunk** transactions across multiple `TransactWriteI
 ## Go
 
 ```go
-err := db.Transaction(ctx, func(tx *tabletheory.Tx) error {
-    if err := tx.Put(&from); err != nil { return err }
-    if err := tx.Put(&to);   err != nil { return err }
-    return tx.ConditionCheck(&audit, "version = :v", map[string]any{":v": expectedVersion})
+// Conditional write composed with peer writes inside a transaction.
+err := db.Transaction(func(tx *core.Tx) error {
+    if err := tx.Model(&fromAcct).Update("balance"); err != nil {
+        return err
+    }
+    if err := tx.Model(&toAcct).Update("balance"); err != nil {
+        return err
+    }
+    return tx.Model(&audit).Create()
 })
-if tabletheory.IsTransactionAborted(err) {
-    // One of the items had a condition failure; reload and retry.
-}
 ```
+
+> The transaction helper signature is `db.Transaction(func(tx *core.Tx) error) error`. See [`pkg/transaction/`](https://github.com/theory-cloud/tabletheory/tree/main/pkg/transaction) for the canonical Tx API.
 
 ## TypeScript
 
 ```typescript
-await db.transaction(async (tx) => {
-  await tx.put(from);
-  await tx.put(to);
-  await tx.conditionCheck(audit, "version = :v", { ":v": expectedVersion });
-});
+// TypeScript exposes batch + transaction APIs on TheorydbClient. See
+// ts/docs/api-reference.md for the exact surface in the version you
+// installed — the design here matches DynamoDB's TransactWriteItems
+// semantics directly.
+await db.transaction([
+  { op: 'update', model: 'Account', item: { ...fromKey, balance: fromBal }, fields: ['balance'] },
+  { op: 'update', model: 'Account', item: { ...toKey,   balance: toBal   }, fields: ['balance'] },
+  { op: 'create', model: 'Audit',   item: auditItem },
+]);
 ```
 
 ## Python
 
 ```python
-with db.transaction() as tx:
-    tx.put(from_acct)
-    tx.put(to_acct)
-    tx.condition_check(audit, "version = :v", {":v": expected_version})
+# Python exposes transaction helpers on Table / theorydb_py. See
+# py/docs/api-reference.md for the exact form; the underlying
+# DynamoDB call is the same TransactWriteItems.
+with table.transaction() as tx:
+    tx.update("ACCOUNT#A", "v1", balance=from_bal)
+    tx.update("ACCOUNT#B", "v1", balance=to_bal)
+    tx.put(audit_item)
 ```
 
 ## Common patterns
 
-- **Transferring state between two items**: put both with conditional expressions.
-- **Atomic create-if-absent of multiple items**: put each with `attribute_not_exists(pk)`.
+- **Transferring state between two items**: update both with conditional expressions.
+- **Atomic create-if-absent of multiple items**: create each with `attribute_not_exists(pk)`.
 - **Composite invariants across a parent and its children**: condition-check the parent's version while writing children atomically.
 
 ## Anti-patterns

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -1,11 +1,11 @@
 ---
 title: Transactions
-description: Real DynamoDB TransactWriteItems / TransactGetItems — composed with the rest of the contract.
+description: Real DynamoDB TransactWriteItems — composed with the rest of the contract.
 ---
 
 # Transactions
 
-TableTheory transactions use the actual DynamoDB transaction APIs — `TransactWriteItems` and `TransactGetItems`. There is no app-level lock, no optimistic-concurrency-over-HTTP simulation, and no hidden retry sleep loop.
+This page documents TableTheory's public write-transaction surfaces, which use the actual DynamoDB `TransactWriteItems` API. There is no app-level lock, no optimistic-concurrency-over-HTTP simulation, and no hidden retry sleep loop.
 
 ## What a transaction guarantees
 
@@ -13,19 +13,24 @@ TableTheory transactions use the actual DynamoDB transaction APIs — `TransactW
 - **Condition evaluation** is server-side: each write item carries its own conditional expression, and a single failed condition aborts the whole transaction.
 - **Optimistic-lock composition**: a versioned item in the group asserts its expected version; a version mismatch aborts the transaction atomically.
 - **Encryption composition**: encrypted fields are encrypted before the transaction is submitted; a KMS failure aborts before any write hits DynamoDB.
-- **Cross-runtime parity**: a transaction submitted from Python sees the same atomicity guarantees as one submitted from Go.
+- **Cross-runtime parity**: a write transaction submitted from Python sees the same atomicity guarantees as one submitted from Go.
 
-## DynamoDB transaction limits to know
+## Write transaction limits to know
 
-| Limit                                     | Value         |
-|-------------------------------------------|---------------|
-| Items per `TransactWriteItems`            | 100           |
-| Items per `TransactGetItems`              | 100           |
-| Maximum total payload size                | 4 MB          |
-| Items addressed across multiple tables    | allowed       |
-| Same item appearing twice in one call     | not allowed   |
+| Limit                                             | Value / behavior                            |
+|---------------------------------------------------|---------------------------------------------|
+| DynamoDB `TransactWriteItems` item limit           | 100 items per service call                  |
+| Go `core.TransactionBuilder` operation cap         | 25 operations in the current public builder |
+| TypeScript `TheorydbClient.transactWrite` cap      | DynamoDB enforces service-call limits       |
+| Python `Table.transact_write` action cap           | 100 actions                                 |
+| Maximum DynamoDB transaction payload size          | 4 MB                                        |
+| Items addressed across multiple tables             | allowed by DynamoDB                         |
+| Same item appearing twice in one call              | not allowed by DynamoDB                     |
 
-TableTheory **does not auto-chunk** transactions across multiple `TransactWriteItems` calls — that would silently break atomicity. If you exceed the 100-item or 4 MB limit, the runtime returns a typed error and you redesign the access pattern.
+TableTheory **does not auto-chunk** write transactions across multiple
+`TransactWriteItems` calls — that would silently break atomicity. If you exceed
+the runtime guard or DynamoDB service limit, redesign the access pattern instead
+of splitting one logical transaction into multiple calls.
 
 ## Go
 

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -46,29 +46,56 @@ err := db.Transaction(func(tx *core.Tx) error {
 
 ## TypeScript
 
+`TheorydbClient.transactWrite(actions: TransactAction[])` accepts a list of
+`{ kind: 'put' | 'update' | 'delete' | 'conditionCheck', model, ... }` actions.
+
 ```typescript
-// TypeScript exposes batch + transaction APIs on TheorydbClient. See
-// ts/docs/api-reference.md for the exact surface in the version you
-// installed — the design here matches DynamoDB's TransactWriteItems
-// semantics directly.
-await db.transaction([
-  { op: 'update', model: 'Account', item: { ...fromKey, balance: fromBal }, fields: ['balance'] },
-  { op: 'update', model: 'Account', item: { ...toKey,   balance: toBal   }, fields: ['balance'] },
-  { op: 'create', model: 'Audit',   item: auditItem },
+await db.transactWrite([
+  {
+    kind: 'update',
+    model: 'Account',
+    item: { ...fromKey, balance: fromBal, version: fromVersion },
+    fields: ['balance'],
+  },
+  {
+    kind: 'update',
+    model: 'Account',
+    item: { ...toKey, balance: toBal, version: toVersion },
+    fields: ['balance'],
+  },
+  {
+    kind: 'put',
+    model: 'Audit',
+    item: auditItem,
+    ifNotExists: true,
+  },
 ]);
 ```
 
+See [`ts/src/transaction.ts`](https://github.com/theory-cloud/tabletheory/blob/main/ts/src/transaction.ts) for the full `TransactAction` shape.
+
 ## Python
 
+`Table.transact_write(actions)` accepts a list of dataclass actions —
+`TransactPut`, `TransactUpdate`, `TransactDelete`, `TransactConditionCheck` — all importable from `theorydb_py`.
+
 ```python
-# Python exposes transaction helpers on Table / theorydb_py. See
-# py/docs/api-reference.md for the exact form; the underlying
-# DynamoDB call is the same TransactWriteItems.
-with table.transaction() as tx:
-    tx.update("ACCOUNT#A", "v1", balance=from_bal)
-    tx.update("ACCOUNT#B", "v1", balance=to_bal)
-    tx.put(audit_item)
+from theorydb_py import TransactPut, TransactUpdate
+
+table.transact_write([
+    TransactUpdate(
+        pk="ACCOUNT#A", sk="v1",
+        updates={"balance": from_bal},
+    ),
+    TransactUpdate(
+        pk="ACCOUNT#B", sk="v1",
+        updates={"balance": to_bal},
+    ),
+    TransactPut(item=audit_item),
+])
 ```
+
+See [`py/src/theorydb_py/transaction.py`](https://github.com/theory-cloud/tabletheory/blob/main/py/src/theorydb_py/transaction.py) for the full action-dataclass shapes.
 
 ## Common patterns
 

--- a/docs/features/ttl.md
+++ b/docs/features/ttl.md
@@ -1,16 +1,23 @@
 ---
 title: TTL
-description: DynamoDB TimeToLive — set per-item, honored on reads, identical across all three runtimes.
+description: DynamoDB TimeToLive attributes — persisted as epoch seconds; deletion remains DynamoDB-eventual.
 ---
 
 # TTL
 
-The `ttl` role marks an attribute as the DynamoDB TimeToLive value. The [TTL P0 scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios) pins these guarantees:
+The `ttl` role marks the attribute that DynamoDB Time To Live should use for
+item expiration. The [TTL P0 scenario](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/05-ttl-epoch-seconds.yml)
+pins the portable persistence contract:
 
-- The tagged field's value (epoch seconds) becomes the item's `TimeToLive` attribute.
-- Expired items return a typed not-found error on read, never an item with stale data.
+- The tagged field's value is stored as a numeric DynamoDB attribute.
+- The unit is **epoch seconds**, not milliseconds.
 - The TTL attribute name matches the DMS-declared shape.
-- Cross-runtime: an item written with TTL by Go is honored by Python and TypeScript reads identically.
+- A value written by one runtime is read back with the same value and DynamoDB
+  number type by the other runtimes.
+
+TableTheory does **not** currently mask physically present expired items at read
+time. If DynamoDB has not yet swept the item, `get` / `First` / `Table.get` can
+still return it.
 
 ## Unit: epoch seconds
 
@@ -67,14 +74,22 @@ class Session:
 
 ## DynamoDB's TTL behavior
 
-DynamoDB does not delete TTL-expired items immediately — its sweep is **eventually consistent**, often within 48 hours. TableTheory **does not paper over this** at the runtime level; it instead enforces the more important guarantee: that an expired item, even if still physically present in the table, **does not return data on a read**. Queries and scans may still observe physical expired items briefly; consumers that need strict expiration semantics should layer that in application code.
+DynamoDB does not delete TTL-expired items immediately — its sweep is
+**eventually consistent**, often within 48 hours. TableTheory configures and
+persists the TTL attribute, but the current read paths do not add an expiration
+filter and do not convert still-present expired items into typed not-found
+errors.
 
-This conservative posture is part of the design — TableTheory does not hide DynamoDB's actual behavior, it just ensures consumers don't accidentally use stale data.
+Consumers that need strict read-time expiration must include that check in their
+access pattern, for example by comparing the TTL field to the current epoch
+seconds after reading or by adding an explicit condition/filter where the access
+pattern allows it.
 
 ## Anti-patterns
 
 - **Don't use milliseconds in the TTL field.** DynamoDB will treat them as far-future values and never expire.
 - **Don't rely on instant deletion.** TTL is eventually consistent at the DynamoDB layer.
+- **Don't assume TableTheory hides physically present expired items.** Current reads return the item DynamoDB returns.
 - **Don't combine `ttl` with `omit_empty` for a field that may legitimately be unset.** An expired-or-missing TTL value disables the expiration semantics — that's a separate access-pattern problem.
 
 ## Related

--- a/docs/features/ttl.md
+++ b/docs/features/ttl.md
@@ -5,22 +5,16 @@ description: DynamoDB TimeToLive — set per-item, honored on reads, identical a
 
 # TTL
 
-`theorydb:"ttl"` marks an attribute as the DynamoDB TimeToLive value. The [TTL P0 scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios) pins these guarantees:
+The `ttl` role marks an attribute as the DynamoDB TimeToLive value. The [TTL P0 scenario](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios) pins these guarantees:
 
 - The tagged field's value (epoch seconds) becomes the item's `TimeToLive` attribute.
-- Expired items return a typed "not found" error on `Get`, never an item with stale data.
-- The TTL attribute name matches the configured naming strategy.
+- Expired items return a typed not-found error on read, never an item with stale data.
+- The TTL attribute name matches the DMS-declared shape.
 - Cross-runtime: an item written with TTL by Go is honored by Python and TypeScript reads identically.
 
-## Important note on units
+## Unit: epoch seconds
 
-DynamoDB's TTL attribute is **epoch seconds**, not milliseconds. This is the one place TableTheory's clock unit differs from lifecycle timestamps (which are milliseconds).
-
-| Tag                       | Unit            |
-|---------------------------|-----------------|
-| `theorydb:"created_at"`   | Epoch ms        |
-| `theorydb:"updated_at"`   | Epoch ms        |
-| `theorydb:"ttl"`          | Epoch **seconds** |
+DynamoDB's TTL attribute is **epoch seconds**, not milliseconds. This is the one place TableTheory's clock unit may differ from your application's wall clock — be careful at the boundary.
 
 ## Go
 
@@ -29,47 +23,51 @@ type Session struct {
     PK        string `theorydb:"pk"  json:"pk"`
     SK        string `theorydb:"sk"  json:"sk"`
     UserID    string `json:"user_id"`
-
     ExpiresAt int64  `theorydb:"ttl" json:"expires_at"` // epoch seconds
 }
 
 s := &Session{
-    PK:        "tenant#42",
-    SK:        "session#abc",
-    UserID:    "user#1",
+    PK:        "TENANT#42",
+    SK:        "SESSION#abc",
+    UserID:    "USER#1",
     ExpiresAt: time.Now().Add(15 * time.Minute).Unix(),
 }
-_ = db.Put(ctx, s)
+db.Model(s).Create()
 ```
 
 ## TypeScript
 
 ```typescript
-@model({ naming: "snake_case", table: "sessions" })
-class Session {
-  @field({ role: "pk" }) pk!: string;
-  @field({ role: "sk" }) sk!: string;
-  @field() user_id!: string;
-
-  @field({ role: "ttl" }) expires_at!: number; // epoch seconds
-}
+const Session = defineModel({
+  name: 'Session',
+  table: { name: 'sessions_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort:      { attribute: 'SK', type: 'S' },
+  },
+  attributes: [
+    { attribute: 'PK',        type: 'S', roles: ['pk'] },
+    { attribute: 'SK',        type: 'S', roles: ['sk'] },
+    { attribute: 'userId',    type: 'S' },
+    { attribute: 'expiresAt', type: 'N', roles: ['ttl'] }, // epoch seconds
+  ],
+});
 ```
 
 ## Python
 
 ```python
-@model(naming="snake_case", table="sessions")
+@dataclass(frozen=True)
 class Session:
-    pk: str
-    sk: str
-    user_id: str
-
-    expires_at: int = field(role="ttl")  # epoch seconds
+    pk:         str = theorydb_field(roles=["pk"])
+    sk:         str = theorydb_field(roles=["sk"])
+    user_id:    str = theorydb_field()
+    expires_at: int = theorydb_field(roles=["ttl"])  # epoch seconds
 ```
 
 ## DynamoDB's TTL behavior
 
-DynamoDB does not delete TTL-expired items immediately — its sweep is **eventually consistent**, often within 48 hours. TableTheory **does not paper over this** at the runtime level; it instead enforces the more important guarantee: that an expired item, even if still physically present in the table, **does not return data on a `Get`**. Queries and scans may still observe physical expired items briefly; consumers that need strict expiration semantics should layer that in application code.
+DynamoDB does not delete TTL-expired items immediately — its sweep is **eventually consistent**, often within 48 hours. TableTheory **does not paper over this** at the runtime level; it instead enforces the more important guarantee: that an expired item, even if still physically present in the table, **does not return data on a read**. Queries and scans may still observe physical expired items briefly; consumers that need strict expiration semantics should layer that in application code.
 
 This conservative posture is part of the design — TableTheory does not hide DynamoDB's actual behavior, it just ensures consumers don't accidentally use stale data.
 
@@ -77,10 +75,10 @@ This conservative posture is part of the design — TableTheory does not hide Dy
 
 - **Don't use milliseconds in the TTL field.** DynamoDB will treat them as far-future values and never expire.
 - **Don't rely on instant deletion.** TTL is eventually consistent at the DynamoDB layer.
-- **Don't combine `theorydb:"ttl"` with `theorydb:"omitempty"`** for a field that may legitimately be unset. An expired-or-missing TTL value disables the expiration semantics — that's a separate access-pattern problem.
+- **Don't combine `ttl` with `omit_empty` for a field that may legitimately be unset.** An expired-or-missing TTL value disables the expiration semantics — that's a separate access-pattern problem.
 
 ## Related
 
-- [Lifecycle Timestamps](lifecycle-timestamps.md) — separate axis, milliseconds, set on every write
+- [Lifecycle Timestamps](lifecycle-timestamps.md) — separate axis governed by its own roles
 - [FaceTheory · TTL Cache Patterns](../facetheory/ttl-cache-patterns.md) — how FaceTheory uses TTL for ISR cache eviction
 - [Contract Scenarios](../reference/contract-scenarios.md) — the full TTL specification

--- a/docs/reference/contract-scenarios.md
+++ b/docs/reference/contract-scenarios.md
@@ -1,49 +1,82 @@
 ---
 title: Contract Scenarios
-description: The P0 specification — the executable contract every runtime is verified against on every commit.
+description: The P0 specification — executable scenarios for supported runtime capabilities.
 ---
 
 # Contract Scenarios
 
-The contract scenarios are TableTheory's **executable specification**. Each scenario is authored language-neutrally and run against every runtime (Go, TypeScript, Python) using a shared DynamoDB Local instance. A scenario that passes in one runtime and fails in another is a parity regression — never a "runtime-specific quirk."
+The contract scenarios are TableTheory's **executable specification**. Each
+scenario is authored language-neutrally and run against the runtimes that declare
+support for that capability using shared DynamoDB Local infrastructure. A
+scenario that passes in one supported runtime and fails in another is a parity
+regression — never a "runtime-specific quirk."
 
-Scenarios live in [`contract-tests/scenarios/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios) with runners under [`contract-tests/runners/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/runners) and shared infrastructure (DynamoDB Local) in [`contract-tests/docker-compose.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/docker-compose.yml).
+Scenarios live in [`contract-tests/scenarios/p0/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/scenarios/p0)
+with runners under [`contract-tests/runners/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/runners)
+and shared infrastructure in [`contract-tests/docker-compose.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/docker-compose.yml).
 
 ## The P0 scenarios
 
-The current P0 set — five scenarios that pin the foundation of every Theory Cloud consumer's persistence layer:
+The current P0 directory contains these scenarios:
 
-### 1. CRUD
+| File | Behavior pinned |
+|------|-----------------|
+| [`01-crud-basic.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/01-crud-basic.yml) | Create / read / update / delete against a single-table model with composite keys. |
+| [`02-omitempty.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/02-omitempty.yml) | How zero values are handled when `omitempty` is present vs absent. |
+| [`03-lifecycle-created-updated.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/03-lifecycle-created-updated.yml) | Persisted `createdAt` / `updatedAt` shape and update ordering in the contract fixture. |
+| [`04-version-optimistic-lock.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/04-version-optimistic-lock.yml) | Versioned update succeeds once, then stale-version update fails with a typed condition error. |
+| [`05-ttl-epoch-seconds.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/05-ttl-epoch-seconds.yml) | TTL role persists a numeric epoch-seconds attribute and reads it back unchanged. |
+| [`06-release-state-write-policy.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/06-release-state-write-policy.yml) | Release-state write-policy enforcement. |
+| [`07-release-state-protected-fields.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/07-release-state-protected-fields.yml) | Release-state protected-field enforcement. |
+| [`08-release-state-transactional-transition.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/08-release-state-transactional-transition.yml) | Release-state transition append performed transactionally. |
+| [`09-release-state-provenance-confidence.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/09-release-state-provenance-confidence.yml) | Release-state deploy-authority provenance and confidence validation. |
 
-The bedrock. Create / read / update / delete against a single-table model with composite keys. Verifies that all three runtimes produce identical DynamoDB items for identical inputs and read them back identically.
+### CRUD
+
+The bedrock. Create / read / update / delete against a single-table model with
+composite keys. Verifies that supported runtimes produce compatible DynamoDB
+items for identical inputs and read them back identically.
 
 See: [Features · CRUD & Marshaling](../features/crud.md)
 
-### 2. Omit-empty
+### Omit-empty
 
-How zero values (`""`, `0`, `False`, empty collections) are handled when `theorydb:"omitempty"` is present vs absent. Every type variant in the matrix is exercised across all three runtimes.
+How zero values (`""`, `0`, `False`, empty collections) are handled when
+`theorydb:"omitempty"` is present vs absent. Every type variant in the matrix is
+exercised across supported runtimes.
 
-### 3. Lifecycle timestamps
+### Lifecycle timestamps
 
-Automatic population of `created_at` and `updated_at` on write operations, with clock ordering semantics consistent across runtimes. Verifies the unit (epoch ms), the "set once on create / set every write on update" semantics, and the monotonicity guarantee.
+The lifecycle fixture pins the persisted `createdAt` / `updatedAt` fields and
+the ordering expectation after an update. Public runtime automation is not
+currently uniform across all generic CRUD APIs: Go and TypeScript write paths
+generate lifecycle values, while Python `Table.put` and `Table.update` serialize
+caller-provided values. See the feature page for runtime-specific guidance.
 
 See: [Features · Lifecycle Timestamps](../features/lifecycle-timestamps.md)
 
-### 4. Optimistic locking
+### Optimistic locking
 
-The `version` field populated on read, incremented on write, conditional-expression-guarded against concurrent writers, with consistent typed error types when a version mismatch occurs.
+The `version` field is populated on read, incremented on versioned write, and
+conditional-expression-guarded against concurrent writers, with consistent typed
+error behavior when a version mismatch occurs.
 
 See: [Features · Optimistic Locking](../features/optimistic-locking.md)
 
-### 5. TTL
+### TTL
 
-The `ttl` tag producing a DynamoDB TimeToLive attribute, with consistent units (epoch seconds), consistent expiration behavior, and consistent post-expiration read semantics (expired item ⇒ typed "not found" error).
+The TTL fixture pins the `ttl` role as a numeric epoch-seconds attribute. It does
+not assert read-time masking of still-present expired items. DynamoDB TTL deletion
+is eventual, and current read paths return any item DynamoDB physically returns.
 
 See: [Features · TTL](../features/ttl.md)
 
 ## How P0 grows
 
-P0 scenarios grow only through deliberate `extend-contract-scenarios` work that runs all three runtimes against the new scenario *before* adding it to the P0 set. New shapes incubate in P1/P2 status — important but not yet frozen — until they pass cross-runtime in three consecutive releases.
+P0 scenarios grow only through deliberate `extend-contract-scenarios` work that
+runs the supported runtimes against the new scenario *before* adding it to the P0
+set. New shapes incubate in P1/P2 status — important but not yet frozen — until
+they pass cross-runtime in three consecutive releases.
 
 ## How a scenario is run
 
@@ -52,17 +85,24 @@ P0 scenarios grow only through deliberate `extend-contract-scenarios` work that 
 cd contract-tests
 docker compose up -d
 
-# Run scenarios across all three runtimes
+# Run scenarios across all supported runners
 make contract-tests          # or: bash contract-tests/run-all.sh
 ```
 
-Locally and in CI, the runners share the same DynamoDB Local instance, ensuring that "the Go runtime wrote it" and "the Python runtime read it" are exercised against literally the same persisted items.
+Locally and in CI, the runners share the same DynamoDB Local instance, ensuring
+that "the Go runtime wrote it" and "another runtime read it" are exercised
+against literally the same persisted items when the scenario requires that shape.
 
 ## Why this is the arbiter
 
-When runtimes disagree, the contract scenario is the deciding evidence. There is no Go reference runtime; there is no TypeScript reference runtime. There is the scenario, and there are three peers that pass it (or one of them is broken).
+When runtimes disagree for a supported scenario, the contract scenario is the
+deciding evidence. There is no Go reference runtime; there is no TypeScript
+reference runtime. There is the scenario, and there are peers that pass it (or
+one of them is broken).
 
-A change that makes one runtime convenient at the cost of breaking a scenario in another runtime is a refusal by default — the scenarios are the load-bearing surface of the framework.
+A change that makes one runtime convenient at the cost of breaking a scenario in
+another runtime is a refusal by default — the scenarios are the load-bearing
+surface of the framework.
 
 ## Related
 

--- a/docs/reference/contract-scenarios.md
+++ b/docs/reference/contract-scenarios.md
@@ -48,10 +48,9 @@ exercised across supported runtimes.
 ### Lifecycle timestamps
 
 The lifecycle fixture pins the persisted `createdAt` / `updatedAt` fields and
-the ordering expectation after an update. Public runtime automation is not
-currently uniform across all generic CRUD APIs: Go and TypeScript write paths
-generate lifecycle values, while Python `Table.put` and `Table.update` serialize
-caller-provided values. See the feature page for runtime-specific guidance.
+the ordering expectation after an update. Go, TypeScript, and Python all execute
+this shared P0 fixture and generate lifecycle values on the high-level write
+paths used by the scenario.
 
 See: [Features · Lifecycle Timestamps](../features/lifecycle-timestamps.md)
 

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -5,64 +5,68 @@ description: TableTheory for Go — installation, Lambda init, and the canonical
 
 # Go runtime
 
-TableTheory's Go runtime is the root module at `github.com/theory-cloud/tabletheory`. It targets the AWS SDK for Go v2, is pinned to the toolchain declared in `go.mod`, and is the runtime the rest of the Theory Cloud stack consumes by default.
+TableTheory's Go runtime is the root module at `github.com/theory-cloud/tabletheory`. It targets the AWS SDK for Go v2 and uses the toolchain pinned in `go.mod`.
+
+The Go runtime is the reference for cross-runtime contract parity, but it is **not** a "reference implementation that TypeScript and Python port" — all three runtimes pass the same P0 contract scenarios independently.
 
 ## Install
 
-```bash
-go get github.com/theory-cloud/tabletheory
-```
-
-Pin to a specific release tag for reproducibility:
+TableTheory is distributed exclusively through immutable [GitHub Releases](https://github.com/theory-cloud/tabletheory/releases). Pin to a specific release tag:
 
 ```bash
-go get github.com/theory-cloud/tabletheory@v1.x.y
+go get github.com/theory-cloud/tabletheory@vX.Y.Z
 ```
 
-Releases are published as immutable [GitHub Releases](https://github.com/theory-cloud/tabletheory/releases). Never depend on a moving `latest`.
+Never depend on a moving `latest`.
 
 ## Lambda init
 
-`tabletheory.LambdaInit` is the blessed entry point. Construct once at cold start, reuse across invocations:
+`tabletheory.NewLambdaOptimized()` is the blessed cold-start entry point. Construct once at module init, reuse across invocations:
 
 ```go
 package main
 
 import (
-    "context"
+    "log"
 
     "github.com/aws/aws-lambda-go/lambda"
     "github.com/theory-cloud/tabletheory"
 )
 
 type Note struct {
-    _  struct{} `theorydb:"naming:snake_case"`
-    PK string   `theorydb:"pk"       json:"pk"`
-    SK string   `theorydb:"sk"       json:"sk"`
-
-    Body      string `theorydb:"omitempty"   json:"body,omitempty"`
-    Version   int64  `theorydb:"version"     json:"version"`
-    CreatedAt int64  `theorydb:"created_at"  json:"created_at"`
-    UpdatedAt int64  `theorydb:"updated_at"  json:"updated_at"`
+    PK   string `theorydb:"pk" json:"pk"`
+    SK   string `theorydb:"sk" json:"sk"`
+    Body string `json:"body"`
 }
 
-var db = tabletheory.LambdaInit(context.Background(),
-    tabletheory.WithTable("notes"),
-    tabletheory.WithModels(&Note{}),
-)
+var db *tabletheory.LambdaDB
 
-func handler(ctx context.Context, evt Note) error {
-    return db.Put(ctx, &evt)
+func init() {
+    var err error
+    db, err = tabletheory.NewLambdaOptimized()
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+
+func handler() error {
+    return db.Model(&Note{
+        PK:   "USER#42",
+        SK:   "NOTE#welcome",
+        Body: "Hello, Theory Cloud.",
+    }).Create()
 }
 
 func main() { lambda.Start(handler) }
 ```
 
-> Constructing the client inside the handler — rather than at module scope — defeats Lambda's connection reuse and burns ~50 ms per cold invocation. `LambdaInit` exists specifically to make the right pattern the easiest one.
+> Construct the client at module init, not inside the handler. Lambda reuses module-scope state across warm invocations; rebuilding the client per request burns ~50 ms each cold start.
+
+`tabletheory.LambdaInit(models ...any) (*LambdaDB, error)` exists as the lower-level variant if you want to register specific model types explicitly at cold start. Most consumers should prefer `NewLambdaOptimized()` and use `db.Model(&Foo{})` per request.
 
 ## Model shape
 
-A TableTheory Go model is an ordinary struct decorated with the `theorydb:` tag vocabulary:
+A TableTheory Go model is an ordinary struct decorated with the `theorydb:` tag vocabulary alongside matching `json:` tags:
 
 | Tag                        | Purpose                                                      |
 |----------------------------|--------------------------------------------------------------|
@@ -75,9 +79,32 @@ A TableTheory Go model is an ordinary struct decorated with the `theorydb:` tag 
 | `theorydb:"updated_at"`    | Lifecycle timestamp populated on every write                 |
 | `theorydb:"ttl"`           | DynamoDB TimeToLive attribute                                |
 | `theorydb:"omitempty"`     | Omit attribute when the field is the zero value              |
-| `theorydb:"naming:…"`      | Apply naming strategy via the leading `_ struct{}` field     |
 
-Every `theorydb` tag must be accompanied by a matching `json` tag (see [Development guidelines](https://theory-cloud.github.io/tabletheory/development-guidelines/)).
+Every `theorydb` tag is accompanied by a matching `json` tag per the [Development guidelines](https://theory-cloud.github.io/tabletheory/development-guidelines/).
+
+## CRUD via the Query builder
+
+The query builder is reached through `db.Model(&model)`:
+
+```go
+// Create
+db.Model(&Note{PK: "USER#42", SK: "NOTE#welcome", Body: "Hi."}).Create()
+
+// Read (use First with a destination)
+var got Note
+db.Model(&Note{PK: "USER#42", SK: "NOTE#welcome"}).First(&got)
+
+// Update selected fields
+db.Model(&Note{PK: "USER#42", SK: "NOTE#welcome", Body: "Updated."}).Update("body")
+
+// Delete
+db.Model(&Note{PK: "USER#42", SK: "NOTE#welcome"}).Delete()
+
+// Conditional create — fails if the key already exists
+db.Model(&Note{PK: "USER#42", SK: "NOTE#welcome"}).IfNotExists().Create()
+```
+
+For a full working program covering conditional helpers, batches, transactions, and streams, see [`examples/feature_spotlight.go`](https://github.com/theory-cloud/tabletheory/blob/main/examples/feature_spotlight.go).
 
 ## Where to go next
 
@@ -89,4 +116,4 @@ Every `theorydb` tag must be accompanied by a matching `json` tag (see [Developm
 
 ## Stability and support
 
-The Go runtime is **GA** (post-1.0) and the reference for cross-runtime contract parity. Breaking changes follow [semver](https://semver.org/) and are coordinated with downstream Theory Cloud products. See [Contract Scenarios](../reference/contract-scenarios.md) for the P0 specification all three runtimes are verified against.
+The Go runtime is **GA** (post-1.0). Breaking changes follow [semver](https://semver.org/) and are coordinated with downstream Theory Cloud products and the TypeScript and Python runtimes — never in isolation.

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -7,7 +7,9 @@ description: TableTheory for Go — installation, Lambda init, and the canonical
 
 TableTheory's Go runtime is the root module at `github.com/theory-cloud/tabletheory`. It targets the AWS SDK for Go v2 and uses the toolchain pinned in `go.mod`.
 
-The Go runtime is the reference for cross-runtime contract parity, but it is **not** a "reference implementation that TypeScript and Python port" — all three runtimes pass the same P0 contract scenarios independently.
+The Go runtime is a peer implementation of the shared contract — not a
+reference implementation that TypeScript and Python port. Contract parity is
+established by the shared scenarios, not by treating one runtime as canonical.
 
 ## Install
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -79,6 +79,7 @@ For a complete working program, see [`py/docs/getting-started.md`](https://githu
 table.put(note)
 note = table.get(pk, sk)                            # raises NotFoundError on miss
 table.update(pk, sk, {"body": "updated"})           # third arg is a Mapping[str, Any]
+table.update(pk, sk, {"body": "guarded"}, expected_version=note.version)  # versioned write
 table.delete(pk, sk)
 
 # Composite updates use update_builder for set/remove/add chains.
@@ -90,7 +91,7 @@ table.update_builder(pk, sk).set("body", "updated").execute()
 - `uv --directory py run ruff format --check .` — format verification
 - `uv --directory py run ruff check .` — lint using the `py/pyproject.toml` line length of 110
 - `uv --directory py run mypy src` — typecheck
-- `uv --directory py run pytest -q` — pytest suite
+- `uv --directory py run pytest -q tests/unit` — unit pytest suite
 - `uv --directory py run pytest -q tests/integration` — integration tests with DynamoDB Local
 - Exercised against shared contract scenarios via [`contract-tests/runners/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/runners) on every commit
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -5,7 +5,7 @@ description: TableTheory for Python — installation, ModelDefinition + Table + 
 
 # Python runtime
 
-The Python runtime lives under [`py/`](https://github.com/theory-cloud/tabletheory/tree/main/py) and is distributed as the wheel `theorydb_py`. It targets **Python 3.14** and the AWS SDK for Python (`boto3`).
+The Python runtime lives under [`py/`](https://github.com/theory-cloud/tabletheory/tree/main/py) and is published as the wheel `tabletheory_py-X.Y.Z-py3-none-any.whl`. The importable module inside that wheel is **`theorydb_py`** — the wheel asset name and the importable package name differ. It targets **Python 3.14** and the AWS SDK for Python (`boto3`).
 
 The Python runtime is a **peer** implementation of the TableTheory contract — not a port. It passes the same P0 contract scenarios as Go and TypeScript independently.
 
@@ -16,14 +16,14 @@ This repo does **not** publish to PyPI. GitHub Releases are the source of truth.
 ```bash
 # Stable release (replace X.Y.Z)
 pip install \
-  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theorydb_py-X.Y.Z-py3-none-any.whl
+  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/tabletheory_py-X.Y.Z-py3-none-any.whl
 
 # Prerelease (replace X.Y.Z-rc.N — PEP 440 form: vX.Y.Z-rc.N tag → X.Y.ZrcN wheel)
 pip install \
-  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z-rc.N/theorydb_py-X.Y.ZrcN-py3-none-any.whl
+  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z-rc.N/tabletheory_py-X.Y.ZrcN-py3-none-any.whl
 ```
 
-The **importable module name is `theorydb_py`**, not `tabletheory_py`. The release wheel filename follows the same module name.
+The **release wheel asset** is `tabletheory_py-X.Y.Z-py3-none-any.whl`; the **importable module** inside that wheel is `theorydb_py`. Use `from theorydb_py import …` in your application code.
 
 ## ModelDefinition + Table
 
@@ -57,7 +57,7 @@ For a complete working program, see [`py/docs/getting-started.md`](https://githu
 
 ## Role vocabulary
 
-`theorydb_field(roles=[…], encrypted=…, omit_empty=…)` maps one-to-one onto the canonical TableTheory contract:
+`theorydb_field(roles=[…], encrypted=…, omitempty=…)` maps one-to-one onto the canonical TableTheory contract:
 
 | Go tag                       | Python field arg                          |
 |------------------------------|-------------------------------------------|
@@ -69,7 +69,7 @@ For a complete working program, see [`py/docs/getting-started.md`](https://githu
 | `theorydb:"created_at"`      | `theorydb_field(roles=["created_at"])`    |
 | `theorydb:"updated_at"`      | `theorydb_field(roles=["updated_at"])`    |
 | `theorydb:"ttl"`             | `theorydb_field(roles=["ttl"])`           |
-| `theorydb:"omitempty"`       | `theorydb_field(omit_empty=True)`         |
+| `theorydb:"omitempty"`       | `theorydb_field(omitempty=True)`         |
 
 ## CRUD methods
 
@@ -77,12 +77,12 @@ For a complete working program, see [`py/docs/getting-started.md`](https://githu
 
 ```python
 table.put(note)
-note = table.get(pk, sk)                       # raises NotFound on miss
-table.update(pk, sk, body="updated")
+note = table.get(pk, sk)                            # raises ItemNotFound on miss
+table.update(pk, sk, {"body": "updated"})           # third arg is a Mapping[str, Any]
 table.delete(pk, sk)
 
-# Composite updates use the update_builder helper for set/remove/add/delete.
-table.update_builder(pk, sk).set("body", "updated").commit()
+# Composite updates use update_builder for set/remove/add chains.
+table.update_builder(pk, sk).set("body", "updated").execute()
 ```
 
 ## Workflows

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -77,7 +77,7 @@ For a complete working program, see [`py/docs/getting-started.md`](https://githu
 
 ```python
 table.put(note)
-note = table.get(pk, sk)                            # raises ItemNotFound on miss
+note = table.get(pk, sk)                            # raises NotFoundError on miss
 table.update(pk, sk, {"body": "updated"})           # third arg is a Mapping[str, Any]
 table.delete(pk, sk)
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -87,8 +87,11 @@ table.update_builder(pk, sk).set("body", "updated").execute()
 
 ## Workflows
 
-- `cd py && python -m unittest` — full unit suite (stdlib `unittest`)
-- `cd py && ruff check --line-length 120 .` — lint
+- `uv --directory py run ruff format --check .` — format verification
+- `uv --directory py run ruff check .` — lint using the `py/pyproject.toml` line length of 110
+- `uv --directory py run mypy src` — typecheck
+- `uv --directory py run pytest -q` — pytest suite
+- `uv --directory py run pytest -q tests/integration` — integration tests with DynamoDB Local
 - Exercised against shared contract scenarios via [`contract-tests/runners/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/runners) on every commit
 
 ## Where to go next

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -1,82 +1,102 @@
 ---
 title: Python
-description: TableTheory for Python — installation, Lambda init, and the canonical model shape.
+description: TableTheory for Python — installation, ModelDefinition + Table + theorydb_field.
 ---
 
 # Python runtime
 
-The Python runtime lives under [`py/`](https://github.com/theory-cloud/tabletheory/tree/main/py) and is distributed as `tabletheory-py` / `theorydb_py`. It targets **Python 3.14** and the AWS SDK for Python (boto3).
+The Python runtime lives under [`py/`](https://github.com/theory-cloud/tabletheory/tree/main/py) and is distributed as the wheel `theorydb_py`. It targets **Python 3.14** and the AWS SDK for Python (`boto3`).
 
-Like the TypeScript runtime, Python is a **peer implementation** of the TableTheory contract — not a port. It passes the same P0 contract scenarios as Go and TypeScript or it is broken.
+The Python runtime is a **peer** implementation of the TableTheory contract — not a port. It passes the same P0 contract scenarios as Go and TypeScript independently.
 
 ## Install
 
-Distributed via immutable [GitHub Releases](https://github.com/theory-cloud/tabletheory/releases) — install the release wheel/sdist:
+This repo does **not** publish to PyPI. GitHub Releases are the source of truth. Install the release wheel directly:
 
 ```bash
-# Download the wheel from a GitHub Release, then:
-pip install ./tabletheory_py-1.x.y-py3-none-any.whl
+# Stable release (replace X.Y.Z)
+pip install \
+  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theorydb_py-X.Y.Z-py3-none-any.whl
+
+# Prerelease (replace X.Y.Z-rc.N — PEP 440 form: vX.Y.Z-rc.N tag → X.Y.ZrcN wheel)
+pip install \
+  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z-rc.N/theorydb_py-X.Y.ZrcN-py3-none-any.whl
 ```
 
-There is **no** PyPI publish. Distribution is GitHub Releases only across all three runtimes.
+The **importable module name is `theorydb_py`**, not `tabletheory_py`. The release wheel filename follows the same module name.
 
-## Lambda init
+## ModelDefinition + Table
+
+The Python public surface declares models as plain dataclasses with `theorydb_field()` defaults, then registers them via `ModelDefinition.from_dataclass()`. CRUD runs through a `Table` instance.
 
 ```python
-from tabletheory_py import TableTheory, model, field
+from dataclasses import dataclass
 
-@model(naming="snake_case", table="notes")
+import boto3
+from theorydb_py import ModelDefinition, Table, theorydb_field
+
+
+@dataclass(frozen=True)
 class Note:
-    pk: str = field(role="pk")
-    sk: str = field(role="sk")
+    pk:   str = theorydb_field(roles=["pk"])
+    sk:   str = theorydb_field(roles=["sk"])
+    body: str = theorydb_field()
 
-    body: str | None = field(omitempty=True, default=None)
 
-    version:    int = field(role="version")
-    created_at: int = field(role="created_at")
-    updated_at: int = field(role="updated_at")
+client = boto3.client("dynamodb", region_name="us-east-1")
+model  = ModelDefinition.from_dataclass(Note, table_name="notes_contract")
+table  = Table(model, client=client)
 
-# Module scope — reused across Lambda invocations.
-db = TableTheory.lambda_init(
-    table="notes",
-    models=[Note],
-)
+table.put(Note(pk="USER#42", sk="NOTE#welcome", body="Hello, Theory Cloud."))
 
-def handler(event, _context):
-    db.put(Note(**event))
+note = table.get("USER#42", "NOTE#welcome")
+table.delete("USER#42", "NOTE#welcome")
 ```
 
-> Always construct the client at module scope. The `lambda_init` entry point exists so the connection, the model registry, and the KMS configuration are built once and reused — moving any of those into the handler defeats the whole purpose.
+For a complete working program, see [`py/docs/getting-started.md`](https://github.com/theory-cloud/tabletheory/blob/main/py/docs/getting-started.md).
 
-## Tag vocabulary mapping
+## Role vocabulary
 
-Python uses `field(...)` descriptors that map one-to-one onto the canonical `theorydb:` tag vocabulary.
+`theorydb_field(roles=[…], encrypted=…, omit_empty=…)` maps one-to-one onto the canonical TableTheory contract:
 
-| Go tag                       | Python field arg                    |
-|------------------------------|-------------------------------------|
-| `theorydb:"pk"`              | `field(role="pk")`                  |
-| `theorydb:"sk"`              | `field(role="sk")`                  |
-| `theorydb:"gsi1pk"`          | `field(role="gsi1pk")`              |
-| `theorydb:"encrypted"`       | `field(encrypted=True)`             |
-| `theorydb:"version"`         | `field(role="version")`             |
-| `theorydb:"created_at"`      | `field(role="created_at")`          |
-| `theorydb:"updated_at"`      | `field(role="updated_at")`          |
-| `theorydb:"ttl"`             | `field(role="ttl")`                 |
-| `theorydb:"omitempty"`       | `field(omitempty=True)`             |
-| `theorydb:"naming:snake_case"` | `@model(naming="snake_case")`     |
+| Go tag                       | Python field arg                          |
+|------------------------------|-------------------------------------------|
+| `theorydb:"pk"`              | `theorydb_field(roles=["pk"])`            |
+| `theorydb:"sk"`              | `theorydb_field(roles=["sk"])`            |
+| `theorydb:"gsi1pk"`          | `theorydb_field(roles=["gsi1pk"])`        |
+| `theorydb:"encrypted"`       | `theorydb_field(encrypted=True)`          |
+| `theorydb:"version"`         | `theorydb_field(roles=["version"])`       |
+| `theorydb:"created_at"`      | `theorydb_field(roles=["created_at"])`    |
+| `theorydb:"updated_at"`      | `theorydb_field(roles=["updated_at"])`    |
+| `theorydb:"ttl"`             | `theorydb_field(roles=["ttl"])`           |
+| `theorydb:"omitempty"`       | `theorydb_field(omit_empty=True)`         |
+
+## CRUD methods
+
+`Table` exposes the canonical CRUD surface:
+
+```python
+table.put(note)
+note = table.get(pk, sk)                       # raises NotFound on miss
+table.update(pk, sk, body="updated")
+table.delete(pk, sk)
+
+# Composite updates use the update_builder helper for set/remove/add/delete.
+table.update_builder(pk, sk).set("body", "updated").commit()
+```
 
 ## Workflows
 
 - `cd py && python -m unittest` — full unit suite (stdlib `unittest`)
 - `cd py && ruff check --line-length 120 .` — lint
-- The Python runtime is exercised against shared contract scenarios via [`contract-tests/runners/py/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/runners) on every commit
+- Exercised against shared contract scenarios via [`contract-tests/runners/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/runners) on every commit
 
 ## Where to go next
 
-- [Getting Started](../getting-started.md) — full walkthrough
-- [Struct Definition Guide](../struct-definition-guide.md) — model authoring
+- [Getting Started](https://theory-cloud.github.io/tabletheory/getting-started/) — full walkthrough
+- [`py/docs/getting-started.md`](https://github.com/theory-cloud/tabletheory/blob/main/py/docs/getting-started.md) — Python-specific runtime documentation
+- [`py/docs/api-reference.md`](https://github.com/theory-cloud/tabletheory/blob/main/py/docs/api-reference.md) — full Python API reference
 - [Features → CRUD & Marshaling](../features/crud.md), [Optimistic Locking](../features/optimistic-locking.md), [Encryption](../features/encryption.md)
-- [`py/docs/`](https://github.com/theory-cloud/tabletheory/tree/main/py/docs) on GitHub — Python-specific runtime documentation
 
 ## Stability and support
 

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -73,7 +73,7 @@ Every `role` accepted by `defineModel` attributes maps one-to-one onto the canon
 | `theorydb:"pk"`              | `roles: ['pk']`                             |
 | `theorydb:"sk"`              | `roles: ['sk']`                             |
 | `theorydb:"gsi1pk"`          | `roles: ['gsi1pk']` + `indexes:`            |
-| `theorydb:"encrypted"`       | `encrypted: true`                           |
+| `theorydb:"encrypted"`       | `encryption: { v: 1 }`                      |
 | `theorydb:"version"`         | `roles: ['version']`                        |
 | `theorydb:"created_at"`      | `roles: ['created_at']`                     |
 | `theorydb:"updated_at"`      | `roles: ['updated_at']`                     |

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -97,8 +97,10 @@ const page = await db.query('Note').partitionKey('USER#42').limit(20).page();
 
 ## Workflows
 
-- `cd ts && npm run check` — lint, typecheck, and full TypeScript test suite
-- `cd ts && npm test` — Jest unit tests
+- `cd ts && npm run format:check` — Prettier verification
+- `cd ts && npm run lint && npm run typecheck && npm run build` — CI static checks
+- `cd ts && npm run test:unit` — unit tests
+- `cd ts && npm run test:integration` — integration tests with DynamoDB Local
 - Exercised against shared contract scenarios via [`contract-tests/runners/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/runners) on every commit
 
 ## Where to go next

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -1,87 +1,113 @@
 ---
 title: TypeScript
-description: TableTheory for TypeScript — installation, Lambda init, and the canonical model shape.
+description: TableTheory for TypeScript — installation, defineModel + TheorydbClient.
 ---
 
 # TypeScript runtime
 
-The TypeScript runtime lives under [`ts/`](https://github.com/theory-cloud/tabletheory/tree/main/ts) and is published as `@theory-cloud/tabletheory-ts`. It targets **Node.js 24** and the AWS SDK for JavaScript v3.
+The TypeScript runtime lives under [`ts/`](https://github.com/theory-cloud/tabletheory/tree/main/ts) and is distributed as `@theory-cloud/tabletheory-ts`. It targets **Node.js 24** and the AWS SDK for JavaScript v3.
 
 The TypeScript runtime is a **peer**, not a port: it implements the same P0 contract scenarios as Go and Python, and a behavior that passes the Go contract test but fails in TypeScript is a parity regression — never a "TypeScript-specific quirk."
 
 ## Install
 
-TableTheory is distributed exclusively through immutable [GitHub Releases](https://github.com/theory-cloud/tabletheory/releases). For TypeScript that means installing the `npm pack` release asset, not from npm:
+This repo does **not** publish to npm. GitHub Releases are the source of truth. Install the release tarball directly:
 
 ```bash
-# Download the release asset from GitHub Releases, then:
-npm install --save-dev ./theory-cloud-tabletheory-ts-1.x.y.tgz
+# Stable release (replace X.Y.Z)
+npm install --save-exact \
+  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theory-cloud-tabletheory-ts-X.Y.Z.tgz
+
+# Prerelease (replace X.Y.Z-rc.N)
+npm install --save-exact \
+  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z-rc.N/theory-cloud-tabletheory-ts-X.Y.Z-rc.N.tgz
 ```
 
-There is **no** npm registry publish. The single distribution path is deliberate — it keeps version drift between language registries impossible and aligns with TableTheory's immutable-release discipline.
+The single distribution path is deliberate — it makes version drift between language registries impossible.
 
-## Lambda init
+## defineModel + TheorydbClient
+
+The TypeScript public surface is **explicit**: models are declared via `defineModel({ … })` (no decorators), and operations run through a `TheorydbClient` instance.
 
 ```typescript
-import { TableTheory, model, field } from "@theory-cloud/tabletheory-ts";
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { TheorydbClient, defineModel } from '@theory-cloud/tabletheory-ts';
 
-@model({ naming: "snake_case", table: "notes" })
-class Note {
-  @field({ role: "pk" }) pk!: string;
-  @field({ role: "sk" }) sk!: string;
-
-  @field({ omitempty: true }) body?: string;
-
-  @field({ role: "version" })    version!: number;
-  @field({ role: "created_at" }) created_at!: number;
-  @field({ role: "updated_at" }) updated_at!: number;
-}
-
-// At module scope — reused across Lambda invocations.
-const db = await TableTheory.lambdaInit({
-  table:  "notes",
-  models: [Note],
+const Note = defineModel({
+  name: 'Note',
+  table: { name: 'notes_contract' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort:      { attribute: 'SK', type: 'S' },
+  },
+  attributes: [
+    { attribute: 'PK',        type: 'S', roles: ['pk'] },
+    { attribute: 'SK',        type: 'S', roles: ['sk'] },
+    { attribute: 'body',      type: 'S', optional: true, omit_empty: true },
+    { attribute: 'createdAt', type: 'S', roles: ['created_at'] },
+    { attribute: 'updatedAt', type: 'S', roles: ['updated_at'] },
+    { attribute: 'version',   type: 'N', roles: ['version'] },
+  ],
 });
 
-export const handler = async (evt: Note) => {
-  await db.put(new Note(evt));
-};
+const ddb = new DynamoDBClient({ region: 'us-east-1' });
+const db  = new TheorydbClient(ddb).register(Note);
+
+await db.create('Note', {
+  PK:   'USER#42',
+  SK:   'NOTE#welcome',
+  body: 'Hello, Theory Cloud.',
+});
+
+const item = await db.get('Note', { PK: 'USER#42', SK: 'NOTE#welcome' });
 ```
 
-> Construct the client at module scope, not inside the handler. Lambda reuses the module-scope state across warm invocations; rebuilding the client per-request costs ~50 ms each cold start.
+For a complete working program (model + GSI + create + query + update + delete + cursor pagination), see [`ts/examples/local.ts`](https://github.com/theory-cloud/tabletheory/blob/main/ts/examples/local.ts).
 
-## Tag vocabulary mapping
+## Role vocabulary
 
-TypeScript uses decorators that map one-to-one onto the canonical `theorydb:` tag vocabulary used in Go and Python.
+Every `role` accepted by `defineModel` attributes maps one-to-one onto the canonical TableTheory contract:
 
-| Go tag                       | TypeScript decorator              |
-|------------------------------|-----------------------------------|
-| `theorydb:"pk"`              | `@field({ role: "pk" })`          |
-| `theorydb:"sk"`              | `@field({ role: "sk" })`          |
-| `theorydb:"gsi1pk"`          | `@field({ role: "gsi1pk" })`      |
-| `theorydb:"encrypted"`       | `@field({ encrypted: true })`     |
-| `theorydb:"version"`         | `@field({ role: "version" })`     |
-| `theorydb:"created_at"`      | `@field({ role: "created_at" })`  |
-| `theorydb:"updated_at"`      | `@field({ role: "updated_at" })`  |
-| `theorydb:"ttl"`             | `@field({ role: "ttl" })`         |
-| `theorydb:"omitempty"`       | `@field({ omitempty: true })`     |
-| `theorydb:"naming:snake_case"` | `@model({ naming: "snake_case" })` |
+| Go tag                       | TypeScript role / option                    |
+|------------------------------|---------------------------------------------|
+| `theorydb:"pk"`              | `roles: ['pk']`                             |
+| `theorydb:"sk"`              | `roles: ['sk']`                             |
+| `theorydb:"gsi1pk"`          | `roles: ['gsi1pk']` + `indexes:`            |
+| `theorydb:"encrypted"`       | `encrypted: true`                           |
+| `theorydb:"version"`         | `roles: ['version']`                        |
+| `theorydb:"created_at"`      | `roles: ['created_at']`                     |
+| `theorydb:"updated_at"`      | `roles: ['updated_at']`                     |
+| `theorydb:"ttl"`             | `roles: ['ttl']`                            |
+| `theorydb:"omitempty"`       | `omit_empty: true`                          |
 
-Naming strategy is declared on `@model`, not per-field — same as Go's sentinel `_ struct{}` convention.
+Naming strategy is implied by how you declare each attribute's name — the explicit shape of `defineModel` means no separate "naming strategy" decoration is needed.
+
+## CRUD methods
+
+`TheorydbClient` exposes the canonical CRUD surface:
+
+```typescript
+await db.create('Note', { … });
+const item = await db.get('Note', key);
+await db.update('Note', { … }, ['body']);
+await db.delete('Note', key);
+
+const page = await db.query('Note').partitionKey('USER#42').limit(20).page();
+```
 
 ## Workflows
 
 - `cd ts && npm run check` — lint, typecheck, and full TypeScript test suite
 - `cd ts && npm test` — Jest unit tests
-- The TypeScript runtime is exercised against shared contract scenarios via [`contract-tests/runners/ts/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/runners) on every commit
+- Exercised against shared contract scenarios via [`contract-tests/runners/`](https://github.com/theory-cloud/tabletheory/tree/main/contract-tests/runners) on every commit
 
 ## Where to go next
 
-- [Getting Started](../getting-started.md) — full walkthrough
-- [Struct Definition Guide](../struct-definition-guide.md) — model authoring
+- [Getting Started](https://theory-cloud.github.io/tabletheory/getting-started/) — full walkthrough
+- [`ts/docs/getting-started.md`](https://github.com/theory-cloud/tabletheory/blob/main/ts/docs/getting-started.md) — TypeScript-specific runtime documentation
+- [`ts/docs/api-reference.md`](https://github.com/theory-cloud/tabletheory/blob/main/ts/docs/api-reference.md) — full TypeScript API reference
 - [Features → CRUD & Marshaling](../features/crud.md), [Optimistic Locking](../features/optimistic-locking.md), [Encryption](../features/encryption.md)
-- [`ts/docs/`](https://github.com/theory-cloud/tabletheory/tree/main/ts/docs) on GitHub — TypeScript-specific runtime documentation
 
 ## Stability and support
 
-The TypeScript runtime is **GA**. Breaking changes follow [semver](https://semver.org/) and ship coordinated with the Go and Python runtimes — never in isolation.
+The TypeScript runtime is **GA**. Versions are aligned with Go and Python per the multi-language version-sync invariant. Breaking changes ship coordinated with the other two runtimes — never in isolation.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -152,7 +152,7 @@ npm --prefix ts run test:integration
 
 ```bash
 make docker-up
-uv --directory py run pytest -q
+uv --directory py run pytest -q tests/integration
 ```
 
 ### Go integration tests

--- a/py/docs/development-guidelines.md
+++ b/py/docs/development-guidelines.md
@@ -17,7 +17,7 @@ From the repo root:
 - Typecheck: `uv --directory py run mypy src`
 - Lint: `uv --directory py run ruff check`
 - Format check: `uv --directory py run ruff format --check`
-- Unit tests + coverage: `uv --directory py run pytest -q`
+- Unit tests: `uv --directory py run pytest -q tests/unit`
 - Build wheel/sdist: `uv --directory py run python -m build`
 
 ## Coding Standards

--- a/py/docs/getting-started.md
+++ b/py/docs/getting-started.md
@@ -19,17 +19,17 @@ This repo does **not** publish to PyPI. GitHub Releases are the source of truth.
 
 ```bash
 pip install \
-  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theorydb_py-X.Y.Z-py3-none-any.whl
+  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/tabletheory_py-X.Y.Z-py3-none-any.whl
 ```
 
 **Prerelease (replace `X.Y.Z-rc.N`):**
 
 Python packages use PEP 440 prerelease formatting. Example: Git tag `v1.2.1-rc.1` becomes Python version `1.2.1rc1`,
-so the wheel name is `theorydb_py-1.2.1rc1-...whl`.
+so the wheel name is `tabletheory_py-1.2.1rc1-...whl`.
 
 ```bash
 pip install \
-  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z-rc.N/theorydb_py-X.Y.ZrcN-py3-none-any.whl
+  https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z-rc.N/tabletheory_py-X.Y.ZrcN-py3-none-any.whl
 ```
 
 ### Option B: Develop from source (this monorepo)

--- a/py/docs/testing-guide.md
+++ b/py/docs/testing-guide.md
@@ -31,7 +31,7 @@ From repo root:
 
 ```bash
 make docker-up
-uv --directory py run pytest -q
+uv --directory py run pytest -q tests/integration
 ```
 
 Environment variables (typical for local):

--- a/py/docs/troubleshooting.md
+++ b/py/docs/troubleshooting.md
@@ -28,5 +28,5 @@ client = boto3.client(
 
 **Cause:** Python follows PEP 440 prerelease normalization.
 
-**Solution:** use the wheel filename from the GitHub Release asset list (e.g., `theorydb_py-1.2.1rc1-...whl`).
+**Solution:** use the wheel filename from the GitHub Release asset list (e.g., `tabletheory_py-1.2.1rc1-...whl`).
 

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -4,6 +4,7 @@ import os
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import MISSING, fields, is_dataclass
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, cast, get_args, get_origin
 
@@ -91,6 +92,11 @@ def _backoff_seconds(attempt: int) -> float:
     return seconds
 
 
+def _now_rfc3339_nano() -> str:
+    now = datetime.now(UTC)
+    return now.strftime("%Y-%m-%dT%H:%M:%S") + f".{now.microsecond:06d}000Z"
+
+
 def _chunked[T](items: Sequence[T], size: int) -> Sequence[Sequence[T]]:
     if size <= 0:
         raise ValueError("size must be > 0")
@@ -107,6 +113,7 @@ class Table[T]:
         kms_key_arn: str | None = None,
         kms_client: Any | None = None,
         rand_bytes: Callable[[int], bytes] | None = None,
+        now: Callable[[], str] | None = None,
     ) -> None:
         if table_name is None:
             table_name = model.table_name
@@ -119,6 +126,7 @@ class Table[T]:
         self._kms_key_arn = (kms_key_arn or "").strip() or None
         self._kms_client: Any | None = kms_client
         self._rand_bytes = rand_bytes or os.urandom
+        self._now = now or _now_rfc3339_nano
         self._serializer = TypeSerializer()
         self._deserializer = TypeDeserializer()
 
@@ -145,6 +153,7 @@ class Table[T]:
             kms_key_arn=self._kms_key_arn,
             kms_client=self._kms_client,
             rand_bytes=self._rand_bytes,
+            now=self._now,
         )
 
     def _attribute_storage_type(self, attr_def: AttributeDefinition) -> str:
@@ -883,6 +892,7 @@ class Table[T]:
         expression_attribute_names: Mapping[str, str] | None = None,
         expression_attribute_values: Mapping[str, Any] | None = None,
         protected_attributes: Sequence[str] = (),
+        expected_version: int | None = None,
     ) -> T:
         req = self._build_update_request(
             pk,
@@ -892,6 +902,7 @@ class Table[T]:
             expression_attribute_names=expression_attribute_names,
             expression_attribute_values=expression_attribute_values,
             protected_attributes=protected_attributes,
+            expected_version=expected_version,
             return_values="ALL_NEW",
         )
 
@@ -920,6 +931,7 @@ class Table[T]:
         expression_attribute_names: Mapping[str, str] | None = None,
         expression_attribute_values: Mapping[str, Any] | None = None,
         protected_attributes: Sequence[str] = (),
+        expected_version: int | None = None,
         return_values: str | None = None,
     ) -> dict[str, Any]:
         key = self._to_key(pk, sk)
@@ -943,6 +955,12 @@ class Table[T]:
                 return set(value)
             return {value}
 
+        version_attr = self._attribute_by_role("version")
+        updated_at_attr = self._attribute_by_role("updated_at")
+
+        if expected_version is not None and version_attr is None:
+            raise ValidationError("model does not define a version field")
+
         for field_name, value in updates.items():
             if field_name not in self._model.attributes:
                 raise ValidationError(f"unknown field: {field_name}")
@@ -950,6 +968,12 @@ class Table[T]:
                 self._model.sk is not None and field_name == self._model.sk.python_name
             ):
                 raise ValidationError(f"cannot update key field: {field_name}")
+            if (
+                expected_version is not None
+                and version_attr is not None
+                and field_name == version_attr.python_name
+            ):
+                raise ValidationError(f"do not include version in update fields: {field_name}")
 
             attr_def = self._model.attributes[field_name]
             name_ref = f"#d_{field_name}"
@@ -987,6 +1011,22 @@ class Table[T]:
             update_values[value_ref] = self._serialize_attr_value(attr_def, value)
             set_parts.append(f"{name_ref} = {value_ref}")
 
+        if updated_at_attr is not None and updated_at_attr.python_name not in updates:
+            update_names["#d_updated_at"] = updated_at_attr.attribute_name
+            update_values[":d_updated_at"] = self._serialize_attr_value(updated_at_attr, self._now())
+            set_parts.insert(0, "#d_updated_at = :d_updated_at")
+
+        version_condition: str | None = None
+        if expected_version is not None and version_attr is not None:
+            update_names["#d_version"] = version_attr.attribute_name
+            update_values[":d_expected_version"] = self._serialize_attr_value(
+                version_attr,
+                expected_version,
+            )
+            update_values[":d_version_increment"] = self._serializer.serialize(1)
+            add_parts.append("#d_version :d_version_increment")
+            version_condition = "#d_version = :d_expected_version"
+
         expr_parts: list[str] = []
         if set_parts:
             expr_parts.append("SET " + ", ".join(set_parts))
@@ -1007,8 +1047,12 @@ class Table[T]:
             req["ExpressionAttributeValues"] = update_values
         if return_values is not None:
             req["ReturnValues"] = return_values
-        if condition_expression:
+        if condition_expression and version_condition:
+            req["ConditionExpression"] = f"({condition_expression}) AND {version_condition}"
+        elif condition_expression:
             req["ConditionExpression"] = condition_expression
+        elif version_condition:
+            req["ConditionExpression"] = version_condition
 
         if expression_attribute_names:
             for k, v in expression_attribute_names.items():
@@ -1071,8 +1115,15 @@ class Table[T]:
             raise ValidationError("item must be a dataclass instance")
 
         out: dict[str, Any] = {}
+        now: str | None = None
         for field_name, attr_def in self._model.attributes.items():
             value = getattr(item, field_name)
+            if "created_at" in attr_def.roles or "updated_at" in attr_def.roles:
+                if now is None:
+                    now = self._now()
+                value = now
+            elif "version" in attr_def.roles and _is_empty(value):
+                value = 0
             if attr_def.omitempty and _is_empty(value):
                 continue
             out[attr_def.attribute_name] = self._serialize_attr_value(attr_def, value)
@@ -1083,6 +1134,12 @@ class Table[T]:
             raise ValidationError("missing sk")
 
         return out
+
+    def _attribute_by_role(self, role: str) -> AttributeDefinition | None:
+        for attr_def in self._model.attributes.values():
+            if role in attr_def.roles:
+                return attr_def
+        return None
 
     def _to_key(self, pk: Any, sk: Any | None) -> dict[str, Any]:
         if pk is None:

--- a/py/tests/unit/test_table_unit_behaviors.py
+++ b/py/tests/unit/test_table_unit_behaviors.py
@@ -26,6 +26,16 @@ class Item:
     note: str = theorydb_field(name="note", omitempty=True, default="")
 
 
+@dataclass(frozen=True)
+class LifecycleItem:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    value: int = theorydb_field(name="value")
+    created_at: str = theorydb_field(name="createdAt", roles=["created_at"], default="")
+    updated_at: str = theorydb_field(name="updatedAt", roles=["updated_at"], default="")
+    version: int | None = theorydb_field(name="version", roles=["version"], default=None)
+
+
 class _StubClient:
     def __init__(self) -> None:
         self.put_reqs: list[dict] = []
@@ -134,6 +144,43 @@ def test_table_put_get_delete_update_happy_path_and_validation() -> None:
     stub.set_update_attrs(None)
     with pytest.raises(ValidationError, match="did not return Attributes"):
         table.update("A", "1", {"value": 3})
+
+
+def test_table_populates_lifecycle_fields_and_initial_version() -> None:
+    model = ModelDefinition.from_dataclass(LifecycleItem, table_name="tbl")
+    table: Table[LifecycleItem] = Table(
+        model, client=_StubClient(), now=lambda: "2026-05-28T00:00:00.000000000Z"
+    )
+
+    item = table._to_item(LifecycleItem(pk="A", sk="1", value=1))
+
+    assert item["createdAt"] == {"S": "2026-05-28T00:00:00.000000000Z"}
+    assert item["updatedAt"] == {"S": "2026-05-28T00:00:00.000000000Z"}
+    assert item["version"] == {"N": "0"}
+
+
+def test_table_update_expected_version_sets_lifecycle_and_lock() -> None:
+    model = ModelDefinition.from_dataclass(LifecycleItem, table_name="tbl")
+    table: Table[LifecycleItem] = Table(
+        model, client=_StubClient(), now=lambda: "2026-05-28T00:00:01.000000000Z"
+    )
+
+    req = table._build_update_request(
+        "A",
+        "1",
+        {"value": 2},
+        expected_version=0,
+        return_values="ALL_NEW",
+    )
+
+    assert req["ConditionExpression"] == "#d_version = :d_expected_version"
+    assert "SET #d_updated_at = :d_updated_at, #d_value = :d_value" in req["UpdateExpression"]
+    assert "ADD #d_version :d_version_increment" in req["UpdateExpression"]
+    assert req["ExpressionAttributeNames"]["#d_updated_at"] == "updatedAt"
+    assert req["ExpressionAttributeNames"]["#d_version"] == "version"
+    assert req["ExpressionAttributeValues"][":d_updated_at"] == {"S": "2026-05-28T00:00:01.000000000Z"}
+    assert req["ExpressionAttributeValues"][":d_expected_version"] == {"N": "0"}
+    assert req["ExpressionAttributeValues"][":d_version_increment"] == {"N": "1"}
 
 
 def test_table_key_and_update_request_validation_errors() -> None:


### PR DESCRIPTION
Follow-up to PR #218 (now merged).

A post-merge review found that the new Pages content pages documented APIs that don't exist in any runtime and install commands that contradict the repo's GitHub-Releases-only distribution model. The fix could not land in #218 before it merged, so it's here as a separate PR.

## Blocking findings from the #218 review (all addressed)

### 1. Install commands corrected to GitHub Releases

| Runtime | Was | Now |
|---|---|---|
| Go | `go get github.com/theory-cloud/tabletheory@vX.Y.Z` (unchanged) | unchanged |
| **TS** | ❌ `npm install --save-dev @theory-cloud/tabletheory-ts` | ✅ `npm install --save-exact https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/theory-cloud-tabletheory-ts-X.Y.Z.tgz` |
| **Py** | ❌ `pip install tabletheory-py` | ✅ `pip install https://github.com/theory-cloud/tabletheory/releases/download/vX.Y.Z/tabletheory_py-X.Y.Z-py3-none-any.whl` |

Matches `ts/docs/getting-started.md` and `py/docs/getting-started.md`.

### 2. Go API corrected

Removed the fabricated `tabletheory.LambdaInit(ctx, WithTable, WithModels)` pattern. Now documents the actual surface from `tabletheory.go` + `pkg/core/interfaces.go`:

- Cold-start init: `tabletheory.NewLambdaOptimized()` or `tabletheory.LambdaInit(models ...any)` (variadic, no Config/Option types).
- CRUD: `db.Model(&x).Create() / .First(&dest) / .Update("field") / .Delete()` (query-builder chain).
- Transactions: `db.TransactWrite(ctx, func(core.TransactionBuilder) error)` / `db.Transact()` for public write transactions.
- Go runtime docs now describe Go as a peer implementation, not a reference runtime.

### 3. TypeScript API corrected

Removed the fabricated `@model({...}) class X { @field(...) ... }` decorator pattern. Now documents the actual surface from `ts/src/index.ts`:

- `defineModel({ name, table, keys, attributes, indexes? })` declarative shape.
- `new TheorydbClient(ddb).register(Model)` + `db.create/get/update/delete('ModelName', …)`.
- `transactWrite` actions use the real `kind: 'put' | 'update' | 'delete' | 'condition'` shape; update actions use `key` plus `updateExpression` or `updateFn`.
- Workflow docs use real scripts: `format:check`, `lint`, `typecheck`, `build`, `test:unit`, and `test:integration`.

### 4. Python API corrected

Fixed the package/import distinction: release wheel assets are `tabletheory_py-...whl`, while the importable module is **`theorydb_py`**. Removed the fabricated `@model` / `@field` decorator pattern. Now documents the actual surface from `py/src/theorydb_py/__init__.py`:

- `from theorydb_py import ModelDefinition, Table, theorydb_field`
- `ModelDefinition.from_dataclass(Note, table_name="…")` + `Table(model, client=client)`.
- CRUD: `table.put/get/update/delete(…)`.
- Optimistic-locking examples now use `Table.update(..., expected_version=current)` for the high-level guarded update path.
- Workflow docs use `uv --directory py run ...` with pytest and the `py/pyproject.toml` Ruff line length of 110.

### 5. Transaction docs narrowed to supported write surfaces

The Transactions feature page now documents public write transactions backed by `TransactWriteItems`; it no longer overclaims `TransactGetItems` support or a uniform 100-action cap. It calls out the current Go `core.TransactionBuilder` cap of 25 operations, Python's 100-action guard, and DynamoDB service limits.

### 6. TTL, lifecycle, and scenario docs aligned to implemented behavior

- TTL docs now say TableTheory persists/configures the TTL attribute but does **not** mask physically present expired items on reads; DynamoDB deletion remains eventual.
- Lifecycle docs now describe the shared Go/TypeScript/Python P0 behavior after Python lifecycle automation landed.
- Optimistic-locking docs now describe Python `Table.update(..., expected_version=...)` guarded updates.
- Contract scenario links now point at `contract-tests/scenarios/p0/*.yml`, and the reference page reflects the current 9 P0 fixtures instead of stale 5-scenario wording.

### 7. Python now executes the shared P0 fixture suite

The review found that Python had targeted contract tests but no runner executing every `contract-tests/scenarios/p0/*.yml` fixture. This PR now adds `contract-tests/runners/py/test_contract_p0.py`, which loads the same DMS models and all 9 P0 YAML scenarios against DynamoDB Local.

Runtime parity fixes included with that runner:

- `Table.put` / `Table.save` populate `created_at`, `updated_at`, and initial `version = 0` for Python dataclass models with those roles.
- `Table.update(..., expected_version=current)` adds the version condition, increments the version, and advances `updated_at` atomically on success.
- Python P0 capabilities now include CRUD, omit-empty, lifecycle timestamps, optimistic locking, TTL epoch-seconds, and the release-state scenarios.

### 8. git diff --check trailing whitespace fixed

- `README.md:81` — markdown soft-break trailing spaces removed
- `docs/assets/svg/{icon,icon-mono-light,wordmark-theory-cloud}.svg` — whitespace stripped; SVG XML still parses cleanly.

## Files touched

- `docs/_data/runtimes.yml` — landing-page tabs (highest visibility)
- `docs/_config.yml` — `tabletheory.runtimes` block
- `docs/runtimes/{go,typescript,python}.md`
- `docs/features/{crud,optimistic-locking,lifecycle-timestamps,ttl,encryption,transactions}.md`
- `docs/reference/contract-scenarios.md` — current P0 fixture links and behavior summaries
- `contract-tests/runners/py/test_contract_p0.py` — Python runner for all shared P0 YAML fixtures
- `py/src/theorydb_py/table.py` — Python lifecycle and optimistic-locking parity for the P0 write paths
- `py/tests/unit/test_table_unit_behaviors.py` — Python lifecycle/version unit coverage
- `py/docs/{getting-started,troubleshooting}.md` — Python release wheel asset naming
- `README.md` — whitespace, workflow-command, and P0-count fixes
- `docs/assets/svg/{icon,icon-mono-light,wordmark-theory-cloud}.svg` — whitespace fixes only

## Verified locally

| Check | Result |
|---|---|
| `git diff --check` | clean |
| `bash scripts/verify-doc-integrity.sh` | **PASS** |
| `bash scripts/verify-theorycloud-tabletheory-subtree.sh` | **PASS** |
| `bash scripts/verify-branch-release-supply-chain.sh` | **PASS** |
| `bash scripts/verify-branch-version-sync.sh` | **SKIP** on feature branch |
| `make rubric` | **PASS (36/36 gates)** |
| `bash scripts/verify-contract-tests.sh` | **PASS** (Go/TS/Python P0 runners; Python executes all 9 shared P0 YAML fixtures) |
| `uv --directory py run pytest -q tests/unit` | **PASS** (241 passed) |
| `uv --directory py run pytest -q tests/integration` | **PASS** (6 passed) |
| `uv --directory py run mypy src` | **PASS** |
| `uv --directory py run ruff check src tests ../contract-tests/runners/py/test_contract_p0.py` | **PASS** |
| Grep for invented/stale patterns (`@field`, `@model`, `WithTable`, `WithModels`, `LambdaInit(ctx`, `from tabletheory_py`, `npm install --save-dev @theory-cloud`, `pip install tabletheory-py`, `TransactGetItems`, `npm run check`, `python -m unittest`, `theorydb_py-...whl`, `honored on reads`, stale scenario paths) | **none found in docs/README/py docs** |

## Test plan

- [x] Local rubric green
- [x] Local doc-integrity + subtree verifiers green
- [x] Local git diff --check clean
- [x] Side-by-side spot-check of every code block against the real API surface
- [x] Python runner executes all 9 shared P0 YAML fixtures
- [ ] Verify rendered docs site still builds (Jekyll workflow runs on main; this branch targets staging so won't auto-deploy)
- [ ] CI green on this PR
