### PR TITLE
fix(pages): build docs at custom-domain root

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ permissions:
   pages: write
   id-token: write
 
-# Coalesce in-flight deploys: if a second `main` push lands before the
+# Coalesce in-flight deploys: if a second `staging` push lands before the
 # previous deploy finishes, queue it (don't cancel) so we never skip a
 # commit's publish.
 concurrency:
@@ -74,7 +74,15 @@ jobs:
           bundle exec jekyll build \
             --source . \
             --destination ./_site \
-            --baseurl "${{ steps.pages.outputs.base_path }}"
+            --baseurl ""
+
+      - name: Verify custom-domain root paths
+        working-directory: docs
+        run: |
+          if grep -R -nE --include='*.html' '(href|src)="/(TableTheory|tabletheory)/' ./_site; then
+            echo "Found root-relative links with the repository path; custom-domain assets must resolve from /." >&2
+            exit 1
+          fi
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
@@ -88,7 +96,7 @@ jobs:
     if: github.ref == 'refs/heads/staging'
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: https://tabletheory.theorycloud.ai/
     steps:
       - name: Deploy
         id: deployment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,7 @@ func TestCreateUser(t *testing.T) {
 
 ### Authoring documentation
 
-The public documentation site at `https://theory-cloud.github.io/tabletheory/` is a Jekyll site rooted at `docs/`. It uses the Theory Cloud design system and is deployed by `.github/workflows/pages.yml` on every push to `main`.
+The public documentation site at `https://tabletheory.theorycloud.ai/` is a Jekyll site rooted at `docs/`. It uses the Theory Cloud design system and is deployed by `.github/workflows/pages.yml` on every push to `staging`.
 
 **Adding a page**
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- AI Training: Root README for the TableTheory multi-language monorepo -->
 
 <p align="center">
-  <a href="https://theory-cloud.github.io/tabletheory/">
+  <a href="https://tabletheory.theorycloud.ai/">
     <img src="docs/assets/svg/icon.svg" width="84" alt="TableTheory">
   </a>
 </p>
@@ -16,7 +16,7 @@
 <p align="center">
   <a href="https://github.com/theory-cloud/tabletheory/releases"><img alt="Release" src="https://img.shields.io/github/v/release/theory-cloud/tabletheory?style=flat-square&label=release&color=2EA7FF"></a>
   <a href="https://github.com/theory-cloud/tabletheory/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-7A5CFF?style=flat-square"></a>
-  <a href="https://theory-cloud.github.io/tabletheory/"><img alt="Docs" src="https://img.shields.io/badge/docs-theory--cloud.github.io%2Ftabletheory-2EA7FF?style=flat-square"></a>
+  <a href="https://tabletheory.theorycloud.ai/"><img alt="Docs" src="https://img.shields.io/badge/docs-tabletheory.theorycloud.ai-2EA7FF?style=flat-square"></a>
   <a href="https://github.com/theory-cloud/tabletheory/actions/workflows/quality-gates.yml"><img alt="Quality gates" src="https://img.shields.io/github/actions/workflow/status/theory-cloud/tabletheory/quality-gates.yml?branch=main&style=flat-square&label=rubric&color=46D397"></a>
   <a href="https://github.com/theory-cloud/tabletheory/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://img.shields.io/github/actions/workflow/status/theory-cloud/tabletheory/codeql.yml?branch=main&style=flat-square&label=CodeQL&color=46D397"></a>
 </p>
@@ -28,10 +28,10 @@
 </p>
 
 <p align="center">
-  <a href="https://theory-cloud.github.io/tabletheory/getting-started/"><strong>Get started →</strong></a> ·
-  <a href="https://theory-cloud.github.io/tabletheory/api-reference/">API reference</a> ·
-  <a href="https://theory-cloud.github.io/tabletheory/reference/contract-scenarios/">Contract scenarios</a> ·
-  <a href="https://theory-cloud.github.io/tabletheory/reference/dms-spec/">DMS spec</a>
+  <a href="https://tabletheory.theorycloud.ai/getting-started/"><strong>Get started →</strong></a> ·
+  <a href="https://tabletheory.theorycloud.ai/api-reference/">API reference</a> ·
+  <a href="https://tabletheory.theorycloud.ai/reference/contract-scenarios/">Contract scenarios</a> ·
+  <a href="https://tabletheory.theorycloud.ai/reference/dms-spec/">DMS spec</a>
 </p>
 
 ---
@@ -57,8 +57,8 @@ TableTheory is distributed exclusively through immutable **[GitHub Releases](htt
 | Runtime | Install |
 |---|---|
 | **Go** | `go get github.com/theory-cloud/tabletheory@vX.Y.Z` |
-| **TypeScript** | install the `npm pack` release asset — see [TypeScript getting started](https://theory-cloud.github.io/tabletheory/runtimes/typescript/) |
-| **Python** | install the wheel/sdist release asset — see [Python getting started](https://theory-cloud.github.io/tabletheory/runtimes/python/) |
+| **TypeScript** | install the `npm pack` release asset — see [TypeScript getting started](https://tabletheory.theorycloud.ai/runtimes/typescript/) |
+| **Python** | install the wheel/sdist release asset — see [Python getting started](https://tabletheory.theorycloud.ai/runtimes/python/) |
 
 ## At a glance
 
@@ -74,8 +74,8 @@ TableTheory is distributed exclusively through immutable **[GitHub Releases](htt
 
 Use TableTheory when you want DynamoDB-backed systems that are:
 
-- **Serverless-first** — patterns that work well in AWS Lambda: cold-start aware `LambdaInit`, batching with Lambda timeout awareness, transactions, streams, optional KMS-backed field encryption that's [fail-closed](https://theory-cloud.github.io/tabletheory/features/encryption/) by design.
-- **Cross-language consistent** — one table, multiple services, multiple runtimes — without schema or behavior drift. Verified on every commit by the [P0 contract scenarios](https://theory-cloud.github.io/tabletheory/reference/contract-scenarios/).
+- **Serverless-first** — patterns that work well in AWS Lambda: cold-start aware `LambdaInit`, batching with Lambda timeout awareness, transactions, streams, optional KMS-backed field encryption that's [fail-closed](https://tabletheory.theorycloud.ai/features/encryption/) by design.
+- **Cross-language consistent** — one table, multiple services, multiple runtimes — without schema or behavior drift. Verified on every commit by the [P0 contract scenarios](https://tabletheory.theorycloud.ai/reference/contract-scenarios/).
 - **Generative-coding friendly** — explicit schema, canonical patterns, and strict verification so AI-generated code stays correct and maintainable.
 
 ✅ Treat schema + semantics as a contract
@@ -83,42 +83,42 @@ Use TableTheory when you want DynamoDB-backed systems that are:
 
 ## Documentation
 
-The full documentation site lives at **[theory-cloud.github.io/tabletheory](https://theory-cloud.github.io/tabletheory/)** — branded with the Theory Cloud design system, with a ⌘K search palette, runtime tabs, and surface-tinted pages.
+The full documentation site lives at **[tabletheory.theorycloud.ai](https://tabletheory.theorycloud.ai/)** — branded with the Theory Cloud design system, with a ⌘K search palette, runtime tabs, and surface-tinted pages.
 
 **Most-used entry points:**
 
 | Section | Link |
 |---|---|
-| Getting started | [theory-cloud.github.io/tabletheory/getting-started/](https://theory-cloud.github.io/tabletheory/getting-started/) |
-| API reference | [theory-cloud.github.io/tabletheory/api-reference/](https://theory-cloud.github.io/tabletheory/api-reference/) |
-| Struct definition guide | [theory-cloud.github.io/tabletheory/struct-definition-guide/](https://theory-cloud.github.io/tabletheory/struct-definition-guide/) |
-| Core patterns | [theory-cloud.github.io/tabletheory/core-patterns/](https://theory-cloud.github.io/tabletheory/core-patterns/) |
-| Architecture patterns | [theory-cloud.github.io/tabletheory/architecture-patterns/](https://theory-cloud.github.io/tabletheory/architecture-patterns/) |
-| Testing | [theory-cloud.github.io/tabletheory/testing-guide/](https://theory-cloud.github.io/tabletheory/testing-guide/) |
-| Troubleshooting | [theory-cloud.github.io/tabletheory/troubleshooting/](https://theory-cloud.github.io/tabletheory/troubleshooting/) |
+| Getting started | [tabletheory.theorycloud.ai/getting-started/](https://tabletheory.theorycloud.ai/getting-started/) |
+| API reference | [tabletheory.theorycloud.ai/api-reference/](https://tabletheory.theorycloud.ai/api-reference/) |
+| Struct definition guide | [tabletheory.theorycloud.ai/struct-definition-guide/](https://tabletheory.theorycloud.ai/struct-definition-guide/) |
+| Core patterns | [tabletheory.theorycloud.ai/core-patterns/](https://tabletheory.theorycloud.ai/core-patterns/) |
+| Architecture patterns | [tabletheory.theorycloud.ai/architecture-patterns/](https://tabletheory.theorycloud.ai/architecture-patterns/) |
+| Testing | [tabletheory.theorycloud.ai/testing-guide/](https://tabletheory.theorycloud.ai/testing-guide/) |
+| Troubleshooting | [tabletheory.theorycloud.ai/troubleshooting/](https://tabletheory.theorycloud.ai/troubleshooting/) |
 
 **Per-runtime entry points:**
 
-- **Go** — [theory-cloud.github.io/tabletheory/runtimes/go/](https://theory-cloud.github.io/tabletheory/runtimes/go/)
-- **TypeScript** — [theory-cloud.github.io/tabletheory/runtimes/typescript/](https://theory-cloud.github.io/tabletheory/runtimes/typescript/)
-- **Python** — [theory-cloud.github.io/tabletheory/runtimes/python/](https://theory-cloud.github.io/tabletheory/runtimes/python/)
+- **Go** — [tabletheory.theorycloud.ai/runtimes/go/](https://tabletheory.theorycloud.ai/runtimes/go/)
+- **TypeScript** — [tabletheory.theorycloud.ai/runtimes/typescript/](https://tabletheory.theorycloud.ai/runtimes/typescript/)
+- **Python** — [tabletheory.theorycloud.ai/runtimes/python/](https://tabletheory.theorycloud.ai/runtimes/python/)
 
 **P0 contract reference and related feature pages:**
 
-- [Contract Scenarios](https://theory-cloud.github.io/tabletheory/reference/contract-scenarios/) — the current 9-fixture P0 surface
-- [CRUD & Marshaling](https://theory-cloud.github.io/tabletheory/features/crud/)
-- [Optimistic Locking](https://theory-cloud.github.io/tabletheory/features/optimistic-locking/)
-- [Lifecycle Timestamps](https://theory-cloud.github.io/tabletheory/features/lifecycle-timestamps/)
-- [TTL](https://theory-cloud.github.io/tabletheory/features/ttl/)
-- [Encryption (fail-closed)](https://theory-cloud.github.io/tabletheory/features/encryption/)
-- [Transactions](https://theory-cloud.github.io/tabletheory/features/transactions/)
+- [Contract Scenarios](https://tabletheory.theorycloud.ai/reference/contract-scenarios/) — the current 9-fixture P0 surface
+- [CRUD & Marshaling](https://tabletheory.theorycloud.ai/features/crud/)
+- [Optimistic Locking](https://tabletheory.theorycloud.ai/features/optimistic-locking/)
+- [Lifecycle Timestamps](https://tabletheory.theorycloud.ai/features/lifecycle-timestamps/)
+- [TTL](https://tabletheory.theorycloud.ai/features/ttl/)
+- [Encryption (fail-closed)](https://tabletheory.theorycloud.ai/features/encryption/)
+- [Transactions](https://tabletheory.theorycloud.ai/features/transactions/)
 
 **Integrations** — how downstream Theory Cloud frameworks use TableTheory:
 
-- [MCP Memory](https://theory-cloud.github.io/tabletheory/integrations/mcp-memory/)
-- [AppTheory](https://theory-cloud.github.io/tabletheory/integrations/apptheory/)
-- [KnowledgeTheory](https://theory-cloud.github.io/tabletheory/integrations/knowledgetheory/)
-- [Autheory](https://theory-cloud.github.io/tabletheory/integrations/autheory/)
+- [MCP Memory](https://tabletheory.theorycloud.ai/integrations/mcp-memory/)
+- [AppTheory](https://tabletheory.theorycloud.ai/integrations/apptheory/)
+- [KnowledgeTheory](https://tabletheory.theorycloud.ai/integrations/knowledgetheory/)
+- [Autheory](https://tabletheory.theorycloud.ai/integrations/autheory/)
 
 ## Repository layout
 
@@ -137,7 +137,7 @@ The CDK demo deploys one DynamoDB table + three Lambda Function URLs (Go, Node.j
 
 → [`examples/cdk-multilang/README.md`](examples/cdk-multilang/README.md)
 
-For infrastructure patterns, see the [CDK integration guide](https://theory-cloud.github.io/tabletheory/cdk/).
+For infrastructure patterns, see the [CDK integration guide](https://tabletheory.theorycloud.ai/cdk/).
 
 ## DMS — the language-neutral schema
 
@@ -157,7 +157,7 @@ models:
       - { attribute: "value", type: "N" }
 ```
 
-DMS is **authored independently** of any runtime — Go, TypeScript, and Python all validate against the same spec. See the [DMS Specification v0.1](https://theory-cloud.github.io/tabletheory/reference/dms-spec/) for the public summary.
+DMS is **authored independently** of any runtime — Go, TypeScript, and Python all validate against the same spec. See the [DMS Specification v0.1](https://tabletheory.theorycloud.ai/reference/dms-spec/) for the public summary.
 
 ## Development & verification
 
@@ -195,4 +195,4 @@ The single-path philosophy starts here: one way to define a table, one way to ac
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 - [CHANGELOG.md](CHANGELOG.md)
 
-<p align="center"><sub>Made with <a href="https://github.com/theory-cloud">Theory Cloud</a> · <a href="https://theory-cloud.github.io/tabletheory/">docs</a></sub></p>
+<p align="center"><sub>Made with <a href="https://github.com/theory-cloud">Theory Cloud</a> · <a href="https://tabletheory.theorycloud.ai/">docs</a></sub></p>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,10 +9,11 @@ description: >-
   The DynamoDB-first multi-language ORM and schema contract for the
   Theory Cloud stack. Go, TypeScript, and Python — one specification.
 
-# When deployed via the canonical org repo, the site lives at
-# https://theory-cloud.github.io/tabletheory/
-url: "https://theory-cloud.github.io"
-baseurl: "/tabletheory"
+# Canonical public docs domain. GitHub still serves the Pages artifact for the
+# project repository, but the custom domain is mounted at the domain root, so
+# generated asset URLs must not carry the repository path as a baseurl.
+url: "https://tabletheory.theorycloud.ai"
+baseurl: ""
 
 # Jekyll engine
 markdown: kramdown

--- a/docs/features/encryption.md
+++ b/docs/features/encryption.md
@@ -84,7 +84,7 @@ For local testing where KMS isn't available, the **caller** must explicitly opt 
 
 ## Related
 
-- [Development Guidelines](https://theory-cloud.github.io/tabletheory/development-guidelines/) — when to tag a field encrypted
+- [Development Guidelines](https://tabletheory.theorycloud.ai/development-guidelines/) — when to tag a field encrypted
 - [Testing](../testing-guide.md) — how to write tests that exercise encrypted fields without KMS
 - [Integrations · Autheory](../integrations/autheory.md) — the largest consumer of encrypted fields in the stack
 - [Contract Scenarios](../reference/contract-scenarios.md) — fail-closed behavior is exercised on every commit

--- a/docs/runtimes/go.md
+++ b/docs/runtimes/go.md
@@ -82,7 +82,7 @@ A TableTheory Go model is an ordinary struct decorated with the `theorydb:` tag 
 | `theorydb:"ttl"`           | DynamoDB TimeToLive attribute                                |
 | `theorydb:"omitempty"`     | Omit attribute when the field is the zero value              |
 
-Every `theorydb` tag is accompanied by a matching `json` tag per the [Development guidelines](https://theory-cloud.github.io/tabletheory/development-guidelines/).
+Every `theorydb` tag is accompanied by a matching `json` tag per the [Development guidelines](https://tabletheory.theorycloud.ai/development-guidelines/).
 
 ## CRUD via the Query builder
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -97,7 +97,7 @@ table.update_builder(pk, sk).set("body", "updated").execute()
 
 ## Where to go next
 
-- [Getting Started](https://theory-cloud.github.io/tabletheory/getting-started/) — full walkthrough
+- [Getting Started](https://tabletheory.theorycloud.ai/getting-started/) — full walkthrough
 - [`py/docs/getting-started.md`](https://github.com/theory-cloud/tabletheory/blob/main/py/docs/getting-started.md) — Python-specific runtime documentation
 - [`py/docs/api-reference.md`](https://github.com/theory-cloud/tabletheory/blob/main/py/docs/api-reference.md) — full Python API reference
 - [Features → CRUD & Marshaling](../features/crud.md), [Optimistic Locking](../features/optimistic-locking.md), [Encryption](../features/encryption.md)

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -105,7 +105,7 @@ const page = await db.query('Note').partitionKey('USER#42').limit(20).page();
 
 ## Where to go next
 
-- [Getting Started](https://theory-cloud.github.io/tabletheory/getting-started/) — full walkthrough
+- [Getting Started](https://tabletheory.theorycloud.ai/getting-started/) — full walkthrough
 - [`ts/docs/getting-started.md`](https://github.com/theory-cloud/tabletheory/blob/main/ts/docs/getting-started.md) — TypeScript-specific runtime documentation
 - [`ts/docs/api-reference.md`](https://github.com/theory-cloud/tabletheory/blob/main/ts/docs/api-reference.md) — full TypeScript API reference
 - [Features → CRUD & Marshaling](../features/crud.md), [Optimistic Locking](../features/optimistic-locking.md), [Encryption](../features/encryption.md)


### PR DESCRIPTION
## Summary
- Build the Jekyll docs site with an empty `baseurl` so custom-domain root assets resolve from `/`.
- Set the canonical docs URL to `https://tabletheory.theorycloud.ai/` and update public docs links away from the old `github.io/tabletheory` path.
- Add a Pages workflow guard that fails if generated HTML reintroduces `/TableTheory/` or `/tabletheory/` root-relative asset/page links.

## Root cause
The Pages workflow used `actions/configure-pages` `base_path`, which returned `/TableTheory` for the project repository. The new custom domain is mounted at `/`, so generated CSS, icon, and search URLs pointed at `/TableTheory/...` and 404ed on `https://tabletheory.theorycloud.ai/`.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pages.yml")'`
- custom static checks for empty Jekyll `baseurl`, removed `steps.pages.outputs.base_path`, and root-path verifier presence
- `git diff --check`
- `bash scripts/verify-doc-integrity.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/verify-branch-version-sync.sh` (SKIP on feature branch)
- `make rubric` (PASS 36/36)

## Notes
Local full Jekyll build could not be completed in this workstation Ruby because native gem builds require Ruby headers; the GitHub Pages workflow uses `ruby/setup-ruby` with Ruby 3.3 and will run the actual Jekyll build on this PR/merge path.