### PR TITLE
fix(release): advance release lane to 1.9.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,12 @@ Immutable version reuse:
 - Do not manually recreate tags, hand-publish releases, edit immutable release assets, or hand-edit manifests as recovery.
 - If publishing fails with `tag_name was used by an immutable release`, recover through a normal release-eligible PR and
   let release-please advance to the next RC/stable version for that lane.
+- If a version is abandoned or exhausted, skip it only through a normal release-eligible commit/PR with a release-please
+  `Release-As` footer for the next allowed version. Do not recover through tags, resets, manual release edits,
+  manifest/package-version edits, or reruns of failed exhausted-version workflows.
+- Current THE-1869 lane decision: `1.9.2` is abandoned; the next RC must be `v1.9.3-rc.1`; the next stable release must be
+  `v1.9.3`; the release-eligible recovery commit must carry `Release-As: 1.9.3-rc.1` and that footer must survive the
+  `staging` -> `premain` merge path.
 
 Stable promotion path:
 
@@ -126,6 +132,8 @@ Release watchpoints and stop conditions:
   `refs/tags/<tag>`, or points the release target and git tag ref at different commits.
 - Stop if release recovery would reuse a deleted or exhausted immutable release version; use a release-eligible PR to
   advance to the next release-please version instead.
+- Stop if abandoned-version recovery lacks the required release-please `Release-As` footer or tries to hand-edit manifests,
+  package versions, tags, releases, or release assets.
 - Stop if automation tries to push directly to `staging`, `premain`, or `main` where this policy requires PR sync.
 
 Useful checks:

--- a/docs/development/planning/templates/high-risk-branch-release-policy.template.md
+++ b/docs/development/planning/templates/high-risk-branch-release-policy.template.md
@@ -67,6 +67,12 @@ Document immutable release version reuse explicitly. Treat published release tag
 or tag is later deleted. If a publish step fails with `tag_name was used by an immutable release`, recovery must go through
 a normal release-eligible PR and the release tool must advance to the next RC/stable version for that lane.
 
+Document abandoned or exhausted lane recovery explicitly. A skipped immutable version must advance only through a normal
+release-eligible commit/PR with the release tool's explicit version override footer, for example
+`Release-As: [next-version-or-rc]` when using release-please. The footer must survive the integration -> prerelease merge
+path. Do not recover by creating tags, rerunning failed exhausted-version workflows, editing immutable releases, patching
+manifests, or hand-editing package-version files.
+
 If release-please or another release-PR tool leaves the stable manifest at the prior stable version until the stable
 release PR merges, document the state as explicit pending stable promotion. The pending verifier mode must be visible in
 the workflow, limited to the release branch, require normalized stable package files to be internally consistent and ahead
@@ -97,6 +103,8 @@ Pause before merge or release when:
 - integration branch lacks the latest stable baseline after a stable release.
 - security/governance checks still observe a vulnerable toolchain or dependency state.
 - branch/version sync checks fail.
+- an abandoned/exhausted version recovery lacks the required release-eligible commit footer or tries to skip the release
+  tool with manual version/tag/release edits.
 - release automation completes without creating the expected release.
 - pending stable promotion persists without an open stable release PR.
 - release asset steps have no tag name, or the GitHub release exists without required assets.

--- a/docs/development/planning/theorydb-branch-release-policy.md
+++ b/docs/development/planning/theorydb-branch-release-policy.md
@@ -63,6 +63,15 @@ If a publish step fails with `tag_name was used by an immutable release`, recove
 flow: land a release-eligible change, promote it through the documented branch path, and let release-please advance to the
 next RC or stable version for that lane.
 
+If a version is abandoned or otherwise exhausted before a healthy release is available, skip it only through a normal
+release-eligible commit/PR with a release-please `Release-As` footer for the next allowed version. The footer must survive
+the `staging` merge and the later `staging` -> `premain` promotion. Do not use tags, resets, manual release edits,
+manifest edits, package-version edits, or reruns of failed exhausted-version workflows to recover.
+
+Current recovery decision: `1.9.2` is abandoned; the next RC must be `v1.9.3-rc.1`; the next stable release must be
+`v1.9.3`. The release-eligible recovery commit must carry `Release-As: 1.9.3-rc.1`. See
+`docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md`.
+
 ## Protections (required)
 
 Protect both `premain` and `main`:
@@ -163,4 +172,6 @@ Run `bash scripts/watch-release-cycle.sh` during a release and rerun with `--str
   URL, or whose git tag ref target differs from the release target commitish.
 - any recovery plan that reuses a deleted/exhausted immutable release version instead of advancing through a
   release-eligible PR and release-please.
+- any abandoned-version recovery that lacks a release-eligible commit with the required release-please `Release-As`
+  footer, or that edits release manifests/package versions by hand.
 - automation attempting direct branch mutation where PR sync is required.

--- a/docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md
+++ b/docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md
@@ -1,0 +1,39 @@
+# TableTheory Release-Cycle Recovery: 1.9.3 Lane
+
+This record documents the THE-1869 release-cycle recovery decision for the abandoned `1.9.2` lane.
+
+## Decision
+
+- `1.9.2` is abandoned and must not be released as an RC or as a stable release.
+- The next prerelease lane is `v1.9.3-rc.1`.
+- The eventual stable release for this lane is `v1.9.3`.
+
+## Required Recovery Path
+
+Recovery must stay inside the normal protected-branch and release-please flow:
+
+1. Land one release-eligible PR into `staging`.
+2. Preserve a release-please footer on the release-eligible commit:
+
+   ```text
+   Release-As: 1.9.3-rc.1
+   ```
+
+3. Merge `staging` into `premain` through a PR.
+4. Let release-please open and CI publish the generated `v1.9.3-rc.1` prerelease.
+5. Promote `premain` to `main` through the documented normalized stable-promotion PR.
+6. Let release-please open and CI publish the generated `v1.9.3` stable release.
+7. Sync the stable `main` baseline back to `staging` and `premain` through PRs or documented verified automation.
+
+## Stop Conditions
+
+- Do not create, recreate, or delete tags for recovery.
+- Do not rerun failed `v1.9.2` workflows as recovery.
+- Do not hand-publish releases, edit immutable GitHub releases, or upload release assets by hand.
+- Do not hand-edit `.release-please-manifest*.json`, `CHANGELOG.md`, `ts/package*.json`, or
+  `py/src/theorydb_py/version.json`; release-please owns those updates.
+- Do not hard reset, force-push, or mutate protected branches directly.
+
+Abandoned or exhausted immutable versions are skipped only through a normal release-eligible commit/PR with a
+release-please `Release-As` footer. For this recovery, the footer must survive the `staging` merge and later
+`staging` -> `premain` promotion so release-please advances the prerelease lane to `v1.9.3-rc.1` instead of `1.9.2`.

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -20,6 +20,7 @@ required_files=(
   ".release-please-manifest.premain.json"
   ".release-please-manifest.json"
   "scripts/sync-post-stable-release-baselines.sh"
+  "docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md"
 )
 
 for f in "${required_files[@]}"; do
@@ -69,6 +70,41 @@ grep -Fq "tag_name was used by an immutable release" \
   echo "branch-release: high-risk branch policy template must include immutable release reuse recovery"
   failures=$((failures + 1))
 }
+grep -Fq "Release-As:" "docs/development/planning/templates/high-risk-branch-release-policy.template.md" || {
+  echo "branch-release: high-risk branch policy template must document release-please Release-As lane recovery"
+  failures=$((failures + 1))
+}
+grep -Fq "Release-As: 1.9.3-rc.1" "AGENTS.md" || {
+  echo "branch-release: AGENTS.md must document the THE-1869 1.9.3 recovery footer"
+  failures=$((failures + 1))
+}
+if [[ -f "docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md" ]]; then
+  recovery_doc="docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md"
+  grep -Fq "1.9.2" "${recovery_doc}" || {
+    echo "branch-release: recovery doc must record the abandoned 1.9.2 lane"
+    failures=$((failures + 1))
+  }
+  grep -Fq "v1.9.3-rc.1" "${recovery_doc}" || {
+    echo "branch-release: recovery doc must record v1.9.3-rc.1 as the next RC"
+    failures=$((failures + 1))
+  }
+  grep -Fq "v1.9.3" "${recovery_doc}" || {
+    echo "branch-release: recovery doc must record v1.9.3 as the next stable release"
+    failures=$((failures + 1))
+  }
+  grep -Fq "Release-As: 1.9.3-rc.1" "${recovery_doc}" || {
+    echo "branch-release: recovery doc must record the release-please Release-As footer"
+    failures=$((failures + 1))
+  }
+  grep -Fq "Do not hand-edit" "${recovery_doc}" && grep -Fq ".release-please-manifest*.json" "${recovery_doc}" || {
+    echo "branch-release: recovery doc must forbid manual release manifest edits"
+    failures=$((failures + 1))
+  }
+  grep -Fq "staging" "${recovery_doc}" && grep -Fq "premain" "${recovery_doc}" && grep -Fq "main" "${recovery_doc}" || {
+    echo "branch-release: recovery doc must document the staging/premain/main path"
+    failures=$((failures + 1))
+  }
+fi
 
 if [[ -f ".github/workflows/prerelease.yml" ]]; then
   grep -Eq 'branches:.*premain' ".github/workflows/prerelease.yml" || {


### PR DESCRIPTION
## Summary

- Documents THE-1869 recovery: `1.9.2` is abandoned, the next RC is `v1.9.3-rc.1`, and the next stable release is `v1.9.3`.
- Records that abandoned/exhausted immutable versions are skipped only through a normal release-eligible PR with release-please `Release-As`, never through tags, resets, manual release edits, manifest edits, or package-version edits.
- Adds a supply-chain verifier check for the 1.9.3 recovery record.

## Release-As Preservation

The release-eligible commit on this branch is `fix(release): advance release lane to 1.9.3` and carries:

```text
Release-As: 1.9.3-rc.1
```

This footer must survive the merge into `staging` and the later `staging` -> `premain` merge so release-please generates `v1.9.3-rc.1`, not a `1.9.2` RC.

## Non-Goals

This PR does not edit `.release-please-manifest*.json`, `CHANGELOG.md`, `ts/package*.json`, or `py/src/theorydb_py/version.json`; release-please owns those updates.

## Validation

- `git diff --check` - PASS
- `bash scripts/verify-branch-release-supply-chain.sh` - PASS
- `bash scripts/verify-release-cycle-state.sh` - PASS (`branch=fix/the-1869-release-193-lane`, `stable=1.9.1`, `premain=1.9.1`)
- `bash scripts/verify-branch-version-sync.sh` - SKIP on feature branch
- `go version` - `go version go1.26.4 linux/amd64`
- `go test ./...` - PASS
- `PATH="/usr/local/go/bin:/home/aron/go/bin:$PATH" bash hgm-infra/verifiers/hgm-verify-rubric.sh` - PASS (`pass=36 fail=0 blocked=0`)