### PR TITLE
fix(release): recover release cycle guardrails

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -20,6 +20,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Verify release cycle state
+        run: |
+          bash scripts/verify-branch-version-sync.sh
+          bash scripts/verify-release-cycle-state.sh
+
       - name: Release Please (PR only)
         id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,6 +14,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Verify release cycle state
+        run: |
+          bash scripts/verify-branch-version-sync.sh
+          bash scripts/verify-release-cycle-state.sh
+
       - name: Release Please (Prerelease)
         id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - name: Verify release cycle state
+        run: |
+          bash scripts/verify-branch-version-sync.sh
+          bash scripts/verify-release-cycle-state.sh
+
       - name: Compute release-as (align to premain RC)
         id: version
         run: |

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -25,8 +25,31 @@ jobs:
 
       - name: Verify release cycle state
         run: |
+          set -euo pipefail
+
           bash scripts/verify-branch-version-sync.sh
-          bash scripts/verify-release-cycle-state.sh
+
+          strict_log="$(mktemp)"
+          pending_log="$(mktemp)"
+          cleanup() {
+            rm -f "${strict_log}" "${pending_log}"
+          }
+          trap cleanup EXIT
+
+          if bash scripts/verify-release-cycle-state.sh >"${strict_log}" 2>&1; then
+            cat "${strict_log}"
+            exit 0
+          fi
+
+          if RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true bash scripts/verify-release-cycle-state.sh >"${pending_log}" 2>&1; then
+            cat "${pending_log}"
+            echo "release-cycle-state: pending stable promotion accepted for stable Release PR generation"
+            exit 0
+          fi
+
+          cat "${strict_log}"
+          cat "${pending_log}"
+          exit 1
 
       - name: Compute release-as (align to premain RC)
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (for release state verification)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Verify release cycle state
+        if: github.ref == 'refs/heads/main'
+        run: |
+          bash scripts/verify-branch-version-sync.sh
+          bash scripts/verify-release-cycle-state.sh
+
       - name: Checkout (for tag-triggered assets)
         if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,46 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Verify release cycle state
+      - name: Classify release cycle state
         if: github.ref == 'refs/heads/main'
+        id: cycle
         run: |
+          set -euo pipefail
+
           bash scripts/verify-branch-version-sync.sh
-          bash scripts/verify-release-cycle-state.sh
+
+          strict_log="$(mktemp)"
+          pending_log="$(mktemp)"
+          cleanup() {
+            rm -f "${strict_log}" "${pending_log}"
+          }
+          trap cleanup EXIT
+
+          if bash scripts/verify-release-cycle-state.sh >"${strict_log}" 2>&1; then
+            cat "${strict_log}"
+            echo "pending_stable_promotion=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true bash scripts/verify-release-cycle-state.sh >"${pending_log}" 2>&1; then
+            cat "${pending_log}"
+            echo "pending_stable_promotion=true" >> "${GITHUB_OUTPUT}"
+            {
+              echo "### Stable release skipped"
+              echo
+              echo "Pending stable promotion detected. release-pr.yml must open the stable release-please PR; stable release creation resumes only after that PR merges and strict equality is restored."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          cat "${strict_log}"
+          cat "${pending_log}"
+          exit 1
+
+      - name: Skip stable release during pending promotion
+        if: github.ref == 'refs/heads/main' && steps.cycle.outputs.pending_stable_promotion == 'true'
+        run: |
+          echo "release-cycle-state: pending stable promotion detected; stable release creation is skipped until the stable release-please PR merges"
 
       - name: Checkout (for tag-triggered assets)
         if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
@@ -93,7 +128,7 @@ jobs:
 
       - name: Release Please (Stable)
         id: release
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.cycle.outputs.pending_stable_promotion != 'true'
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,19 @@ Stable promotion path:
   strips RC state from the prerelease manifest and SDK version files before the PR targets `main`; the stable manifest is
   left for release-please to advance in the stable Release PR.
 - Open a PR from the normalized promotion branch to `main`. Raw RC files must not land on `main`.
+- After the normalized promotion PR merges to `main`, the release cycle may enter a short **pending stable promotion**
+  state: `.release-please-manifest.json` remains at the prior stable version while
+  `.release-please-manifest.premain.json` and the TypeScript/Python version files are normalized to the next stable
+  version. This state is allowed only until `.github/workflows/release-pr.yml` opens the stable release-please PR and that
+  PR merges.
+- Pending stable promotion is explicit automation state only:
+  `RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true` may be used by the release workflows to verify the normalized
+  promotion commit, and `.github/workflows/release.yml` must skip stable release creation while that state is present.
+- After the stable release-please PR merges, strict stable equality is required again: run
+  `bash scripts/verify-release-cycle-state.sh` without the pending env var, and confirm the stable manifest and SDK files
+  match.
+- If pending state persists because release-please did not open the stable PR, pause and investigate the workflow/check
+  failure. Do not patch `main`, retag, edit releases, or hand-edit manifests to advance the cycle.
 - After the stable release is published, sync `main` back to `staging` and `premain` through PRs, or through an explicitly
   documented automation path that runs the same verifiers and does not directly mutate protected branches.
 
@@ -94,6 +107,8 @@ Release watchpoints and stop conditions:
   stable release.
 - Stop if SEC-2/govulncheck still observes Go `1.26.3`, COM-8 branch/version sync fails, or release-please opens a
   stable PR for an RC version.
+- Stop if `main` remains in pending stable promotion and no stable release-please PR opens for the normalized stable
+  version.
 - Stop if a release workflow was expected to create a release but did not report `release_created`, if asset/publish steps
   have no `tag_name`, or if a GitHub release exists without the TypeScript/Python assets.
 - Stop if automation tries to push directly to `staging`, `premain`, or `main` where this policy requires PR sync.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,44 @@ Multi-language versioning:
 - **TypeScript**: `ts/package.json`, `ts/package-lock.json`
 - **Python**: `py/src/theorydb_py/version.json`
 
+Release ownership:
+
+- `staging` owns integration-ready code, docs, security/toolchain updates, and the latest stable baseline returned from
+  `main`. It must not pretend to cut a release.
+- `premain` owns RC generation. It may carry `X.Y.Z-rc.N` in the prerelease manifest and SDK version files only while
+  the prerelease lane is active.
+- `main` owns stable state only. The stable manifest and SDK version files on `main` must never contain `-rc`.
+
+Stable promotion path:
+
+- Create a promotion branch from `origin/main`.
+- Merge `origin/premain` into that promotion branch locally or in a PR branch, not directly into `main`.
+- Run `bash scripts/prepare-stable-promotion.sh --check`, then `--write` after reviewing the deterministic plan. This
+  strips RC state from the prerelease manifest and SDK version files before the PR targets `main`; the stable manifest is
+  left for release-please to advance in the stable Release PR.
+- Open a PR from the normalized promotion branch to `main`. Raw RC files must not land on `main`.
+- After the stable release is published, sync `main` back to `staging` and `premain` through PRs, or through an explicitly
+  documented automation path that runs the same verifiers and does not directly mutate protected branches.
+
+Release watchpoints and stop conditions:
+
+- Stop if `main` stable files contain `-rc`, or if `.release-please-manifest.json` is an RC version.
+- Stop if `premain` stable manifest is behind `origin/main`, or if `staging` lacks the latest stable baseline after a
+  stable release.
+- Stop if SEC-2/govulncheck still observes Go `1.26.3`, COM-8 branch/version sync fails, or release-please opens a
+  stable PR for an RC version.
+- Stop if a release workflow was expected to create a release but did not report `release_created`, if asset/publish steps
+  have no `tag_name`, or if a GitHub release exists without the TypeScript/Python assets.
+- Stop if automation tries to push directly to `staging`, `premain`, or `main` where this policy requires PR sync.
+
+Useful checks:
+
+- `bash scripts/verify-branch-release-supply-chain.sh`
+- `bash scripts/verify-branch-version-sync.sh`
+- `bash scripts/verify-release-cycle-state.sh`
+- `bash scripts/watch-release-cycle.sh` for read-only PASS/WARN/FAIL branch and release watchpoints; add `--strict`
+  before merge/release gates.
+
 Every PR to `staging` must check both release and release-candidate version alignment before it is opened or updated.
 The stable release baseline and prerelease/RC baseline must agree with the current `main` line so release-please never
 generates an older RC (for example `v1.6.0-rc.N`) after a newer stable release (for example `v1.7.0`) has shipped.

--- a/docs/development/planning/templates/high-risk-branch-release-policy.template.md
+++ b/docs/development/planning/templates/high-risk-branch-release-policy.template.md
@@ -26,8 +26,10 @@ If the project uses separate integration, prerelease, and stable branches, prefe
 3. Prerelease automation produces `vX.Y.Z-rc.N` on `[prerelease-branch]`.
 4. Create a promotion branch from `[release-branch]`, merge `[prerelease-branch]` into it, and normalize RC-owned files
    to stable state before opening the PR to `[release-branch]`.
-5. Stable automation publishes immutable `vX.Y.Z`.
-6. Sync the stable baseline back to `[integration-branch]` and `[prerelease-branch]` through PRs or documented verified
+5. After the normalized promotion PR merges, release-PR automation opens the stable release PR while release automation
+   skips publishing during the temporary pending stable promotion state.
+6. Merging the stable release PR restores strict equality and stable automation publishes immutable `vX.Y.Z`.
+7. Sync the stable baseline back to `[integration-branch]` and `[prerelease-branch]` through PRs or documented verified
    automation.
 
 ## Protections (required)
@@ -56,7 +58,15 @@ Document forbidden stable-branch states:
 - stable manifest set to `X.Y.Z-rc.N`.
 - language/package version files left at `X.Y.Z-rc.N`.
 - release automation opening a stable release PR for an RC version.
+- pending stable promotion persisting after the normalized promotion commit without an open stable release PR.
 - direct branch pushes or ref mutations where policy requires PR sync.
+
+If release-please or another release-PR tool leaves the stable manifest at the prior stable version until the stable
+release PR merges, document the state as explicit pending stable promotion. The pending verifier mode must be visible in
+the workflow, limited to the release branch, require normalized stable package files to be internally consistent and ahead
+of the current stable baseline, and must not publish a stable release. Once the stable release PR merges,
+strict stable equality is required again. If the pending state persists because no stable release PR opens, pause and
+investigate; do not patch the release branch by hand.
 
 ## Required workflow artifacts
 
@@ -82,6 +92,7 @@ Pause before merge or release when:
 - security/governance checks still observe a vulnerable toolchain or dependency state.
 - branch/version sync checks fail.
 - release automation completes without creating the expected release.
+- pending stable promotion persists without an open stable release PR.
 - release asset steps have no tag name, or the GitHub release exists without required assets.
 - automation attempts direct branch mutation where the documented path expects PR sync.
 

--- a/docs/development/planning/templates/high-risk-branch-release-policy.template.md
+++ b/docs/development/planning/templates/high-risk-branch-release-policy.template.md
@@ -7,11 +7,28 @@ This template is intended to be copied and filled per project.
 - `[prerelease-branch]` — prerelease integration branch (source of prereleases).
 - `[release-branch]` — release branch (source of stable releases).
 
+Define exactly what each branch owns. For a three-branch model, document:
+
+- `[integration-branch]` owns normal work and the latest stable baseline after release.
+- `[prerelease-branch]` owns RC state and may carry `X.Y.Z-rc.N` in prerelease manifests and SDK/package files.
+- `[release-branch]` owns stable state only; stable manifests and SDK/package files must not contain `-rc`.
+
 ## Merge flow (expected)
 
 - Feature/fix work lands via PRs into `[prerelease-branch]`.
 - A release is cut by merging `[prerelease-branch]` into `[release-branch]` (via PR).
 - Hotfixes may merge directly into `[release-branch]` (then backported to `[prerelease-branch]`).
+
+If the project uses separate integration, prerelease, and stable branches, prefer this stable-promotion flow:
+
+1. Work lands on `[integration-branch]`.
+2. `[integration-branch]` -> `[prerelease-branch]` PR starts the prerelease lane.
+3. Prerelease automation produces `vX.Y.Z-rc.N` on `[prerelease-branch]`.
+4. Create a promotion branch from `[release-branch]`, merge `[prerelease-branch]` into it, and normalize RC-owned files
+   to stable state before opening the PR to `[release-branch]`.
+5. Stable automation publishes immutable `vX.Y.Z`.
+6. Sync the stable baseline back to `[integration-branch]` and `[prerelease-branch]` through PRs or documented verified
+   automation.
 
 ## Protections (required)
 
@@ -34,6 +51,13 @@ Implementation options (pick one and pin versions):
 - **release-please** (merge-driven versioning + changelog updates)
 - **goreleaser** (tag-driven releases + artifact builds)
 
+Document forbidden stable-branch states:
+
+- stable manifest set to `X.Y.Z-rc.N`.
+- language/package version files left at `X.Y.Z-rc.N`.
+- release automation opening a stable release PR for an RC version.
+- direct branch pushes or ref mutations where policy requires PR sync.
+
 ## Required workflow artifacts
 
 - `.github/workflows/prerelease.yml`
@@ -45,3 +69,22 @@ Implementation options (pick one and pin versions):
   - the workflows don’t exist,
   - tools are unpinned (`@latest`),
   - releases are not gated on the project’s quality/security surface.
+
+Evidence should include deterministic branch/version checks and a read-only release watch command.
+
+## Watchpoints / stop conditions
+
+Pause before merge or release when:
+
+- stable-branch files contain `-rc`.
+- prerelease stable baseline is behind the release branch.
+- integration branch lacks the latest stable baseline after a stable release.
+- security/governance checks still observe a vulnerable toolchain or dependency state.
+- branch/version sync checks fail.
+- release automation completes without creating the expected release.
+- release asset steps have no tag name, or the GitHub release exists without required assets.
+- automation attempts direct branch mutation where the documented path expects PR sync.
+
+Allowed recovery should be non-destructive: new PR branches from known bases, deterministic normalization scripts, and
+verified PR-based sync. Do not retag, overwrite release assets, force-push, delete protected branches, or merge around
+quality/security checks.

--- a/docs/development/planning/theorydb-branch-release-policy.md
+++ b/docs/development/planning/theorydb-branch-release-policy.md
@@ -8,12 +8,51 @@ This document defines the intended branch strategy and release automation for Ta
 - `premain` — prerelease branch (source of prereleases).
 - `main` — release branch (source of stable releases).
 
+## Ownership
+
+- `staging` owns integration-ready code, docs, security/toolchain updates, and release-cycle guardrails before they enter
+  prerelease or stable lanes. After a stable release, `staging` must receive the latest stable baseline from `main` so the
+  next cycle starts from the released state.
+- `premain` owns prerelease state. The prerelease manifest `.release-please-manifest.premain.json` and SDK version files
+  (`ts/package.json`, `ts/package-lock.json`, `py/src/theorydb_py/version.json`) may carry `X.Y.Z-rc.N` while an RC is in
+  progress. Its stable manifest `.release-please-manifest.json` must stay aligned with the latest stable baseline.
+- `main` owns stable state only. `.release-please-manifest.json`, `ts/package.json`, `ts/package-lock.json`, and
+  `py/src/theorydb_py/version.json` must never contain `-rc` on `main`.
+
 ## Merge flow (expected)
 
 - Feature/fix work lands via PRs into `staging`.
 - An **RC** is cut by merging `staging` into `premain` (via PR), then merging the release-please prerelease PR.
-- A **release** is cut by merging `premain` into `main` (via PR), then merging the release-please stable release PR.
+- A **release** is prepared by creating a promotion branch from `origin/main`, merging `origin/premain` into that branch,
+  normalizing RC-owned files to stable state, and opening a PR to `main`.
+- A **release** is cut by merging the normalized promotion PR to `main`, then merging the release-please stable release PR.
 - Hotfixes should still follow `staging` -> `premain` -> `main` so version lines stay aligned.
+
+## Stable promotion path
+
+Do not raw-merge `premain` into `main` and then fix `main`. Use this path instead:
+
+1. Fetch without pruning and record `origin/staging`, `origin/premain`, and `origin/main` SHAs.
+2. Create a promotion branch from `origin/main`.
+3. Merge `origin/premain` into the promotion branch. Resolve conflicts only on the promotion branch.
+4. Run `bash scripts/prepare-stable-promotion.sh --check`. Review the target stable version and planned file changes.
+5. Run `bash scripts/prepare-stable-promotion.sh --write` when the plan is correct.
+6. Run `bash scripts/verify-release-cycle-state.sh` and `bash scripts/verify-branch-release-supply-chain.sh`.
+7. Open a PR from the normalized promotion branch to `main`.
+8. After the promotion PR merges, allow `.github/workflows/release-pr.yml` to open the stable release-please PR.
+9. Merge the stable release-please PR only after quality/security gates pass and the version is stable `X.Y.Z`, not
+   `X.Y.Z-rc.N`.
+
+`scripts/prepare-stable-promotion.sh` normalizes `.release-please-manifest.premain.json`, `ts/package.json`,
+`ts/package-lock.json`, and `py/src/theorydb_py/version.json`. It validates but does not advance
+`.release-please-manifest.json`; release-please must advance the stable manifest in the stable release PR.
+
+Forbidden on `main`:
+
+- `.release-please-manifest.json` set to an RC version.
+- `ts/package.json`, `ts/package-lock.json`, or `py/src/theorydb_py/version.json` left at `X.Y.Z-rc.N`.
+- A stable release PR titled or shaped as an RC release.
+- Direct pushes or branch-ref API mutations to `main`, `premain`, or `staging` where this policy requires PR sync.
 
 ## Post-release sync (required)
 
@@ -27,6 +66,14 @@ as well so prereleases do not remain on an older major/minor track.
 
 If `.release-please-manifest.premain.json` is behind the latest stable version, reset it to the latest stable version
 to start the next prerelease cycle from the correct baseline.
+
+Acceptable post-stable sync paths:
+
+- Preferred: PR from `main` to `staging`, then PR from `main` or updated `staging` to `premain`.
+- Acceptable automation: a documented workflow that creates PR branches, runs COM-8 and SEC-2 checks, and never pushes
+  directly to protected branches.
+- Recovery: if a branch is already stranded, create a new PR branch from the correct base and replay only the needed file
+  state. Do not retag, overwrite release assets, force-push, delete branches, or mutate GitHub releases.
 
 ## Protections (required)
 
@@ -69,6 +116,11 @@ GitHub Releases must attach build artifacts for the non-Go SDKs:
 - **TypeScript:** `npm pack` output from `ts/` (tarball)
 - **Python:** wheel + sdist from `py/` (`python -m build`)
 
+If a release workflow was expected to publish but `release_created` is false, pause before trying to patch files by hand.
+If an asset upload or publish step has no `tag_name`, fail the workflow. If a GitHub release exists but TypeScript/Python
+assets are missing, use a documented asset recovery workflow only after confirming the tag and release are immutable and
+correct.
+
 ## Multi-language versioning (required)
 
 - **Single shared repo version:** Go, TypeScript, and Python use the same GitHub tag/release version.
@@ -84,6 +136,9 @@ These files are required to exist and be kept current:
 
 - `.github/workflows/prerelease.yml`
 - `.github/workflows/release.yml`
+- `scripts/verify-release-cycle-state.sh`
+- `scripts/watch-release-cycle.sh`
+- `scripts/prepare-stable-promotion.sh`
 
 Additionally, quality/security workflows should run on PRs to (and/or pushes on) both protected branches:
 
@@ -94,3 +149,19 @@ Additionally, quality/security workflows should run on PRs to (and/or pushes on)
 
 - This policy is intentionally tool-agnostic; the rubric requires automation and pinning, not a specific release tool.
 - Branch protection rules are configured in the hosting platform (GitHub settings) and must be treated as part of the supply chain.
+
+## Release watchpoints
+
+Run `bash scripts/watch-release-cycle.sh` during a release and rerun with `--strict` before merge/release gates. Pause on:
+
+- `origin/main` stable files containing `-rc`.
+- `.release-please-manifest.json` set to an RC version.
+- `origin/premain` stable manifest behind `origin/main`.
+- `origin/staging` missing the latest stable baseline after a stable release.
+- SEC-2/govulncheck still observing Go `1.26.3`.
+- COM-8 branch/version sync failing.
+- release-please opening a stable PR for an RC version.
+- a release workflow expected to create a release but not reporting `release_created`.
+- asset/publish steps missing `tag_name`.
+- a GitHub release existing without uploaded TypeScript/Python assets.
+- automation attempting direct branch mutation where PR sync is required.

--- a/docs/development/planning/theorydb-branch-release-policy.md
+++ b/docs/development/planning/theorydb-branch-release-policy.md
@@ -47,11 +47,35 @@ Do not raw-merge `premain` into `main` and then fix `main`. Use this path instea
 `ts/package-lock.json`, and `py/src/theorydb_py/version.json`. It validates but does not advance
 `.release-please-manifest.json`; release-please must advance the stable manifest in the stable release PR.
 
+### Pending stable promotion
+
+The normalized promotion commit on `main` is a deliberate temporary state:
+
+- `.release-please-manifest.json` remains at the previous stable version.
+- `.release-please-manifest.premain.json`, `ts/package.json`, `ts/package-lock.json`, and
+  `py/src/theorydb_py/version.json` are stable, non-prerelease, internally consistent, and may be one stable base ahead of
+  `.release-please-manifest.json`.
+- The state is valid only between the normalized promotion PR merge to `main` and the stable release-please PR merge.
+
+Automation must make this state explicit. `.github/workflows/release-pr.yml` may verify with
+`RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true` so it can open the stable release-please PR. `.github/workflows/release.yml`
+must classify the same state, verify it with the pending env var, and skip stable release creation until strict equality
+is restored.
+
+After the stable release-please PR merges, pending mode is no longer allowed operationally. Run
+`bash scripts/verify-release-cycle-state.sh` without `RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION`; the stable manifest
+and SDK files must match again before the stable release workflow creates `vX.Y.Z`.
+
+If the pending state persists because release-please did not open the stable PR, pause and investigate workflow logs,
+permissions, release-please configuration, and COM-8 results. Do not patch `main`, hand-advance manifests, retag, or edit
+GitHub releases to force the cycle forward.
+
 Forbidden on `main`:
 
 - `.release-please-manifest.json` set to an RC version.
 - `ts/package.json`, `ts/package-lock.json`, or `py/src/theorydb_py/version.json` left at `X.Y.Z-rc.N`.
 - A stable release PR titled or shaped as an RC release.
+- A pending stable promotion that persists without an open stable release-please PR for the normalized stable version.
 - Direct pushes or branch-ref API mutations to `main`, `premain`, or `staging` where this policy requires PR sync.
 
 ## Post-release sync (required)
@@ -161,6 +185,7 @@ Run `bash scripts/watch-release-cycle.sh` during a release and rerun with `--str
 - SEC-2/govulncheck still observing Go `1.26.3`.
 - COM-8 branch/version sync failing.
 - release-please opening a stable PR for an RC version.
+- `origin/main` in pending stable promotion without an open stable release-please PR for the normalized stable version.
 - a release workflow expected to create a release but not reporting `release_created`.
 - asset/publish steps missing `tag_name`.
 - a GitHub release existing without uploaded TypeScript/Python assets.

--- a/examples/multi-tenant/go.mod
+++ b/examples/multi-tenant/go.mod
@@ -2,7 +2,7 @@ module github.com/theory-cloud/tabletheory/examples/multi-tenant
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/theory-cloud/tabletheory
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/aws/aws-lambda-go v1.54.0

--- a/hgm-infra/verifiers/hgm-verify-rubric.sh
+++ b/hgm-infra/verifiers/hgm-verify-rubric.sh
@@ -624,7 +624,7 @@ CMD_LINT_CONFIG="golangci-lint config verify -c .golangci-v2.yml"
 CMD_COV_THRESHOLD="bash scripts/verify-coverage-threshold.sh"
 CMD_CI_RUBRIC="bash scripts/verify-ci-rubric-enforced.sh"
 CMD_DYNAMODB_PIN="bash scripts/verify-dynamodb-local-pin.sh"
-CMD_BRANCH_RELEASE="bash scripts/verify-branch-release-supply-chain.sh && bash scripts/verify-branch-version-sync.sh"
+CMD_BRANCH_RELEASE="bash scripts/verify-branch-release-supply-chain.sh && bash scripts/verify-branch-version-sync.sh && bash scripts/verify-release-cycle-state.sh"
 
 CMD_SAST="check_security_config_not_diluted && bash scripts/sec-gosec.sh"
 CMD_VULN="bash scripts/sec-dependency-scans.sh"

--- a/scripts/prepare-stable-promotion.sh
+++ b/scripts/prepare-stable-promotion.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Normalize RC-owned files on a stable-promotion branch before it is proposed to main.
+#
+# Expected use:
+#   1. Create a promotion branch from origin/main.
+#   2. Merge origin/premain into that branch without pushing to main.
+#   3. Run this script in dry-run mode, then with --write after reviewing the plan.
+#   4. Open a PR from the normalized promotion branch to main.
+#
+# This script does not create branches, merge refs, push, tag, or publish releases.
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/prepare-stable-promotion.sh [--check|--write] [--expected-version X.Y.Z]
+
+Options:
+  --check                 Print the normalization plan only. This is the default.
+  --write                 Rewrite RC-owned files to the stable baseline.
+  --expected-version VER  Require the derived stable baseline to equal VER.
+  -h, --help              Show this help.
+
+Files normalized with --write:
+  .release-please-manifest.premain.json
+  ts/package.json
+  ts/package-lock.json
+  py/src/theorydb_py/version.json
+
+The stable manifest (.release-please-manifest.json) is validated but not advanced here.
+Release Please must advance it in the stable release PR so the immutable release remains
+traceable to the release workflow.
+USAGE
+}
+
+mode="check"
+expected_version=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      mode="check"
+      shift
+      ;;
+    --write)
+      mode="write"
+      shift
+      ;;
+    --expected-version)
+      if [[ $# -lt 2 ]]; then
+        echo "stable-promotion: FAIL (--expected-version requires a value)" >&2
+        exit 2
+      fi
+      expected_version="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "stable-promotion: FAIL (unknown argument: $1)" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${mode}" != "check" && "${mode}" != "write" ]]; then
+  echo "stable-promotion: FAIL (invalid mode: ${mode})" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+python3 - "${mode}" "${expected_version}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+mode = sys.argv[1]
+expected_version = sys.argv[2].strip()
+
+semver_re = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$")
+
+
+def fail(message: str) -> None:
+    print(f"stable-promotion: FAIL ({message})")
+    raise SystemExit(1)
+
+
+def load_json(path: str) -> object:
+    p = Path(path)
+    if not p.is_file():
+        fail(f"missing {path}")
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def semver_info(version: str) -> tuple[tuple[int, int, int], str, bool]:
+    match = semver_re.match(version.strip())
+    if not match:
+        fail(f"invalid semver: {version}")
+    base_tuple = tuple(int(part) for part in match.group(1, 2, 3))
+    base = ".".join(str(part) for part in base_tuple)
+    prerelease = match.group(4) or ""
+    return base_tuple, base, bool(prerelease)
+
+
+stable_manifest = load_json(".release-please-manifest.json")
+premain_manifest = load_json(".release-please-manifest.premain.json")
+ts_package = load_json("ts/package.json")
+ts_lock = load_json("ts/package-lock.json")
+py_version = load_json("py/src/theorydb_py/version.json")
+
+versions = {
+    ".release-please-manifest.json": stable_manifest.get(".", ""),
+    ".release-please-manifest.premain.json": premain_manifest.get(".", ""),
+    "ts/package.json": ts_package.get("version", ""),
+    "ts/package-lock.json": ts_lock.get("version", ""),
+    "ts/package-lock.json packages['']": ts_lock.get("packages", {}).get("", {}).get("version", ""),
+    "py/src/theorydb_py/version.json": py_version.get("version", ""),
+}
+
+for path, version in versions.items():
+    if not isinstance(version, str) or not version.strip():
+        fail(f"missing version in {path}")
+
+parsed = {path: semver_info(version) for path, version in versions.items()}
+
+stable_version = versions[".release-please-manifest.json"]
+if parsed[".release-please-manifest.json"][2]:
+    fail(f"stable manifest is a prerelease: {stable_version}")
+
+target_tuple, target_version = max((info[0], info[1]) for info in parsed.values())
+
+if expected_version:
+    expected_tuple, expected_base, expected_is_prerelease = semver_info(expected_version)
+    if expected_is_prerelease:
+        fail(f"--expected-version must be stable, got {expected_version}")
+    if expected_tuple != target_tuple:
+        fail(f"derived stable baseline {target_version} != expected {expected_base}")
+    target_version = expected_base
+
+if parsed[".release-please-manifest.json"][0] > target_tuple:
+    fail(
+        "stable manifest is ahead of derived promotion baseline "
+        f"({stable_version} > {target_version})"
+    )
+
+changes: list[tuple[str, str, str]] = []
+
+
+def plan(path: str, current: str, desired: str) -> None:
+    if current != desired:
+        changes.append((path, current, desired))
+
+
+plan(".release-please-manifest.premain.json", versions[".release-please-manifest.premain.json"], target_version)
+plan("ts/package.json", versions["ts/package.json"], target_version)
+plan("ts/package-lock.json", versions["ts/package-lock.json"], target_version)
+plan("ts/package-lock.json packages['']", versions["ts/package-lock.json packages['']"], target_version)
+plan("py/src/theorydb_py/version.json", versions["py/src/theorydb_py/version.json"], target_version)
+
+print(f"stable-promotion: target={target_version}")
+print(f"stable-promotion: stable-manifest={stable_version} (validated, not advanced)")
+
+if not changes:
+    print("stable-promotion: PASS (no normalization needed)")
+    raise SystemExit(0)
+
+for path, current, desired in changes:
+    print(f"stable-promotion: PLAN {path}: {current} -> {desired}")
+
+if mode == "check":
+    print("stable-promotion: PASS (dry-run)")
+    raise SystemExit(0)
+
+premain_manifest["."] = target_version
+ts_package["version"] = target_version
+ts_lock["version"] = target_version
+ts_lock.setdefault("packages", {}).setdefault("", {})["version"] = target_version
+py_version["version"] = target_version
+
+files = {
+    ".release-please-manifest.premain.json": premain_manifest,
+    "ts/package.json": ts_package,
+    "ts/package-lock.json": ts_lock,
+    "py/src/theorydb_py/version.json": py_version,
+}
+
+for path, data in files.items():
+    Path(path).write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+print("stable-promotion: PASS (files normalized)")
+PY

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -109,6 +109,22 @@ if [[ -f ".github/workflows/release.yml" ]]; then
     echo "branch-release: release workflow must verify release-cycle state before release-please"
     failures=$((failures + 1))
   }
+  grep -Fq "RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true" ".github/workflows/release.yml" || {
+    echo "branch-release: release workflow must explicitly verify pending stable promotion mode"
+    failures=$((failures + 1))
+  }
+  grep -Fq "pending_stable_promotion" ".github/workflows/release.yml" || {
+    echo "branch-release: release workflow must classify pending stable promotion"
+    failures=$((failures + 1))
+  }
+  grep -Fq "stable release creation is skipped" ".github/workflows/release.yml" || {
+    echo "branch-release: release workflow must skip stable release creation during pending promotion"
+    failures=$((failures + 1))
+  }
+  grep -Fq "steps.cycle.outputs.pending_stable_promotion != 'true'" ".github/workflows/release.yml" || {
+    echo "branch-release: release workflow must gate stable release-please on strict release-cycle state"
+    failures=$((failures + 1))
+  }
   grep -Eq 'missing tag_name output' ".github/workflows/release.yml" || {
     echo "branch-release: release workflow must fail asset/publish steps when tag_name is missing"
     failures=$((failures + 1))
@@ -187,6 +203,14 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
   }
   grep -Fq "scripts/verify-release-cycle-state.sh" ".github/workflows/release-pr.yml" || {
     echo "branch-release: release-pr workflow must verify release-cycle state before release-please"
+    failures=$((failures + 1))
+  }
+  grep -Fq "RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true" ".github/workflows/release-pr.yml" || {
+    echo "branch-release: release-pr workflow must explicitly allow pending stable promotion verification"
+    failures=$((failures + 1))
+  }
+  grep -Fq "pending stable promotion accepted for stable Release PR generation" ".github/workflows/release-pr.yml" || {
+    echo "branch-release: release-pr workflow must document pending promotion PR generation"
     failures=$((failures + 1))
   }
   grep -Eq 'skip-github-release:\s*true' ".github/workflows/release-pr.yml" || {

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -19,6 +19,9 @@ required_files=(
   "release-please-config.json"
   ".release-please-manifest.premain.json"
   ".release-please-manifest.json"
+  "scripts/prepare-stable-promotion.sh"
+  "scripts/verify-release-cycle-state.sh"
+  "scripts/watch-release-cycle.sh"
 )
 
 for f in "${required_files[@]}"; do
@@ -47,6 +50,14 @@ if [[ -f ".github/workflows/prerelease.yml" ]]; then
   }
   grep -Eq 'manifest-file:\s*\.release-please-manifest\.premain\.json' ".github/workflows/prerelease.yml" || {
     echo "branch-release: prerelease workflow must reference .release-please-manifest.premain.json"
+    failures=$((failures + 1))
+  }
+  grep -Fq "scripts/verify-release-cycle-state.sh" ".github/workflows/prerelease.yml" || {
+    echo "branch-release: prerelease workflow must verify release-cycle state before release-please"
+    failures=$((failures + 1))
+  }
+  grep -Fq "scripts/verify-branch-version-sync.sh" ".github/workflows/prerelease.yml" || {
+    echo "branch-release: prerelease workflow must verify branch version sync before release-please"
     failures=$((failures + 1))
   }
 
@@ -94,6 +105,14 @@ if [[ -f ".github/workflows/release.yml" ]]; then
     echo "branch-release: release workflow must reference .release-please-manifest.json"
     failures=$((failures + 1))
   }
+  grep -Fq "scripts/verify-release-cycle-state.sh" ".github/workflows/release.yml" || {
+    echo "branch-release: release workflow must verify release-cycle state before release-please"
+    failures=$((failures + 1))
+  }
+  grep -Eq 'missing tag_name output' ".github/workflows/release.yml" || {
+    echo "branch-release: release workflow must fail asset/publish steps when tag_name is missing"
+    failures=$((failures + 1))
+  }
 
   # Ensure stable releases attach multi-language release artifacts.
   grep -Eq 'release_created' ".github/workflows/release.yml" || {
@@ -135,6 +154,14 @@ if [[ -f ".github/workflows/prerelease-pr.yml" ]]; then
     echo "branch-release: prerelease-pr workflow must reference .release-please-manifest.premain.json"
     failures=$((failures + 1))
   }
+  grep -Fq "scripts/verify-release-cycle-state.sh" ".github/workflows/prerelease-pr.yml" || {
+    echo "branch-release: prerelease-pr workflow must verify release-cycle state before release-please"
+    failures=$((failures + 1))
+  }
+  grep -Fq "scripts/verify-branch-version-sync.sh" ".github/workflows/prerelease-pr.yml" || {
+    echo "branch-release: prerelease-pr workflow must verify branch version sync before release-please"
+    failures=$((failures + 1))
+  }
   grep -Eq 'skip-github-release:\s*true' ".github/workflows/prerelease-pr.yml" || {
     echo "branch-release: prerelease-pr workflow must set skip-github-release: true"
     failures=$((failures + 1))
@@ -156,6 +183,10 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
   }
   grep -Eq 'manifest-file:\s*\.release-please-manifest\.json' ".github/workflows/release-pr.yml" || {
     echo "branch-release: release-pr workflow must reference .release-please-manifest.json"
+    failures=$((failures + 1))
+  }
+  grep -Fq "scripts/verify-release-cycle-state.sh" ".github/workflows/release-pr.yml" || {
+    echo "branch-release: release-pr workflow must verify release-cycle state before release-please"
     failures=$((failures + 1))
   }
   grep -Eq 'skip-github-release:\s*true' ".github/workflows/release-pr.yml" || {

--- a/scripts/verify-release-cycle-state.sh
+++ b/scripts/verify-release-cycle-state.sh
@@ -39,7 +39,9 @@ done
 if [[ "${failures}" -eq 0 ]]; then
   if ! python3 - <<'PY'
 import json
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -50,11 +52,15 @@ def read(path: str) -> object:
     return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
+def fail(message: str) -> None:
+    print(f"release-cycle-state: FAIL ({message})")
+    raise SystemExit(1)
+
+
 def version_info(label: str, version: str) -> tuple[tuple[int, int, int], bool]:
     match = semver_re.match(version.strip())
     if not match:
-        print(f"release-cycle-state: FAIL ({label} has invalid semver {version!r})")
-        raise SystemExit(1)
+        fail(f"{label} has invalid semver {version!r}")
     base = tuple(int(part) for part in match.group(1, 2, 3))
     return base, bool(match.group(4))
 
@@ -75,40 +81,82 @@ stable_files = {
     "py/src/theorydb_py/version.json": py_version,
 }
 
+normalized_promotion_files = {
+    ".release-please-manifest.premain.json": premain,
+    "ts/package.json": ts_package,
+    "ts/package-lock.json": ts_lock_root,
+    "ts/package-lock.json packages['']": ts_lock_pkg,
+    "py/src/theorydb_py/version.json": py_version,
+}
+
 for label, version in {**stable_files, ".release-please-manifest.premain.json": premain}.items():
     if not isinstance(version, str) or not version.strip():
-        print(f"release-cycle-state: FAIL ({label} is missing a version)")
-        raise SystemExit(1)
+        fail(f"{label} is missing a version")
 
 stable_base, stable_is_prerelease = version_info(".release-please-manifest.json", stable)
 if stable_is_prerelease:
-    print(f"release-cycle-state: FAIL (.release-please-manifest.json is prerelease {stable})")
-    raise SystemExit(1)
+    fail(f".release-please-manifest.json is prerelease {stable}")
 
 current_branch = (
-    __import__("os").environ.get("GITHUB_BASE_REF")
-    or __import__("os").environ.get("GITHUB_REF_NAME")
+    os.environ.get("GITHUB_BASE_REF")
+    or os.environ.get("GITHUB_REF_NAME")
     or ""
 )
 if not current_branch:
-    import subprocess
-
     current_branch = subprocess.check_output(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
     ).strip()
+
+pending_mode_raw = os.environ.get("RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION", "")
+pending_mode = pending_mode_raw == "true"
+if pending_mode_raw and pending_mode_raw not in {"true", "false"}:
+    fail("RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION must be exactly true or false")
+
+if pending_mode:
+    if current_branch != "main":
+        fail(
+            "pending stable promotion mode is only allowed on main "
+            f"(current branch: {current_branch})"
+        )
+
+    pending_base = None
+    pending_version = None
+    for label, version in normalized_promotion_files.items():
+        base, is_prerelease = version_info(label, version)
+        if is_prerelease:
+            fail(f"{label} is prerelease {version} in pending stable promotion mode")
+        if pending_base is None:
+            pending_base = base
+            pending_version = version
+            continue
+        if base != pending_base or version != pending_version:
+            fail(
+                "pending stable promotion files are inconsistent "
+                f"({label} {version} != {pending_version})"
+            )
+
+    if pending_base is None or pending_version is None:
+        fail("pending stable promotion has no normalized version files")
+    if pending_base <= stable_base:
+        fail(
+            "pending stable promotion version must be ahead of the stable manifest "
+            f"({pending_version} <= {stable})"
+        )
+
+    print(
+        "release-cycle-state: PASS "
+        f"(branch={current_branch}, mode=pending-stable-promotion, "
+        f"stable={stable}, pending={pending_version})"
+    )
+    raise SystemExit(0)
 
 if current_branch in {"main", "staging"}:
     for label, version in stable_files.items():
         base, is_prerelease = version_info(label, version)
         if is_prerelease:
-            print(f"release-cycle-state: FAIL ({label} is prerelease {version} on {current_branch})")
-            raise SystemExit(1)
-        if base != stable_base:
-            print(
-                "release-cycle-state: FAIL "
-                f"({label} {version} does not match stable manifest {stable})"
-            )
-            raise SystemExit(1)
+            fail(f"{label} is prerelease {version} on {current_branch}")
+        if base != stable_base or version != stable:
+            fail(f"{label} {version} does not match stable manifest {stable}")
 
 print(
     "release-cycle-state: PASS "

--- a/scripts/verify-release-cycle-state.sh
+++ b/scripts/verify-release-cycle-state.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CI-safe local release-cycle checks. This verifier is intentionally local: it
+# fails on checked-out forbidden stable state and on missing guardrails, while
+# remote branch drift is reported by scripts/watch-release-cycle.sh.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+failures=0
+
+fail() {
+  echo "release-cycle-state: FAIL ($1)"
+  failures=$((failures + 1))
+}
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing ${path}"
+  fi
+}
+
+required_files=(
+  "scripts/prepare-stable-promotion.sh"
+  "scripts/watch-release-cycle.sh"
+  ".release-please-manifest.json"
+  ".release-please-manifest.premain.json"
+  "ts/package.json"
+  "ts/package-lock.json"
+  "py/src/theorydb_py/version.json"
+)
+
+for path in "${required_files[@]}"; do
+  require_file "${path}"
+done
+
+if [[ "${failures}" -eq 0 ]]; then
+  if ! python3 - <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+semver_re = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$")
+
+
+def read(path: str) -> object:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def version_info(label: str, version: str) -> tuple[tuple[int, int, int], bool]:
+    match = semver_re.match(version.strip())
+    if not match:
+        print(f"release-cycle-state: FAIL ({label} has invalid semver {version!r})")
+        raise SystemExit(1)
+    base = tuple(int(part) for part in match.group(1, 2, 3))
+    return base, bool(match.group(4))
+
+
+stable = read(".release-please-manifest.json").get(".", "")
+premain = read(".release-please-manifest.premain.json").get(".", "")
+ts_package = read("ts/package.json").get("version", "")
+ts_lock = read("ts/package-lock.json")
+ts_lock_root = ts_lock.get("version", "")
+ts_lock_pkg = ts_lock.get("packages", {}).get("", {}).get("version", "")
+py_version = read("py/src/theorydb_py/version.json").get("version", "")
+
+stable_files = {
+    ".release-please-manifest.json": stable,
+    "ts/package.json": ts_package,
+    "ts/package-lock.json": ts_lock_root,
+    "ts/package-lock.json packages['']": ts_lock_pkg,
+    "py/src/theorydb_py/version.json": py_version,
+}
+
+for label, version in {**stable_files, ".release-please-manifest.premain.json": premain}.items():
+    if not isinstance(version, str) or not version.strip():
+        print(f"release-cycle-state: FAIL ({label} is missing a version)")
+        raise SystemExit(1)
+
+stable_base, stable_is_prerelease = version_info(".release-please-manifest.json", stable)
+if stable_is_prerelease:
+    print(f"release-cycle-state: FAIL (.release-please-manifest.json is prerelease {stable})")
+    raise SystemExit(1)
+
+current_branch = (
+    __import__("os").environ.get("GITHUB_BASE_REF")
+    or __import__("os").environ.get("GITHUB_REF_NAME")
+    or ""
+)
+if not current_branch:
+    import subprocess
+
+    current_branch = subprocess.check_output(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+    ).strip()
+
+if current_branch in {"main", "staging"}:
+    for label, version in stable_files.items():
+        base, is_prerelease = version_info(label, version)
+        if is_prerelease:
+            print(f"release-cycle-state: FAIL ({label} is prerelease {version} on {current_branch})")
+            raise SystemExit(1)
+        if base != stable_base:
+            print(
+                "release-cycle-state: FAIL "
+                f"({label} {version} does not match stable manifest {stable})"
+            )
+            raise SystemExit(1)
+
+print(
+    "release-cycle-state: PASS "
+    f"(branch={current_branch}, stable={stable}, premain={premain})"
+)
+PY
+  then
+    failures=$((failures + 1))
+  fi
+fi
+
+if ! bash scripts/prepare-stable-promotion.sh --check >/tmp/tabletheory-stable-promotion-check.$$ 2>&1; then
+  cat /tmp/tabletheory-stable-promotion-check.$$
+  rm -f /tmp/tabletheory-stable-promotion-check.$$
+  fail "stable promotion helper dry-run failed"
+else
+  rm -f /tmp/tabletheory-stable-promotion-check.$$
+fi
+
+if grep -RInE 'git push +origin +(main|premain|staging)|git push +[^[:space:]]+ +(main|premain|staging)' .github/workflows scripts | grep -v 'verify-release-cycle-state.sh'; then
+  fail "release automation contains direct branch mutation"
+fi
+
+if grep -RInE 'gh api .*git/refs/(heads/)?(main|premain|staging)|gh api .*contents/.*(main|premain|staging)' .github/workflows scripts | grep -v 'verify-release-cycle-state.sh'; then
+  fail "release automation appears to mutate protected branch refs through GitHub API"
+fi
+
+if [[ "${failures}" -ne 0 ]]; then
+  echo "release-cycle-state: FAIL (${failures} issue(s))"
+  exit 1
+fi
+
+echo "release-cycle-state: PASS"

--- a/scripts/watch-release-cycle.sh
+++ b/scripts/watch-release-cycle.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only release-cycle watch helper.
+#
+# Default mode reports PASS/WARN/FAIL findings and exits 0 so it can be used
+# during incident review without masking all findings behind the first failure.
+# Use --strict in CI or before merge/release to exit non-zero on FAIL findings.
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/watch-release-cycle.sh [--strict] [--tag vX.Y.Z]
+
+Options:
+  --strict   Exit non-zero if any FAIL finding is reported.
+  --tag TAG  Check that an existing GitHub release has non-source assets.
+  -h, --help Show this help.
+
+This command reads local refs and, when gh is authenticated, open PR/release
+metadata. It does not fetch, push, merge, tag, publish, edit, or delete anything.
+USAGE
+}
+
+strict=0
+tag_name=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --strict)
+      strict=1
+      shift
+      ;;
+    --tag)
+      if [[ $# -lt 2 ]]; then
+        echo "watch-release-cycle: FAIL (--tag requires a value)" >&2
+        exit 2
+      fi
+      tag_name="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "watch-release-cycle: FAIL (unknown argument: $1)" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+fail_count=0
+warn_count=0
+
+pass() {
+  echo "watch-release-cycle: PASS $1"
+}
+
+warn() {
+  echo "watch-release-cycle: WARN $1"
+  warn_count=$((warn_count + 1))
+}
+
+fail() {
+  echo "watch-release-cycle: FAIL $1"
+  fail_count=$((fail_count + 1))
+}
+
+json_value_at_ref() {
+  local ref="$1"
+  local path="$2"
+  local expr="$3"
+
+  git show "${ref}:${path}" 2>/dev/null | python3 -c '
+import json
+import sys
+
+expr = sys.argv[1]
+data = json.load(sys.stdin)
+if expr == ".":
+    print(data.get(".", "") if isinstance(data, dict) else "")
+    raise SystemExit(0)
+value = data
+for part in expr.split("."):
+    if not part:
+        continue
+    if isinstance(value, dict):
+        value = value.get(part, "")
+    else:
+        value = ""
+print(value if isinstance(value, str) else "")
+' "${expr}"
+}
+
+toolchain_at_ref() {
+  local ref="$1"
+  local path="$2"
+  git show "${ref}:${path}" 2>/dev/null | awk '$1 == "toolchain" { print $2; exit }'
+}
+
+semver_base() {
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+v = sys.argv[1].strip()
+m = re.match(r"^v?(\d+)\.(\d+)\.(\d+)", v)
+if not m:
+    raise SystemExit(1)
+print(".".join(m.group(i) for i in range(1, 4)))
+PY
+}
+
+semver_lt() {
+  python3 - "$1" "$2" <<'PY'
+import re
+import sys
+
+
+def parse(v: str) -> tuple[int, int, int]:
+    m = re.match(r"^v?(\d+)\.(\d+)\.(\d+)", v.strip())
+    if not m:
+        raise SystemExit(2)
+    return tuple(int(m.group(i)) for i in range(1, 4))
+
+raise SystemExit(0 if parse(sys.argv[1]) < parse(sys.argv[2]) else 1)
+PY
+}
+
+refs=(origin/main origin/premain origin/staging)
+for ref in "${refs[@]}"; do
+  if ! git rev-parse --verify --quiet "${ref}" >/dev/null; then
+    warn "${ref} is not available locally; run git fetch origin before relying on this report"
+  fi
+done
+
+main_stable=""
+premain_stable=""
+premain_prerelease=""
+staging_stable=""
+
+if git rev-parse --verify --quiet origin/main >/dev/null; then
+  main_stable="$(json_value_at_ref origin/main .release-please-manifest.json '.')"
+  main_ts="$(json_value_at_ref origin/main ts/package.json version)"
+  main_ts_lock="$(json_value_at_ref origin/main ts/package-lock.json version)"
+  main_ts_lock_pkg="$(git show origin/main:ts/package-lock.json 2>/dev/null | python3 -c 'import json,sys; print(json.load(sys.stdin).get("packages", {}).get("", {}).get("version", ""))')"
+  main_py="$(json_value_at_ref origin/main py/src/theorydb_py/version.json version)"
+
+  if [[ "${main_stable}" == *-rc* ]]; then
+    fail "origin/main stable manifest is prerelease (${main_stable})"
+  else
+    pass "origin/main stable manifest is ${main_stable:-<missing>}"
+  fi
+
+  for item in \
+    "ts/package.json:${main_ts}" \
+    "ts/package-lock.json:${main_ts_lock}" \
+    "ts/package-lock.json packages['']:${main_ts_lock_pkg}" \
+    "py/src/theorydb_py/version.json:${main_py}"; do
+    label="${item%%:*}"
+    version="${item#*:}"
+    if [[ -z "${version}" ]]; then
+      fail "origin/main ${label} version is missing"
+    elif [[ "${version}" == *-rc* ]]; then
+      fail "origin/main ${label} remains prerelease (${version})"
+    elif [[ -n "${main_stable}" && "${version}" != "${main_stable}" ]]; then
+      fail "origin/main ${label} ${version} != stable manifest ${main_stable}"
+    else
+      pass "origin/main ${label} is stable (${version})"
+    fi
+  done
+
+  main_go="$(toolchain_at_ref origin/main go.mod)"
+  main_example_go="$(toolchain_at_ref origin/main examples/multi-tenant/go.mod)"
+  for item in "go.mod:${main_go}" "examples/multi-tenant/go.mod:${main_example_go}"; do
+    label="${item%%:*}"
+    version="${item#*:}"
+    if [[ "${version}" == "go1.26.3" ]]; then
+      fail "origin/main ${label} still observes vulnerable toolchain ${version}"
+    elif [[ -z "${version}" ]]; then
+      fail "origin/main ${label} has no toolchain line"
+    else
+      pass "origin/main ${label} toolchain is ${version}"
+    fi
+  done
+fi
+
+if git rev-parse --verify --quiet origin/premain >/dev/null; then
+  premain_stable="$(json_value_at_ref origin/premain .release-please-manifest.json '.')"
+  premain_prerelease="$(json_value_at_ref origin/premain .release-please-manifest.premain.json '.')"
+
+  if [[ -n "${main_stable}" && -n "${premain_stable}" && "${premain_stable}" != "${main_stable}" ]]; then
+    fail "origin/premain stable manifest ${premain_stable} != origin/main ${main_stable}"
+  else
+    pass "origin/premain stable manifest matches origin/main (${premain_stable:-<missing>})"
+  fi
+
+  if [[ -n "${main_stable}" && -n "${premain_prerelease}" ]]; then
+    premain_base="$(semver_base "${premain_prerelease}" || true)"
+    main_base="$(semver_base "${main_stable}" || true)"
+    if [[ -n "${premain_base}" && -n "${main_base}" ]] && semver_lt "${premain_base}" "${main_base}"; then
+      fail "origin/premain prerelease track ${premain_prerelease} is behind origin/main ${main_stable}"
+    else
+      pass "origin/premain prerelease track is ${premain_prerelease}"
+    fi
+  fi
+
+  premain_go="$(toolchain_at_ref origin/premain go.mod)"
+  if [[ "${premain_go}" == "go1.26.3" ]]; then
+    fail "origin/premain go.mod still observes vulnerable toolchain ${premain_go}"
+  elif [[ -n "${premain_go}" ]]; then
+    pass "origin/premain go.mod toolchain is ${premain_go}"
+  else
+    fail "origin/premain go.mod has no toolchain line"
+  fi
+fi
+
+if git rev-parse --verify --quiet origin/staging >/dev/null; then
+  staging_stable="$(json_value_at_ref origin/staging .release-please-manifest.json '.')"
+  if [[ -n "${main_stable}" && -n "${staging_stable}" && "${staging_stable}" != "${main_stable}" ]]; then
+    fail "origin/staging stable manifest ${staging_stable} != origin/main ${main_stable}"
+  else
+    pass "origin/staging stable manifest matches origin/main (${staging_stable:-<missing>})"
+  fi
+
+  staging_go="$(toolchain_at_ref origin/staging go.mod)"
+  staging_example_go="$(toolchain_at_ref origin/staging examples/multi-tenant/go.mod)"
+  for item in "go.mod:${staging_go}" "examples/multi-tenant/go.mod:${staging_example_go}"; do
+    label="${item%%:*}"
+    version="${item#*:}"
+    if [[ "${version}" == "go1.26.3" ]]; then
+      fail "origin/staging ${label} still observes vulnerable toolchain ${version}"
+    elif [[ -z "${version}" ]]; then
+      fail "origin/staging ${label} has no toolchain line"
+    else
+      pass "origin/staging ${label} toolchain is ${version}"
+    fi
+  done
+fi
+
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  stable_rc_prs="$(
+    gh pr list \
+      --repo theory-cloud/TableTheory \
+      --base main \
+      --state open \
+      --json number,title,headRefName,url \
+      --jq '.[] | select(.title | test("-rc\\.")) | "\(.number) \(.title) \(.url)"' \
+      2>/dev/null || true
+  )"
+  if [[ -n "${stable_rc_prs}" ]]; then
+    while IFS= read -r pr; do
+      fail "stable release PR requires review for RC shape: ${pr}"
+    done <<<"${stable_rc_prs}"
+  else
+    pass "no open main release PR advertises an RC version"
+  fi
+
+  if [[ -n "${tag_name}" ]]; then
+    release_json="$(gh release view "${tag_name}" --repo theory-cloud/TableTheory --json assets,isDraft,isPrerelease,tagName 2>/dev/null || true)"
+    if [[ -z "${release_json}" ]]; then
+      fail "GitHub release ${tag_name} does not exist"
+    else
+      asset_count="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("assets", [])))' <<<"${release_json}")"
+      if [[ "${asset_count}" -eq 0 ]]; then
+        fail "GitHub release ${tag_name} exists but has no uploaded assets"
+      else
+        pass "GitHub release ${tag_name} has ${asset_count} uploaded asset(s)"
+      fi
+    fi
+  else
+    warn "no --tag supplied; skipped GitHub release asset check"
+  fi
+else
+  warn "gh is unavailable or unauthenticated; skipped PR and release asset watchpoints"
+fi
+
+if [[ "${strict}" -eq 1 && "${fail_count}" -ne 0 ]]; then
+  echo "watch-release-cycle: SUMMARY fail=${fail_count} warn=${warn_count} strict=1"
+  exit 1
+fi
+
+echo "watch-release-cycle: SUMMARY fail=${fail_count} warn=${warn_count} strict=${strict}"
+if [[ "${strict}" -eq 0 && "${fail_count}" -ne 0 ]]; then
+  echo "watch-release-cycle: observation mode exits 0; rerun with --strict before merge/release gates"
+fi

--- a/scripts/watch-release-cycle.sh
+++ b/scripts/watch-release-cycle.sh
@@ -142,18 +142,46 @@ main_stable=""
 premain_stable=""
 premain_prerelease=""
 staging_stable=""
+main_pending_promotion=0
+main_pending_version=""
 
 if git rev-parse --verify --quiet origin/main >/dev/null; then
   main_stable="$(json_value_at_ref origin/main .release-please-manifest.json '.')"
+  main_premain="$(json_value_at_ref origin/main .release-please-manifest.premain.json '.')"
   main_ts="$(json_value_at_ref origin/main ts/package.json version)"
   main_ts_lock="$(json_value_at_ref origin/main ts/package-lock.json version)"
   main_ts_lock_pkg="$(git show origin/main:ts/package-lock.json 2>/dev/null | python3 -c 'import json,sys; print(json.load(sys.stdin).get("packages", {}).get("", {}).get("version", ""))')"
   main_py="$(json_value_at_ref origin/main py/src/theorydb_py/version.json version)"
 
+  main_pending_candidate=1
+  main_pending_version="${main_premain}"
+  for version in "${main_premain}" "${main_ts}" "${main_ts_lock}" "${main_ts_lock_pkg}" "${main_py}"; do
+    if [[ -z "${version}" || "${version}" == *-* || "${version}" != "${main_pending_version}" ]]; then
+      main_pending_candidate=0
+    fi
+  done
+
+  if [[ "${main_pending_candidate}" -eq 1 && -n "${main_stable}" && "${main_stable}" != *-* ]] && semver_lt "${main_stable}" "${main_pending_version}"; then
+    main_pending_promotion=1
+    warn "origin/main pending stable promotion: stable manifest ${main_stable}, normalized files ${main_pending_version}"
+  fi
+
   if [[ "${main_stable}" == *-rc* ]]; then
     fail "origin/main stable manifest is prerelease (${main_stable})"
   else
     pass "origin/main stable manifest is ${main_stable:-<missing>}"
+  fi
+
+  if [[ -z "${main_premain}" ]]; then
+    fail "origin/main .release-please-manifest.premain.json version is missing"
+  elif [[ "${main_pending_promotion}" -eq 1 && "${main_premain}" == "${main_pending_version}" ]]; then
+    warn "origin/main .release-please-manifest.premain.json is pending stable promotion (${main_premain}; stable manifest ${main_stable})"
+  elif [[ "${main_premain}" == *-rc* ]]; then
+    fail "origin/main .release-please-manifest.premain.json remains prerelease (${main_premain})"
+  elif [[ -n "${main_stable}" && "${main_premain}" != "${main_stable}" ]]; then
+    fail "origin/main .release-please-manifest.premain.json ${main_premain} != stable manifest ${main_stable}"
+  else
+    pass "origin/main .release-please-manifest.premain.json is stable (${main_premain})"
   fi
 
   for item in \
@@ -167,6 +195,8 @@ if git rev-parse --verify --quiet origin/main >/dev/null; then
       fail "origin/main ${label} version is missing"
     elif [[ "${version}" == *-rc* ]]; then
       fail "origin/main ${label} remains prerelease (${version})"
+    elif [[ "${main_pending_promotion}" -eq 1 && "${version}" == "${main_pending_version}" ]]; then
+      warn "origin/main ${label} is pending stable promotion (${version}; stable manifest ${main_stable})"
     elif [[ -n "${main_stable}" && "${version}" != "${main_stable}" ]]; then
       fail "origin/main ${label} ${version} != stable manifest ${main_stable}"
     else
@@ -260,6 +290,25 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
     pass "no open main release PR advertises an RC version"
   fi
 
+  if [[ "${main_pending_promotion}" -eq 1 ]]; then
+    pending_prs="$(
+      VERSION="${main_pending_version}" gh pr list \
+        --repo theory-cloud/TableTheory \
+        --base main \
+        --state open \
+        --json number,title,headRefName,url \
+        --jq '.[] | select((.headRefName == "release-please--branches--main") or ((.title | test("release"; "i")) and (.title | test(env.VERSION)))) | "\(.number) \(.title) \(.url)"' \
+        2>/dev/null || true
+    )"
+    if [[ -z "${pending_prs}" ]]; then
+      fail "origin/main pending stable promotion ${main_pending_version} has no open stable release-please PR; pause and investigate"
+    else
+      while IFS= read -r pr; do
+        pass "pending stable promotion has open stable release PR: ${pr}"
+      done <<<"${pending_prs}"
+    fi
+  fi
+
   if [[ -n "${tag_name}" ]]; then
     release_json="$(gh release view "${tag_name}" --repo theory-cloud/TableTheory --json assets,isDraft,isPrerelease,tagName 2>/dev/null || true)"
     if [[ -z "${release_json}" ]]; then
@@ -276,6 +325,9 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
     warn "no --tag supplied; skipped GitHub release asset check"
   fi
 else
+  if [[ "${main_pending_promotion}" -eq 1 ]]; then
+    warn "origin/main pending stable promotion requires an open stable release PR check, but gh is unavailable or unauthenticated"
+  fi
   warn "gh is unavailable or unauthenticated; skipped PR and release asset watchpoints"
 fi
 


### PR DESCRIPTION
## Summary

- Bump the repo and multi-tenant example Go toolchain pins to go1.26.4 for the staging-side security recovery.
- Document the TableTheory release-cycle ownership model, stable-promotion path, post-stable sync path, watchpoints, stop conditions, and non-destructive recovery paths.
- Add deterministic release-cycle guardrails: stable-promotion dry-run/write helper, local release-cycle verifier, and read-only release watch helper.
- Add explicit pending stable promotion handling for the normalized promotion commit: `RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true` allows only stable, internally consistent normalized files ahead of the stable manifest on `main`.
- Wire `.github/workflows/release-pr.yml` to accept that pending state for stable release-please PR generation, while `.github/workflows/release.yml` classifies the same state and skips stable release creation until strict equality is restored.
- Update COM-8 and release watchpoints so the pending-promotion guard and missing stable release PR condition are checked intentionally.

Closes THE-1869

## Validation

- `git diff --check` - PASS
- `bash scripts/verify-branch-release-supply-chain.sh` - PASS
- `bash scripts/verify-branch-version-sync.sh` - SKIP on this staging-target branch
- `bash scripts/verify-release-cycle-state.sh` - PASS (`stable=1.9.1`, `premain=1.9.0-rc.2`)
- Deterministic `/tmp` copy proof - PASS:
  - `GITHUB_REF_NAME=main bash scripts/verify-release-cycle-state.sh` on normalized pending state failed strict mode as expected (`ts/package.json 1.9.2 does not match stable manifest 1.9.1`)
  - `GITHUB_REF_NAME=main RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true bash scripts/verify-release-cycle-state.sh` passed (`stable=1.9.1`, `pending=1.9.2`)
  - after advancing only the temp copy stable manifest to `1.9.2`, strict mode passed (`stable=1.9.2`, `premain=1.9.2`)
- `bash scripts/watch-release-cycle.sh` - observation mode completed with known current remote drift: `fail=10 warn=1 strict=0` (RC SDK/premain state on `origin/main`, stale `origin/premain`, stale Go toolchain on `origin/staging`; no open main release PR advertises an RC version)
- `go version` - `go version go1.26.4 linux/amd64`
- `go test ./...` - PASS
- `PATH="/usr/local/go/bin:/home/aron/go/bin:$PATH" bash hgm-infra/verifiers/hgm-verify-rubric.sh` - PASS (`pass=36 fail=0 blocked=0`)

## Notes

This PR does not edit manifests, CHANGELOG, TypeScript package versions, Python version files, tags, or releases. It intentionally does not merge or repair `main` directly. The PR remains a draft.