### PR TITLE
fix(py): reject lifecycle timestamp update tampering (THE-1750)

### DIFF
--- a/docs/features/lifecycle-timestamps.md
+++ b/docs/features/lifecycle-timestamps.md
@@ -100,7 +100,9 @@ high-level guarded update shape.
 
 ## Anti-patterns
 
-- **Don't set `created_at` or `updated_at` manually in high-level create/update paths.** The runtime owns lifecycle fields on those paths.
+- **Don't set `created_at` or `updated_at` manually in high-level create/update paths.** The runtime owns
+  lifecycle fields on those paths; caller-supplied lifecycle timestamp fields are rejected on update rather
+  than written through.
 - **Don't rely on `created_at` for tie-breaking equal-version writes.** Use the version role; that's what it's for.
 
 ## Related

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -976,6 +976,9 @@ class Table[T]:
                 raise ValidationError(f"do not include version in update fields: {field_name}")
 
             attr_def = self._model.attributes[field_name]
+            if "created_at" in attr_def.roles or "updated_at" in attr_def.roles:
+                raise ValidationError(f"cannot update lifecycle timestamp field: {field_name}")
+
             name_ref = f"#d_{field_name}"
             update_names[name_ref] = attr_def.attribute_name
 
@@ -1011,10 +1014,12 @@ class Table[T]:
             update_values[value_ref] = self._serialize_attr_value(attr_def, value)
             set_parts.append(f"{name_ref} = {value_ref}")
 
-        if updated_at_attr is not None and updated_at_attr.python_name not in updates:
-            update_names["#d_updated_at"] = updated_at_attr.attribute_name
-            update_values[":d_updated_at"] = self._serialize_attr_value(updated_at_attr, self._now())
-            set_parts.insert(0, "#d_updated_at = :d_updated_at")
+        if updated_at_attr is not None:
+            updated_at_name_ref = f"#d_{updated_at_attr.python_name}"
+            updated_at_value_ref = f":d_{updated_at_attr.python_name}"
+            update_names[updated_at_name_ref] = updated_at_attr.attribute_name
+            update_values[updated_at_value_ref] = self._serialize_attr_value(updated_at_attr, self._now())
+            set_parts.insert(0, f"{updated_at_name_ref} = {updated_at_value_ref}")
 
         version_condition: str | None = None
         if expected_version is not None and version_attr is not None:

--- a/py/src/theorydb_py/update_builder.py
+++ b/py/src/theorydb_py/update_builder.py
@@ -142,9 +142,12 @@ class UpdateBuilder[T]:
             ):
                 raise ValidationError(f"cannot update key field: {field_name}")
 
+            attr_def = self._table._model.attributes[field_name]
+            if "created_at" in attr_def.roles or "updated_at" in attr_def.roles:
+                raise ValidationError(f"cannot update lifecycle timestamp field: {field_name}")
+
             assert_protected_fields_can_mutate(self._table._model, [field_name])
 
-            attr_def = self._table._model.attributes[field_name]
             ref = f"#u_{field_name}"
             names.setdefault(ref, attr_def.attribute_name)
             return ref, attr_def
@@ -275,6 +278,17 @@ class UpdateBuilder[T]:
                 continue
 
             raise ValidationError(f"unsupported update operation: {kind}")
+
+        updated_at_attr = self._table._attribute_by_role("updated_at")
+        if updated_at_attr is not None:
+            updated_at_name_ref = f"#u_{updated_at_attr.python_name}"
+            updated_at_value_ref = f":u_{updated_at_attr.python_name}"
+            names[updated_at_name_ref] = updated_at_attr.attribute_name
+            update_values[updated_at_value_ref] = self._table._serialize_attr_value(
+                updated_at_attr,
+                self._table._now(),
+            )
+            set_parts.insert(0, f"{updated_at_name_ref} = {updated_at_value_ref}")
 
         expr_parts: list[str] = []
         if set_parts:

--- a/py/tests/unit/test_table_unit_behaviors.py
+++ b/py/tests/unit/test_table_unit_behaviors.py
@@ -183,6 +183,34 @@ def test_table_update_expected_version_sets_lifecycle_and_lock() -> None:
     assert req["ExpressionAttributeValues"][":d_version_increment"] == {"N": "1"}
 
 
+@pytest.mark.parametrize("field_name", ["created_at", "updated_at"])
+def test_table_update_rejects_lifecycle_timestamp_tampering(field_name: str) -> None:
+    model = ModelDefinition.from_dataclass(LifecycleItem, table_name="tbl")
+    stub = _StubClient()
+    table: Table[LifecycleItem] = Table(model, client=stub, now=lambda: "2026-05-28T00:00:01.000000000Z")
+
+    with pytest.raises(ValidationError, match="lifecycle timestamp field"):
+        table.update("A", "1", {field_name: "1970-01-01T00:00:00.000000000Z"})
+
+    assert stub.update_reqs == []
+
+
+def test_table_update_stamps_updated_at_for_valid_update_without_lock() -> None:
+    model = ModelDefinition.from_dataclass(LifecycleItem, table_name="tbl")
+    table: Table[LifecycleItem] = Table(
+        model, client=_StubClient(), now=lambda: "2026-05-28T00:00:02.000000000Z"
+    )
+
+    req = table._build_update_request("A", "1", {"value": 3}, return_values="ALL_NEW")
+
+    assert req["UpdateExpression"] == "SET #d_updated_at = :d_updated_at, #d_value = :d_value"
+    assert req["ExpressionAttributeNames"]["#d_updated_at"] == "updatedAt"
+    assert req["ExpressionAttributeNames"]["#d_value"] == "value"
+    assert req["ExpressionAttributeValues"][":d_updated_at"] == {"S": "2026-05-28T00:00:02.000000000Z"}
+    assert req["ExpressionAttributeValues"][":d_value"] == {"N": "3"}
+    assert ":d_created_at" not in req["ExpressionAttributeValues"]
+
+
 def test_table_key_and_update_request_validation_errors() -> None:
     model = ModelDefinition.from_dataclass(Item, table_name="tbl")
     table: Table[Item] = Table(model, client=_StubClient())

--- a/py/tests/unit/test_update_builder.py
+++ b/py/tests/unit/test_update_builder.py
@@ -19,6 +19,15 @@ class Item:
     items: list[object] = theorydb_field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class LifecycleItem:
+    pk: str = theorydb_field(roles=["pk"])
+    sk: str = theorydb_field(roles=["sk"])
+    name: str = theorydb_field()
+    created_at: str = theorydb_field(name="createdAt", roles=["created_at"], default="")
+    updated_at: str = theorydb_field(name="updatedAt", roles=["updated_at"], default="")
+
+
 def test_update_builder_builds_update_and_condition_expressions() -> None:
     client = FakeDynamoDBClient()
 
@@ -179,6 +188,38 @@ def test_update_builder_rejects_invalid_updates_and_conditions() -> None:
 
     with pytest.raises(ValidationError, match="= requires one value"):
         table.update_builder("A", "B").set("name", "x").condition("name", "=").execute()
+
+
+@pytest.mark.parametrize("field_name", ["created_at", "updated_at"])
+def test_update_builder_rejects_lifecycle_timestamp_tampering(field_name: str) -> None:
+    model = ModelDefinition.from_dataclass(LifecycleItem, table_name="tbl")
+    table: Table[LifecycleItem] = Table(model, client=FakeDynamoDBClient())
+
+    with pytest.raises(ValidationError, match="lifecycle timestamp field"):
+        table.update_builder("A", "B").set(field_name, "1970-01-01T00:00:00.000000000Z").execute()
+
+
+def test_update_builder_stamps_updated_at_for_valid_update() -> None:
+    client = FakeDynamoDBClient()
+
+    def validate(req: dict) -> None:
+        assert req["UpdateExpression"] == "SET #u_updated_at = :u_updated_at, #u_name = :u1"
+        assert req["ExpressionAttributeNames"]["#u_updated_at"] == "updatedAt"
+        assert req["ExpressionAttributeNames"]["#u_name"] == "name"
+        assert req["ExpressionAttributeValues"][":u_updated_at"] == {"S": "2026-05-28T00:00:03.000000000Z"}
+        assert req["ExpressionAttributeValues"][":u1"] == {"S": "safe"}
+
+    client.expect("update_item", validate, response={})
+
+    model = ModelDefinition.from_dataclass(LifecycleItem, table_name="tbl")
+    table: Table[LifecycleItem] = Table(
+        model,
+        client=client,
+        now=lambda: "2026-05-28T00:00:03.000000000Z",
+    )
+
+    table.update_builder("A", "B").set("name", "safe").execute()
+    client.assert_no_pending()
 
 
 def test_update_builder_execute_returns_none_when_no_attributes() -> None:


### PR DESCRIPTION
## Summary
- Reject Python update payloads that target attributes carrying `created_at` or `updated_at` roles before building a DynamoDB write expression.
- Keep lifecycle update stamping server-owned by always adding the `updated_at` `_now()` value for valid updates, including the `update_builder` path.
- Add regression coverage for `created_at` tampering, `updated_at` tampering, and valid update stamping; document that caller-supplied lifecycle timestamps are rejected on update.

## Root cause
`Table._build_update_request` only guarded key fields and version fields in guarded updates. A caller-provided `updated_at` field skipped the automatic stamp path, and a caller-provided `created_at` field flowed through the generic `SET` path.

## Validation
- `git diff --check` — passed
- `uv --directory py run pytest -q tests/unit/test_table_unit_behaviors.py tests/unit/test_update_builder.py` — 19 passed
- `uv --directory py run pytest -q tests/unit` — 247 passed
- `uv --directory py run ruff check src/theorydb_py/table.py src/theorydb_py/update_builder.py tests/unit/test_table_unit_behaviors.py tests/unit/test_update_builder.py` — passed
- `uv --directory py run mypy src` — passed

## Compatibility notes
- Valid update payloads and optimistic-lock condition behavior remain unchanged.
- Lifecycle-role fields are now treated as managed fields on Python update APIs and raise `ValidationError` if supplied by callers.
- No AWS/cloud mutation was performed.

## Stewardship notes
- Branch was created from `origin/staging` (`9c253336aaaff867982c4c1c60edf09505183922`), not from the pre-existing `fix/pages-custom-domain-baseurl` branch.
- Scoped memory tools were searched for this issue/security invariant but were not exposed in this session, so no prior memory was applied.

Closes THE-1750