### PR TITLE
fix: keep brace-expansion audit finding visible (THE-1757)

### DIFF
--- a/examples/cdk-multilang/README.md
+++ b/examples/cdk-multilang/README.md
@@ -39,6 +39,11 @@ Additional endpoints:
 
 As of the May 2026 dependency refresh, `aws-cdk-lib@2.257.0` removes the previous bundled `fast-uri` high-severity audit finding. `npm audit` may still report a moderate `brace-expansion@5.0.5` finding bundled inside `aws-cdk-lib`; keep that visible rather than suppressing it, and refresh CDK again once AWS publishes a bundle with `brace-expansion >=5.0.6`.
 
+SEC-2 records that advisory in `hgm-infra/planning/theorydb-visible-npm-audit-findings.json`, not in the supply-chain
+suppression allowlist. The verifier therefore stays green only while the finding remains explicitly printed in SEC-2
+evidence as a visible upstream-bundled finding; if AWS CDK updates the bundled dependency, remove the visible policy entry
+instead of adding an allowlist suppression.
+
 ## Smoke test
 
 Runs an end-to-end cross-language check (encryption + batch + tx) and verifies the encrypted attribute is stored as an

--- a/hgm-infra/README.md
+++ b/hgm-infra/README.md
@@ -18,6 +18,9 @@ Notes:
 - Verifier scripts are intentionally safe to commit **without** execute permissions; always run via `bash …`.
 - Missing or unimplemented checks should be recorded as `BLOCKED`, not “fixed” by weakening gates.
 - Supply-chain checks may use the allowlist with justification: `hgm-infra/planning/theorydb-supply-chain-allowlist.txt`.
+- Upstream-bundled findings that must stay visible in green SEC-2 evidence are tracked separately in
+  `hgm-infra/planning/theorydb-visible-npm-audit-findings.json`; do not copy those findings into the suppression
+  allowlist.
 
 ## What’s In Here
 
@@ -35,6 +38,9 @@ Notes:
 - If a verifier depends on a missing tool/version pin, **fail closed** (`BLOCKED`) until pinned.
 - Don’t commit secrets into `hgm-infra/`.
 - If you suppress a supply-chain finding, add the exact ID to `hgm-infra/planning/theorydb-supply-chain-allowlist.txt` with a justification comment.
+- If a supply-chain finding is accepted only because it is an unfixed upstream bundle, add it to
+  `hgm-infra/planning/theorydb-visible-npm-audit-findings.json` instead. The SEC-2 log must still print the exact finding
+  and must not call it allowlisted.
 
 ## Next Steps
 

--- a/hgm-infra/pack.json
+++ b/hgm-infra/pack.json
@@ -26,6 +26,7 @@
       "hgm-infra/planning/theorydb-workstream-logging-ops-roadmap.md",
       "hgm-infra/planning/theorydb-workstream-maintainability-plan-roadmap.md",
       "hgm-infra/planning/theorydb-supply-chain-allowlist.txt",
+      "hgm-infra/planning/theorydb-visible-npm-audit-findings.json",
       "hgm-infra/planning/theorydb-ai-drift-recovery.md"
     ],
     "verifiers": [

--- a/hgm-infra/planning/theorydb-evidence-plan.md
+++ b/hgm-infra/planning/theorydb-evidence-plan.md
@@ -15,6 +15,7 @@ Defines where evidence for rubric items is produced and how to regenerate it. Ev
 - Roadmap: `hgm-infra/planning/theorydb-10of10-roadmap.md`
 - Evidence plan: `hgm-infra/planning/theorydb-evidence-plan.md`
 - Supply-chain allowlist: `hgm-infra/planning/theorydb-supply-chain-allowlist.txt`
+- Visible npm-audit findings: `hgm-infra/planning/theorydb-visible-npm-audit-findings.json`
 - Threat model: `hgm-infra/planning/theorydb-threat-model.md`
 - Logging/ops standards: `hgm-infra/planning/theorydb-logging-ops-standards.md`
 - Maintainability roadmap: `hgm-infra/planning/theorydb-maintainability-roadmap.md`

--- a/hgm-infra/planning/theorydb-supply-chain-allowlist.txt
+++ b/hgm-infra/planning/theorydb-supply-chain-allowlist.txt
@@ -8,6 +8,7 @@
 # - `#` comments are allowed.
 # - Keep this file versioned in git; treat allowlist changes as security-relevant.
 # - Prefer fixing/removing the dependency over allowlisting. If you allowlist, include a justification comment.
+# - Do not use this file for visible upstream-bundled findings; use theorydb-visible-npm-audit-findings.json instead.
 #
 # Examples (copy exact IDs from the failing scanner output):
 # HGM-SUPPLY:GO:REPLACE:rule=REMOTE_REPLACE:from=github.com/example/upstream@v1.2.3:to=github.com/example/fork@v1.2.3

--- a/hgm-infra/planning/theorydb-supply-chain-allowlist.txt
+++ b/hgm-infra/planning/theorydb-supply-chain-allowlist.txt
@@ -11,7 +11,3 @@
 #
 # Examples (copy exact IDs from the failing scanner output):
 # HGM-SUPPLY:GO:REPLACE:rule=REMOTE_REPLACE:from=github.com/example/upstream@v1.2.3:to=github.com/example/fork@v1.2.3
-# Reviewed 2026-05-25: aws-cdk-lib@2.257.0 still bundles brace-expansion@5.0.5 through
-# minimatch@10.2.5. This is confined to the examples/cdk-multilang CDK app's test/synth/deploy
-# tooling path, not TableTheory runtime code. Remove once AWS CDK bundles brace-expansion >= 5.0.6.
-NPM-AUDIT:examples/cdk-multilang:brace-expansion:GHSA-jxxr-4gwj-5jf2:node_modules/aws-cdk-lib/node_modules/brace-expansion

--- a/hgm-infra/planning/theorydb-visible-npm-audit-findings.json
+++ b/hgm-infra/planning/theorydb-visible-npm-audit-findings.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://theory.cloud/tabletheory/schemas/visible-npm-audit-findings.schema.json",
+  "purpose": "Findings listed here are intentionally visible in SEC-2 evidence and are not supply-chain allowlist suppressions.",
+  "findings": [
+    {
+      "project": "examples/cdk-multilang",
+      "package": "brace-expansion",
+      "advisory": "GHSA-jxxr-4gwj-5jf2",
+      "node": "node_modules/aws-cdk-lib/node_modules/brace-expansion",
+      "visibility": "visible",
+      "status": "upstream-bundled-pending-fix",
+      "reviewed_on": "2026-05-30",
+      "current_upstream_package": "aws-cdk-lib",
+      "current_upstream_version": "2.257.0",
+      "current_bundled_version": "5.0.5",
+      "remove_when": "Remove this visible finding policy once aws-cdk-lib publishes a bundle with brace-expansion >= 5.0.6.",
+      "justification": "aws-cdk-lib@2.257.0 is still the latest npm package and bundles brace-expansion@5.0.5 through minimatch@10.2.5. npm audit fix reports that the bundled dependency cannot be fixed automatically and must be fixed by an aws-cdk-lib update."
+    }
+  ]
+}

--- a/scripts/check-npm-audit-allowlist.mjs
+++ b/scripts/check-npm-audit-allowlist.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 
-const [reportPath, allowlistPath, projectPathArg] = process.argv.slice(2);
+const [reportPath, allowlistPath, projectPathArg, visiblePolicyPath] = process.argv.slice(2);
 
 if (!reportPath || !allowlistPath || !projectPathArg) {
   console.error(
-    'usage: node scripts/check-npm-audit-allowlist.mjs <audit-json> <allowlist> <project-path>',
+    'usage: node scripts/check-npm-audit-allowlist.mjs <audit-json> <allowlist> <project-path> [visible-policy-json]',
   );
   process.exit(2);
 }
@@ -27,6 +27,70 @@ const allowlist = new Set(
     .map((line) => line.replace(/#.*/, '').trim())
     .filter(Boolean),
 );
+
+function findingId(project, packageName, advisory, node) {
+  return `NPM-AUDIT:${project}:${packageName}:${advisory}:${node}`;
+}
+
+function policyError(message) {
+  console.error(`npm-audit: invalid visible policy: ${message}`);
+  process.exit(2);
+}
+
+function requirePolicyString(entry, index, field) {
+  const value = entry?.[field];
+  if (typeof value !== 'string' || value.trim() === '') {
+    policyError(`findings[${index}].${field} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function loadVisiblePolicy(policyPath) {
+  if (!policyPath || !fs.existsSync(policyPath)) {
+    return new Map();
+  }
+
+  let policy;
+  try {
+    policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+  } catch (err) {
+    policyError(`${policyPath}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (
+    !policy ||
+    typeof policy !== 'object' ||
+    Array.isArray(policy) ||
+    !Array.isArray(policy.findings)
+  ) {
+    policyError(`${policyPath}: expected an object with a findings array`);
+  }
+
+  const visible = new Map();
+  for (const [index, entry] of policy.findings.entries()) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      policyError(`findings[${index}] must be an object`);
+    }
+
+    const visibility = requirePolicyString(entry, index, 'visibility');
+    if (visibility !== 'visible') {
+      policyError(`findings[${index}].visibility must be "visible"`);
+    }
+
+    const id = findingId(
+      requirePolicyString(entry, index, 'project'),
+      requirePolicyString(entry, index, 'package'),
+      requirePolicyString(entry, index, 'advisory'),
+      requirePolicyString(entry, index, 'node'),
+    );
+
+    visible.set(id, entry);
+  }
+
+  return visible;
+}
+
+const visiblePolicy = loadVisiblePolicy(visiblePolicyPath);
 
 function advisoryId(via) {
   if (typeof via === 'string') {
@@ -103,7 +167,7 @@ for (const vulnerability of Object.values(vulnerabilities)) {
 
   for (const node of nodes) {
     for (const advisory of advisories) {
-      findings.push(`NPM-AUDIT:${projectPath}:${packageName}:${advisory}:${node}`);
+      findings.push(findingId(projectPath, packageName, advisory, node));
     }
   }
 }
@@ -115,16 +179,40 @@ if (findings.length === 0) {
   process.exit(2);
 }
 
+const policyConflicts = findings.filter((finding) => allowlist.has(finding) && visiblePolicy.has(finding));
+if (policyConflicts.length > 0) {
+  console.error(
+    `npm-audit: ${policyConflicts.length} visible finding(s) cannot also be in the suppression allowlist`,
+  );
+  for (const finding of policyConflicts) {
+    console.error(`  ${finding}`);
+  }
+  process.exit(2);
+}
+
 const missing = findings.filter((finding) => !allowlist.has(finding));
-if (missing.length > 0) {
-  console.error(`npm-audit: ${missing.length} unallowlisted finding(s) in ${projectPath}`);
-  for (const finding of missing) {
+const visibleMissing = missing.filter((finding) => visiblePolicy.has(finding));
+const unhandledMissing = missing.filter((finding) => !visiblePolicy.has(finding));
+if (unhandledMissing.length > 0) {
+  console.error(`npm-audit: ${unhandledMissing.length} unallowlisted finding(s) in ${projectPath}`);
+  for (const finding of unhandledMissing) {
     console.error(`  ${finding}`);
   }
   process.exit(1);
 }
 
-console.log(`npm-audit: ${findings.length} allowlisted finding(s) in ${projectPath}`);
-for (const finding of findings) {
-  console.log(`  ${finding}`);
+const allowlistedFindings = findings.filter((finding) => allowlist.has(finding));
+if (allowlistedFindings.length > 0) {
+  console.log(`npm-audit: ${allowlistedFindings.length} allowlisted finding(s) in ${projectPath}`);
+  for (const finding of allowlistedFindings) {
+    console.log(`  ${finding}`);
+  }
+}
+
+if (visibleMissing.length > 0) {
+  console.log(`npm-audit: ${visibleMissing.length} visible unallowlisted finding(s) in ${projectPath}`);
+  console.log('npm-audit: visible findings remain in SEC-2 evidence and are not supply-chain allowlist suppressions');
+  for (const finding of visibleMissing) {
+    console.log(`  ${finding}`);
+  }
 }

--- a/scripts/sec-dependency-scans.sh
+++ b/scripts/sec-dependency-scans.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 bash scripts/sec-govulncheck.sh
+bash scripts/test-npm-audit-policy.sh
 bash scripts/sec-npm-audit.sh
 bash scripts/sec-pip-audit.sh
 

--- a/scripts/sec-npm-audit.sh
+++ b/scripts/sec-npm-audit.sh
@@ -12,6 +12,7 @@ command -v npm >/dev/null 2>&1 || {
 }
 
 allowlist_file="hgm-infra/planning/theorydb-supply-chain-allowlist.txt"
+visible_policy_file="hgm-infra/planning/theorydb-visible-npm-audit-findings.json"
 
 run_npm_audit() {
   local prefix="$1"
@@ -25,8 +26,8 @@ run_npm_audit() {
     return 0
   fi
 
-  if [[ -f "${allowlist_file}" ]] && node scripts/check-npm-audit-allowlist.mjs "${report}" "${allowlist_file}" "${prefix}"; then
-    echo "npm-audit: PASS (${prefix}; all findings allowlisted)"
+  if [[ -f "${allowlist_file}" ]] && node scripts/check-npm-audit-allowlist.mjs "${report}" "${allowlist_file}" "${prefix}" "${visible_policy_file}"; then
+    echo "npm-audit: PASS (${prefix}; findings handled by repo policy)"
     rm -f "${report}"
     return 0
   fi

--- a/scripts/test-npm-audit-policy.sh
+++ b/scripts/test-npm-audit-policy.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+finding="NPM-AUDIT:examples/cdk-multilang:brace-expansion:GHSA-jxxr-4gwj-5jf2:node_modules/aws-cdk-lib/node_modules/brace-expansion"
+checker="scripts/check-npm-audit-allowlist.mjs"
+
+cat >"${tmpdir}/audit.json" <<'JSON'
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "brace-expansion": {
+      "name": "brace-expansion",
+      "severity": "moderate",
+      "via": [
+        {
+          "source": 1234567,
+          "name": "brace-expansion",
+          "dependency": "brace-expansion",
+          "title": "brace-expansion: Large numeric range defeats documented max DoS protection",
+          "url": "https://github.com/advisories/GHSA-jxxr-4gwj-5jf2"
+        }
+      ],
+      "effects": [],
+      "range": "5.0.2 - 5.0.5",
+      "nodes": [
+        "node_modules/aws-cdk-lib/node_modules/brace-expansion"
+      ],
+      "fixAvailable": true
+    }
+  }
+}
+JSON
+
+cat >"${tmpdir}/visible.json" <<'JSON'
+{
+  "findings": [
+    {
+      "project": "examples/cdk-multilang",
+      "package": "brace-expansion",
+      "advisory": "GHSA-jxxr-4gwj-5jf2",
+      "node": "node_modules/aws-cdk-lib/node_modules/brace-expansion",
+      "visibility": "visible",
+      "status": "upstream-bundled-pending-fix"
+    }
+  ]
+}
+JSON
+
+: >"${tmpdir}/empty-allowlist.txt"
+
+expect_success_contains() {
+  local expected="$1"
+  shift
+
+  local output
+  if ! output="$("$@" 2>&1)"; then
+    printf '%s\n' "${output}"
+    echo "npm-audit-policy-test: expected command to succeed"
+    exit 1
+  fi
+  if ! grep -Fq "${expected}" <<<"${output}"; then
+    printf '%s\n' "${output}"
+    echo "npm-audit-policy-test: expected output to contain: ${expected}"
+    exit 1
+  fi
+}
+
+expect_failure_contains() {
+  local expected="$1"
+  shift
+
+  local output
+  if output="$("$@" 2>&1)"; then
+    printf '%s\n' "${output}"
+    echo "npm-audit-policy-test: expected command to fail"
+    exit 1
+  fi
+  if ! grep -Fq "${expected}" <<<"${output}"; then
+    printf '%s\n' "${output}"
+    echo "npm-audit-policy-test: expected failure output to contain: ${expected}"
+    exit 1
+  fi
+}
+
+expect_success_contains \
+  "visible unallowlisted finding(s)" \
+  node "${checker}" "${tmpdir}/audit.json" "${tmpdir}/empty-allowlist.txt" examples/cdk-multilang "${tmpdir}/visible.json"
+
+expect_failure_contains \
+  "unallowlisted finding(s)" \
+  node "${checker}" "${tmpdir}/audit.json" "${tmpdir}/empty-allowlist.txt" examples/cdk-multilang
+
+printf '%s\n' "${finding}" >"${tmpdir}/allowlist.txt"
+expect_success_contains \
+  "allowlisted finding(s)" \
+  node "${checker}" "${tmpdir}/audit.json" "${tmpdir}/allowlist.txt" examples/cdk-multilang
+
+expect_failure_contains \
+  "visible finding(s) cannot also be in the suppression allowlist" \
+  node "${checker}" "${tmpdir}/audit.json" "${tmpdir}/allowlist.txt" examples/cdk-multilang "${tmpdir}/visible.json"
+
+if grep -Fxq "${finding}" hgm-infra/planning/theorydb-supply-chain-allowlist.txt; then
+  echo "npm-audit-policy-test: THE-1757 brace-expansion finding must not be in the suppression allowlist"
+  exit 1
+fi
+
+node <<'NODE'
+const fs = require('node:fs');
+
+const lock = JSON.parse(fs.readFileSync('examples/cdk-multilang/package-lock.json', 'utf8'));
+const cdkLib = lock.packages?.['node_modules/aws-cdk-lib'];
+if (cdkLib?.version !== '2.257.0') {
+  throw new Error(`expected aws-cdk-lib lock entry to remain 2.257.0 while the visible policy is active, got ${cdkLib?.version ?? 'missing'}`);
+}
+
+const bundledBrace = lock.packages?.['node_modules/aws-cdk-lib/node_modules/brace-expansion'];
+if (bundledBrace?.version !== '5.0.5') {
+  throw new Error(`expected aws-cdk-lib bundled brace-expansion lock entry to remain 5.0.5, got ${bundledBrace?.version ?? 'missing'}`);
+}
+
+const policy = JSON.parse(fs.readFileSync('hgm-infra/planning/theorydb-visible-npm-audit-findings.json', 'utf8'));
+const hasVisibleBracePolicy = policy.findings?.some(
+  (finding) =>
+    finding.project === 'examples/cdk-multilang' &&
+    finding.package === 'brace-expansion' &&
+    finding.advisory === 'GHSA-jxxr-4gwj-5jf2' &&
+    finding.node === 'node_modules/aws-cdk-lib/node_modules/brace-expansion' &&
+    finding.visibility === 'visible' &&
+    finding.current_upstream_version === '2.257.0' &&
+    finding.current_bundled_version === '5.0.5',
+);
+if (!hasVisibleBracePolicy) {
+  throw new Error('expected visible THE-1757 brace-expansion policy for bundled version 5.0.5');
+}
+NODE
+
+echo "npm-audit-policy-test: PASS"


### PR DESCRIPTION
Linear: THE-1757

## Summary
- Removed the exact npm-audit suppression allowlist entry for `GHSA-jxxr-4gwj-5jf2` in `examples/cdk-multilang`.
- Confirmed there is no safe upstream CDK bundle yet: npm reports `aws-cdk-lib@2.257.0` as latest, and `npm audit fix --package-lock-only` reports bundled `brace-expansion@5.0.5` cannot be fixed automatically until `aws-cdk-lib` updates.
- Added a separate visible npm-audit policy (`hgm-infra/planning/theorydb-visible-npm-audit-findings.json`) so SEC-2 remains green only while the advisory is still printed in evidence as a visible upstream-bundled finding, not hidden as an allowlist suppression.
- Added verifier coverage (`scripts/test-npm-audit-policy.sh`) proving visible findings pass, untracked findings fail, and a visible finding cannot also be present in the suppression allowlist.

## Validation
```text
$ git diff --check origin/staging...HEAD
# PASS (no output)
```

```text
$ make rubric
Status: PASS (pass=36 fail=0 blocked=0)
verify-theorycloud-tabletheory-subtree: PASS (output=/tmp/theorycloud-tabletheory-source/tabletheory; included=86; excluded=53)
rubric: PASS
```

```text
$ bash scripts/verify-branch-release-supply-chain.sh
branch-release: PASS
```

```text
$ bash scripts/verify-branch-version-sync.sh
branch-version-sync: SKIP
```

```text
$ bash scripts/test-npm-audit-policy.sh && bash scripts/sec-npm-audit.sh
npm-audit-policy-test: PASS
npm-audit: PASS (ts)
npm-audit: PASS (contract-tests/runners/ts)
npm-audit: 1 visible unallowlisted finding(s) in examples/cdk-multilang
npm-audit: visible findings remain in SEC-2 evidence and are not supply-chain allowlist suppressions
  NPM-AUDIT:examples/cdk-multilang:brace-expansion:GHSA-jxxr-4gwj-5jf2:node_modules/aws-cdk-lib/node_modules/brace-expansion
npm-audit: PASS (examples/cdk-multilang; findings handled by repo policy)
npm-audit: PASS
```

```text
$ direct THE-1757 allowlist/lockfile assertion
allowlist-check: PASS prior suppression line absent from supply-chain allowlist
lock-evidence: aws-cdk-lib=2.257.0
lock-evidence: aws-cdk-lib bundled minimatch=10.2.5 depends brace-expansion=^5.0.5
lock-evidence: 5.0.5 at node_modules/aws-cdk-lib/node_modules/brace-expansion
```

## GitHub Actions
- Unit Coverage (Short) — success
- TypeScript (TS) — success
- Python (PY) — success
- Quality Gates (10/10 Rubric) — success