### PR TITLE
fix(release): recover immutable RC publish flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,10 +76,21 @@ Release ownership:
   the prerelease lane is active.
 - `main` owns stable state only. The stable manifest and SDK version files on `main` must never contain `-rc`.
 
+Immutable version reuse:
+
+- Treat published GitHub release tag names as one-time-use, even if the published release or git tag was later deleted.
+  A deleted immutable release/tag has exhausted that version name for release-cycle purposes.
+- Do not manually recreate tags, hand-publish releases, edit immutable release assets, or hand-edit manifests as recovery.
+- If publishing fails with `tag_name was used by an immutable release`, recover through a normal release-eligible PR and
+  let release-please advance to the next RC/stable version for that lane.
+
 Stable promotion path:
 
 - Create a promotion branch from `origin/main`.
 - Merge `origin/premain` into that promotion branch locally or in a PR branch, not directly into `main`.
+- Do not start `premain` -> `main` promotion until the intended RC exists as a GitHub release that is published,
+  non-draft, marked prerelease, backed by `refs/tags/vX.Y.Z-rc.N`, and complete with the required TypeScript/Python
+  assets.
 - Run `bash scripts/prepare-stable-promotion.sh --check`, then `--write` after reviewing the deterministic plan. This
   strips RC state from the prerelease manifest and SDK version files before the PR targets `main`; the stable manifest is
   left for release-please to advance in the stable Release PR.
@@ -111,6 +122,10 @@ Release watchpoints and stop conditions:
   version.
 - Stop if a release workflow was expected to create a release but did not report `release_created`, if asset/publish steps
   have no `tag_name`, or if a GitHub release exists without the TypeScript/Python assets.
+- Stop if a requested release tag is draft, has no `publishedAt`, uses an `untagged-...` release URL, is missing
+  `refs/tags/<tag>`, or points the release target and git tag ref at different commits.
+- Stop if release recovery would reuse a deleted or exhausted immutable release version; use a release-eligible PR to
+  advance to the next release-please version instead.
 - Stop if automation tries to push directly to `staging`, `premain`, or `main` where this policy requires PR sync.
 
 Useful checks:

--- a/docs/development/planning/templates/high-risk-branch-release-policy.template.md
+++ b/docs/development/planning/templates/high-risk-branch-release-policy.template.md
@@ -60,6 +60,12 @@ Document forbidden stable-branch states:
 - release automation opening a stable release PR for an RC version.
 - pending stable promotion persisting after the normalized promotion commit without an open stable release PR.
 - direct branch pushes or ref mutations where policy requires PR sync.
+- manual recovery that recreates deleted tags, hand-publishes replacement releases, or reuses an exhausted immutable
+  release version.
+
+Document immutable release version reuse explicitly. Treat published release tag names as one-time-use even if the release
+or tag is later deleted. If a publish step fails with `tag_name was used by an immutable release`, recovery must go through
+a normal release-eligible PR and the release tool must advance to the next RC/stable version for that lane.
 
 If release-please or another release-PR tool leaves the stable manifest at the prior stable version until the stable
 release PR merges, document the state as explicit pending stable promotion. The pending verifier mode must be visible in
@@ -94,8 +100,11 @@ Pause before merge or release when:
 - release automation completes without creating the expected release.
 - pending stable promotion persists without an open stable release PR.
 - release asset steps have no tag name, or the GitHub release exists without required assets.
+- a requested release tag is draft, lacks a published timestamp, has no git tag ref, uses an `untagged-...` draft URL, or
+  points the release target and git tag ref at different commits.
+- the intended RC is not yet published, non-draft, marked prerelease, tagged, and asset-complete.
 - automation attempts direct branch mutation where the documented path expects PR sync.
 
 Allowed recovery should be non-destructive: new PR branches from known bases, deterministic normalization scripts, and
-verified PR-based sync. Do not retag, overwrite release assets, force-push, delete protected branches, or merge around
-quality/security checks.
+verified PR-based sync. Do not retag, overwrite release assets, force-push, delete protected branches, hand-publish
+replacement releases, reuse exhausted immutable release versions, or merge around quality/security checks.

--- a/docs/development/planning/theorydb-branch-release-policy.md
+++ b/docs/development/planning/theorydb-branch-release-policy.md
@@ -53,6 +53,16 @@ Acceptable post-stable sync paths:
 - Recovery: if a branch is already stranded, create a new PR branch from the correct base and replay only the needed file
   state. Do not retag, overwrite release assets, force-push, delete branches, or mutate GitHub releases.
 
+## Immutable release version reuse
+
+GitHub release tag names are one-time-use for TableTheory release-cycle purposes. If a published immutable release or its
+git tag is deleted, that version name is still exhausted and must not be reused. Do not manually recreate the tag, publish
+a replacement release by hand, edit immutable release assets, or patch manifests to make the same version run again.
+
+If a publish step fails with `tag_name was used by an immutable release`, recover through the normal PR-driven release
+flow: land a release-eligible change, promote it through the documented branch path, and let release-please advance to the
+next RC or stable version for that lane.
+
 ## Protections (required)
 
 Protect both `premain` and `main`:
@@ -100,6 +110,11 @@ If an asset upload or publish step has no `tag_name`, fail the workflow. If a Gi
 assets are missing, use a documented asset recovery workflow only after confirming the tag and release are immutable and
 correct.
 
+Before promoting `premain` to `main`, confirm the intended RC is actually published: it must be non-draft, marked as a
+GitHub prerelease, have a `publishedAt` timestamp, resolve through `refs/tags/vX.Y.Z-rc.N`, use a tag-addressed release
+URL rather than an `untagged-...` draft URL, and include the required TypeScript/Python assets. Asset presence alone is
+not sufficient evidence that a release is healthy.
+
 ## Multi-language versioning (required)
 
 - **Single shared repo version:** Go, TypeScript, and Python use the same GitHub tag/release version.
@@ -144,4 +159,8 @@ Run `bash scripts/watch-release-cycle.sh` during a release and rerun with `--str
 - a release workflow expected to create a release but not reporting `release_created`.
 - asset/publish steps missing `tag_name`.
 - a GitHub release existing without uploaded TypeScript/Python assets.
+- a requested release tag that is draft, missing `publishedAt`, missing `refs/tags/<tag>`, using an `untagged-...` release
+  URL, or whose git tag ref target differs from the release target commitish.
+- any recovery plan that reuses a deleted/exhausted immutable release version instead of advancing through a
+  release-eligible PR and release-please.
 - automation attempting direct branch mutation where PR sync is required.

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -29,6 +29,47 @@ for f in "${required_files[@]}"; do
   fi
 done
 
+if [[ -f "scripts/watch-release-cycle.sh" ]]; then
+  grep -Fq "isDraft" "scripts/watch-release-cycle.sh" || {
+    echo "branch-release: watch-release-cycle must check GitHub release draft state for --tag"
+    failures=$((failures + 1))
+  }
+  grep -Fq "publishedAt" "scripts/watch-release-cycle.sh" || {
+    echo "branch-release: watch-release-cycle must check GitHub release publishedAt for --tag"
+    failures=$((failures + 1))
+  }
+  grep -Fq "git/ref/tags" "scripts/watch-release-cycle.sh" || {
+    echo "branch-release: watch-release-cycle must check git tag refs for --tag"
+    failures=$((failures + 1))
+  }
+  grep -Fq "untagged-" "scripts/watch-release-cycle.sh" || {
+    echo "branch-release: watch-release-cycle must reject untagged draft release URLs for --tag"
+    failures=$((failures + 1))
+  }
+  grep -Fq "targetCommitish" "scripts/watch-release-cycle.sh" || {
+    echo "branch-release: watch-release-cycle must compare release targetCommitish with the tag ref"
+    failures=$((failures + 1))
+  }
+fi
+
+grep -Fq "tag_name was used by an immutable release" "docs/development/planning/theorydb-branch-release-policy.md" || {
+  echo "branch-release: branch release policy must document immutable release tag-name reuse recovery"
+  failures=$((failures + 1))
+}
+grep -Fq "one-time-use" "docs/development/planning/theorydb-branch-release-policy.md" || {
+  echo "branch-release: branch release policy must name one-time-use immutable release versions"
+  failures=$((failures + 1))
+}
+grep -Fq "Do not manually recreate tags" "AGENTS.md" || {
+  echo "branch-release: AGENTS.md must prohibit manual tag recreation during release recovery"
+  failures=$((failures + 1))
+}
+grep -Fq "tag_name was used by an immutable release" \
+  "docs/development/planning/templates/high-risk-branch-release-policy.template.md" || {
+  echo "branch-release: high-risk branch policy template must include immutable release reuse recovery"
+  failures=$((failures + 1))
+}
+
 if [[ -f ".github/workflows/prerelease.yml" ]]; then
   grep -Eq 'branches:.*premain' ".github/workflows/prerelease.yml" || {
     echo "branch-release: prerelease workflow must target premain"

--- a/scripts/watch-release-cycle.sh
+++ b/scripts/watch-release-cycle.sh
@@ -13,7 +13,7 @@ Usage: bash scripts/watch-release-cycle.sh [--strict] [--tag vX.Y.Z]
 
 Options:
   --strict   Exit non-zero if any FAIL finding is reported.
-  --tag TAG  Check that an existing GitHub release has non-source assets.
+  --tag TAG  Check that an existing GitHub release is published, tagged, and has non-source assets.
   -h, --help Show this help.
 
 This command reads local refs and, when gh is authenticated, open PR/release
@@ -23,6 +23,7 @@ USAGE
 
 strict=0
 tag_name=""
+github_repo="theory-cloud/TableTheory"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -94,6 +95,44 @@ for part in expr.split("."):
         value = ""
 print(value if isinstance(value, str) else "")
 ' "${expr}"
+}
+
+json_string_value() {
+  local json="$1"
+  local expr="$2"
+
+  JSON_INPUT="${json}" python3 - "${expr}" <<'PY'
+import json
+import os
+import sys
+
+expr = sys.argv[1]
+raw = os.environ["JSON_INPUT"]
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    try:
+        data, _ = json.JSONDecoder().raw_decode(raw)
+    except json.JSONDecodeError:
+        print("")
+        raise SystemExit(0)
+value = data
+for part in expr.split("."):
+    if not part:
+        continue
+    if isinstance(value, dict):
+        value = value.get(part)
+    else:
+        value = None
+if isinstance(value, bool):
+    print("true" if value else "false")
+elif value is None:
+    print("")
+elif isinstance(value, (str, int, float)):
+    print(value)
+else:
+    print(json.dumps(value))
+PY
 }
 
 toolchain_at_ref() {
@@ -275,7 +314,7 @@ fi
 if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   stable_rc_prs="$(
     gh pr list \
-      --repo theory-cloud/TableTheory \
+      --repo "${github_repo}" \
       --base main \
       --state open \
       --json number,title,headRefName,url \
@@ -293,7 +332,7 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   if [[ "${main_pending_promotion}" -eq 1 ]]; then
     pending_prs="$(
       VERSION="${main_pending_version}" gh pr list \
-        --repo theory-cloud/TableTheory \
+        --repo "${github_repo}" \
         --base main \
         --state open \
         --json number,title,headRefName,url \
@@ -310,11 +349,110 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   fi
 
   if [[ -n "${tag_name}" ]]; then
-    release_json="$(gh release view "${tag_name}" --repo theory-cloud/TableTheory --json assets,isDraft,isPrerelease,tagName 2>/dev/null || true)"
+    release_json="$(
+      gh release view "${tag_name}" \
+        --repo "${github_repo}" \
+        --json assets,isDraft,isPrerelease,publishedAt,tagName,targetCommitish,url \
+        2>/dev/null || true
+    )"
     if [[ -z "${release_json}" ]]; then
       fail "GitHub release ${tag_name} does not exist"
     else
+      release_tag="$(json_string_value "${release_json}" tagName)"
+      release_is_draft="$(json_string_value "${release_json}" isDraft)"
+      release_is_prerelease="$(json_string_value "${release_json}" isPrerelease)"
+      release_published_at="$(json_string_value "${release_json}" publishedAt)"
+      release_target_commitish="$(json_string_value "${release_json}" targetCommitish)"
+      release_url="$(json_string_value "${release_json}" url)"
       asset_count="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("assets", [])))' <<<"${release_json}")"
+
+      if [[ "${release_tag}" != "${tag_name}" ]]; then
+        fail "GitHub release lookup for ${tag_name} returned tag ${release_tag:-<missing>}"
+      else
+        pass "GitHub release ${tag_name} reports matching tag name"
+      fi
+
+      if [[ "${release_is_draft}" == "true" ]]; then
+        fail "GitHub release ${tag_name} is still draft"
+      else
+        pass "GitHub release ${tag_name} is not draft"
+      fi
+
+      if [[ -z "${release_published_at}" ]]; then
+        fail "GitHub release ${tag_name} has no publishedAt timestamp"
+      else
+        pass "GitHub release ${tag_name} publishedAt is ${release_published_at}"
+      fi
+
+      if [[ "${release_url}" == *"/releases/tag/untagged-"* ]]; then
+        fail "GitHub release ${tag_name} URL is an untagged draft URL (${release_url})"
+      elif [[ -z "${release_url}" ]]; then
+        warn "GitHub release ${tag_name} URL is missing from release metadata"
+      else
+        pass "GitHub release ${tag_name} URL is tag-addressed"
+      fi
+
+      if [[ "${tag_name}" == *"-rc"* ]]; then
+        if [[ "${release_is_prerelease}" == "true" ]]; then
+          pass "GitHub release ${tag_name} is marked prerelease"
+        else
+          fail "GitHub release ${tag_name} is not marked prerelease"
+        fi
+      elif [[ "${release_is_prerelease}" == "true" ]]; then
+        fail "GitHub release ${tag_name} is marked prerelease for a non-RC tag"
+      fi
+
+      tag_ref_json="$(gh api "repos/${github_repo}/git/ref/tags/${tag_name}" 2>/dev/null || true)"
+      tag_ref_target_sha=""
+      tag_ref_status="$(json_string_value "${tag_ref_json:-{}}" status)"
+      tag_ref_message="$(json_string_value "${tag_ref_json:-{}}" message)"
+      if [[ -z "${tag_ref_json}" || "${tag_ref_status}" == "404" || "${tag_ref_message}" == "Not Found" ]]; then
+        fail "git tag ref refs/tags/${tag_name} is missing"
+      else
+        tag_ref_type="$(json_string_value "${tag_ref_json}" object.type)"
+        tag_ref_sha="$(json_string_value "${tag_ref_json}" object.sha)"
+        case "${tag_ref_type}" in
+          commit)
+            tag_ref_target_sha="${tag_ref_sha}"
+            pass "git tag ref refs/tags/${tag_name} points to commit ${tag_ref_target_sha}"
+            ;;
+          tag)
+            annotated_tag_json="$(gh api "repos/${github_repo}/git/tags/${tag_ref_sha}" 2>/dev/null || true)"
+            if [[ -z "${annotated_tag_json}" ]]; then
+              fail "git tag ref refs/tags/${tag_name} points to an unreadable annotated tag ${tag_ref_sha}"
+            else
+              annotated_target_type="$(json_string_value "${annotated_tag_json}" object.type)"
+              annotated_target_sha="$(json_string_value "${annotated_tag_json}" object.sha)"
+              if [[ "${annotated_target_type}" == "commit" && -n "${annotated_target_sha}" ]]; then
+                tag_ref_target_sha="${annotated_target_sha}"
+                pass "git tag ref refs/tags/${tag_name} dereferences to commit ${tag_ref_target_sha}"
+              else
+                fail "git tag ref refs/tags/${tag_name} does not dereference to a commit"
+              fi
+            fi
+            ;;
+          "")
+            fail "git tag ref refs/tags/${tag_name} has no observable target"
+            ;;
+          *)
+            fail "git tag ref refs/tags/${tag_name} points to unsupported object type ${tag_ref_type}"
+            ;;
+        esac
+      fi
+
+      if [[ -n "${release_target_commitish}" && -n "${tag_ref_target_sha}" ]]; then
+        release_target_sha="$(gh api "repos/${github_repo}/commits/${release_target_commitish}" --jq .sha 2>/dev/null || true)"
+        if [[ -z "${release_target_sha}" ]]; then
+          warn "GitHub release ${tag_name} targetCommitish ${release_target_commitish} could not be resolved"
+        elif [[ "${release_target_sha}" != "${tag_ref_target_sha}" ]]; then
+          fail "git tag ref ${tag_name} targets ${tag_ref_target_sha}, release targetCommitish resolves to ${release_target_sha}"
+        else
+          pass "git tag ref ${tag_name} matches release targetCommitish ${release_target_sha}"
+        fi
+      elif [[ -z "${release_target_commitish}" ]]; then
+        warn "GitHub release ${tag_name} targetCommitish is missing from release metadata"
+      fi
+
       if [[ "${asset_count}" -eq 0 ]]; then
         fail "GitHub release ${tag_name} exists but has no uploaded assets"
       else


### PR DESCRIPTION
Factory-coordinated staging -> premain promotion for THE-1869 / GO-1264 release-cycle recovery.

Purpose:
- Bring PR #245 release-cycle watchpoints into `premain`.
- Let the normal `premain` release-please flow advance to the next unique immutable RC (expected: `v1.9.2-rc.2`) instead of reusing exhausted `v1.9.2-rc.1`.

Do not:
- manually create/recreate tags;
- hard reset protected branches;
- hand-publish or edit immutable releases/assets;
- rerun the failed `v1.9.2-rc.1` publish as the recovery mechanism.

Merge guidance:
- Prefer a merge/squash result whose commit title remains release-eligible, e.g. `fix(release): recover immutable RC publish flow`.
- After merge, wait for release-please to open the next `premain` prerelease PR.
- Merge that generated prerelease PR only after checks pass, then verify the new RC is published/non-draft, backed by `refs/tags/<new-rc>`, and has the required TS/Python assets.

Known caveat:
- `origin/main` still contains RC-state files from the earlier raw `premain -> main` merge. That is a separate stable-promotion drift and should be repaired by the documented normalized stable-promotion PR path after a valid new RC exists.
