### PR TITLE
fix(release): carry CI-driven stable promotion to premain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,23 +92,23 @@ Immutable version reuse:
 
 Stable promotion path:
 
-- Create a promotion branch from `origin/main`.
-- Merge `origin/premain` into that promotion branch locally or in a PR branch, not directly into `main`.
 - Do not start `premain` -> `main` promotion until the intended RC exists as a GitHub release that is published,
   non-draft, marked prerelease, backed by `refs/tags/vX.Y.Z-rc.N`, and complete with the required TypeScript/Python
   assets.
-- Run `bash scripts/prepare-stable-promotion.sh --check`, then `--write` after reviewing the deterministic plan. This
-  strips RC state from the prerelease manifest and SDK version files before the PR targets `main`; the stable manifest is
-  left for release-please to advance in the stable Release PR.
-- Open a PR from the normalized promotion branch to `main`. Raw RC files must not land on `main`.
-- After the normalized promotion PR merges to `main`, the release cycle may enter a short **pending stable promotion**
-  state: `.release-please-manifest.json` remains at the prior stable version while
-  `.release-please-manifest.premain.json` and the TypeScript/Python version files are normalized to the next stable
-  version. This state is allowed only until `.github/workflows/release-pr.yml` opens the stable release-please PR and that
-  PR merges.
+- Open and merge the promotion PR from `premain` to `main`; do not create a local stable-normalization branch as the
+  normal path.
+- After the `premain` -> `main` promotion merges, the release cycle may enter a short **pending stable promotion** state:
+  `.release-please-manifest.json` remains at the prior stable version while prerelease/SDK files still reflect the
+  promoted RC lane. This state is allowed only until `.github/workflows/release-pr.yml` opens the stable release-please PR
+  and that PR merges.
 - Pending stable promotion is explicit automation state only:
-  `RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true` may be used by the release workflows to verify the normalized
-  promotion commit, and `.github/workflows/release.yml` must skip stable release creation while that state is present.
+  `RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true` may be used by the release workflows to verify the promotion
+  commit, and `.github/workflows/release.yml` must skip stable release creation while that state is present.
+- `.github/workflows/release-pr.yml` computes the stable `release-as` value from the premain RC baseline (for THE-1869,
+  `1.9.3`) and opens the stable release-please PR.
+- The stable release-please PR must normalize `.release-please-manifest.json`,
+  `.release-please-manifest.premain.json`, `ts/package.json`, `ts/package-lock.json`, and
+  `py/src/theorydb_py/version.json` to the stable version; `release-please-config.json` owns those version-file changes.
 - After the stable release-please PR merges, strict stable equality is required again: run
   `bash scripts/verify-release-cycle-state.sh` without the pending env var, and confirm the stable manifest and SDK files
   match.
@@ -116,6 +116,8 @@ Stable promotion path:
   failure. Do not patch `main`, retag, edit releases, or hand-edit manifests to advance the cycle.
 - After the stable release is published, sync `main` back to `staging` and `premain` through PRs, or through an explicitly
   documented automation path that runs the same verifiers and does not directly mutate protected branches.
+- `scripts/prepare-stable-promotion.sh` is diagnostic/fallback tooling only. It is not the normal stable release path and
+  must not replace release-please-owned stable version/changelog updates.
 
 Release watchpoints and stop conditions:
 
@@ -124,7 +126,7 @@ Release watchpoints and stop conditions:
   stable release.
 - Stop if SEC-2/govulncheck still observes Go `1.26.3`, COM-8 branch/version sync fails, or release-please opens a
   stable PR for an RC version.
-- Stop if `main` remains in pending stable promotion and no stable release-please PR opens for the normalized stable
+- Stop if `main` remains in pending stable promotion and no stable release-please PR opens for the computed stable
   version.
 - Stop if a release workflow was expected to create a release but did not report `release_created`, if asset/publish steps
   have no `tag_name`, or if a GitHub release exists without the TypeScript/Python assets.

--- a/docs/development/planning/templates/high-risk-branch-release-policy.template.md
+++ b/docs/development/planning/templates/high-risk-branch-release-policy.template.md
@@ -24,11 +24,12 @@ If the project uses separate integration, prerelease, and stable branches, prefe
 1. Work lands on `[integration-branch]`.
 2. `[integration-branch]` -> `[prerelease-branch]` PR starts the prerelease lane.
 3. Prerelease automation produces `vX.Y.Z-rc.N` on `[prerelease-branch]`.
-4. Create a promotion branch from `[release-branch]`, merge `[prerelease-branch]` into it, and normalize RC-owned files
-   to stable state before opening the PR to `[release-branch]`.
-5. After the normalized promotion PR merges, release-PR automation opens the stable release PR while release automation
-   skips publishing during the temporary pending stable promotion state.
-6. Merging the stable release PR restores strict equality and stable automation publishes immutable `vX.Y.Z`.
+4. Verify the intended RC is published and asset-complete, then open and merge the `[prerelease-branch]` ->
+   `[release-branch]` promotion PR.
+5. Release automation skips publishing during the temporary pending stable promotion state while release-PR automation
+   opens the stable release PR with the stable `release-as` derived from the RC baseline.
+6. Merging the stable release PR normalizes stable manifests, prerelease manifests, and SDK/package version files to the
+   stable version; stable automation then publishes immutable `vX.Y.Z`.
 7. Sync the stable baseline back to `[integration-branch]` and `[prerelease-branch]` through PRs or documented verified
    automation.
 
@@ -58,7 +59,7 @@ Document forbidden stable-branch states:
 - stable manifest set to `X.Y.Z-rc.N`.
 - language/package version files left at `X.Y.Z-rc.N`.
 - release automation opening a stable release PR for an RC version.
-- pending stable promotion persisting after the normalized promotion commit without an open stable release PR.
+- pending stable promotion persisting after the release-branch promotion without an open stable release PR.
 - direct branch pushes or ref mutations where policy requires PR sync.
 - manual recovery that recreates deleted tags, hand-publishes replacement releases, or reuses an exhausted immutable
   release version.
@@ -73,12 +74,12 @@ release-eligible commit/PR with the release tool's explicit version override foo
 path. Do not recover by creating tags, rerunning failed exhausted-version workflows, editing immutable releases, patching
 manifests, or hand-editing package-version files.
 
-If release-please or another release-PR tool leaves the stable manifest at the prior stable version until the stable
-release PR merges, document the state as explicit pending stable promotion. The pending verifier mode must be visible in
-the workflow, limited to the release branch, require normalized stable package files to be internally consistent and ahead
-of the current stable baseline, and must not publish a stable release. Once the stable release PR merges,
-strict stable equality is required again. If the pending state persists because no stable release PR opens, pause and
-investigate; do not patch the release branch by hand.
+If release-please or another release-PR tool leaves the release branch at a promoted RC state until the stable release PR
+merges, document the state as explicit pending stable promotion. The pending verifier mode must be visible in the
+workflow, limited to the release branch, require the generated stable release PR to normalize manifests and package files
+to the stable version, and must not publish a stable release. Once the stable release PR merges, strict stable equality is
+required again. If the pending state persists because no stable release PR opens, pause and investigate; do not patch the
+release branch by hand.
 
 ## Required workflow artifacts
 
@@ -113,6 +114,7 @@ Pause before merge or release when:
 - the intended RC is not yet published, non-draft, marked prerelease, tagged, and asset-complete.
 - automation attempts direct branch mutation where the documented path expects PR sync.
 
-Allowed recovery should be non-destructive: new PR branches from known bases, deterministic normalization scripts, and
-verified PR-based sync. Do not retag, overwrite release assets, force-push, delete protected branches, hand-publish
-replacement releases, reuse exhausted immutable release versions, or merge around quality/security checks.
+Allowed recovery should be non-destructive: new PR branches from known bases, diagnostic/fallback normalization helpers,
+and verified PR-based sync. The normal release path should leave version and changelog edits to release automation. Do not
+retag, overwrite release assets, force-push, delete protected branches, hand-publish replacement releases, reuse exhausted
+immutable release versions, or merge around quality/security checks.

--- a/docs/development/planning/theorydb-branch-release-policy.md
+++ b/docs/development/planning/theorydb-branch-release-policy.md
@@ -23,9 +23,12 @@ This document defines the intended branch strategy and release automation for Ta
 
 - Feature/fix work lands via PRs into `staging`.
 - An **RC** is cut by merging `staging` into `premain` (via PR), then merging the release-please prerelease PR.
-- A **release** is prepared by creating a promotion branch from `origin/main`, merging `origin/premain` into that branch,
-  normalizing RC-owned files to stable state, and opening a PR to `main`.
-- A **release** is cut by merging the normalized promotion PR to `main`, then merging the release-please stable release PR.
+- A **release** is prepared by verifying the intended RC release, then opening and merging the `premain` -> `main`
+  promotion PR.
+- The `main` release workflow skips publishing while pending stable promotion is present, and `release-pr.yml` opens the
+  stable release-please PR with `release-as` computed from the premain RC baseline.
+- A **release** is cut by merging the stable release-please PR, which normalizes the stable manifest, prerelease manifest,
+  and SDK version files to stable state before the stable release workflow publishes `vX.Y.Z`.
 - Hotfixes should still follow `staging` -> `premain` -> `main` so version lines stay aligned.
 
 ## Post-release sync (automated)
@@ -44,6 +47,11 @@ After a stable release is published on `main`, the `Release (main)` workflow run
 This replaces manual manifest resets and manual post-release `main` -> `premain` / `main` -> `staging` release-baseline
 back-merges. The next `staging` -> `premain` promotion starts from the latest stable version, and the subsequent
 prerelease PR advances from that baseline.
+
+The normal stable promotion path does not use a local stable-normalization branch. `release-please-config.json` must keep
+`.release-please-manifest.premain.json`, `ts/package.json`, `ts/package-lock.json`, and
+`py/src/theorydb_py/version.json` wired as stable release-please extra-files so the generated stable Release PR owns all
+version-file normalization.
 
 Acceptable post-stable sync paths:
 
@@ -132,6 +140,8 @@ not sufficient evidence that a release is healthy.
   update `ts/package.json` and `ts/package-lock.json` to match the repo version.
 - **Release automation must update Python versions:** if `py/pyproject.toml` exists, the prerelease/release workflows must
   update `py/src/theorydb_py/version.json` to match the repo version.
+- **Stable release automation must normalize prerelease state:** `release-please-config.json` must update
+  `.release-please-manifest.premain.json` to the stable version in the generated stable Release PR.
 
 ## Required workflow artifacts (Rubric COM-8)
 
@@ -142,6 +152,9 @@ These files are required to exist and be kept current:
 - `scripts/verify-release-cycle-state.sh`
 - `scripts/watch-release-cycle.sh`
 - `scripts/prepare-stable-promotion.sh`
+
+`scripts/prepare-stable-promotion.sh` is retained as a diagnostic/fallback helper. It is not the normal stable promotion
+path, and it must not replace release-please-owned stable version/changelog updates.
 
 Additionally, quality/security workflows should run on PRs to (and/or pushes on) both protected branches:
 
@@ -164,7 +177,7 @@ Run `bash scripts/watch-release-cycle.sh` during a release and rerun with `--str
 - SEC-2/govulncheck still observing Go `1.26.3`.
 - COM-8 branch/version sync failing.
 - release-please opening a stable PR for an RC version.
-- `origin/main` in pending stable promotion without an open stable release-please PR for the normalized stable version.
+- `origin/main` in pending stable promotion without an open stable release-please PR for the computed stable version.
 - a release workflow expected to create a release but not reporting `release_created`.
 - asset/publish steps missing `tag_name`.
 - a GitHub release existing without uploaded TypeScript/Python assets.

--- a/docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md
+++ b/docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md
@@ -21,9 +21,15 @@ Recovery must stay inside the normal protected-branch and release-please flow:
 
 3. Merge `staging` into `premain` through a PR.
 4. Let release-please open and CI publish the generated `v1.9.3-rc.1` prerelease.
-5. Promote `premain` to `main` through the documented normalized stable-promotion PR.
-6. Let release-please open and CI publish the generated `v1.9.3` stable release.
-7. Sync the stable `main` baseline back to `staging` and `premain` through PRs or documented verified automation.
+5. After verifying that `v1.9.3-rc.1` is published, non-draft, marked prerelease, tagged, and asset-complete, promote
+   `premain` to `main` through a PR.
+6. Let `release.yml` skip stable publishing during the temporary pending stable-promotion state.
+7. Let `release-pr.yml` open the stable release-please PR with `release-as: 1.9.3`.
+8. Merge the stable release-please PR; release-please must normalize `.release-please-manifest.json`,
+   `.release-please-manifest.premain.json`, `ts/package.json`, `ts/package-lock.json`, and
+   `py/src/theorydb_py/version.json` to `1.9.3`.
+9. Let CI publish the generated immutable `v1.9.3` stable release.
+10. Sync the stable `main` baseline back to `staging` and `premain` through PRs or documented verified automation.
 
 ## Stop Conditions
 
@@ -32,6 +38,8 @@ Recovery must stay inside the normal protected-branch and release-please flow:
 - Do not hand-publish releases, edit immutable GitHub releases, or upload release assets by hand.
 - Do not hand-edit `.release-please-manifest*.json`, `CHANGELOG.md`, `ts/package*.json`, or
   `py/src/theorydb_py/version.json`; release-please owns those updates.
+- Do not use a local stable-normalization branch as the normal path; `scripts/prepare-stable-promotion.sh` is only a
+  diagnostic/fallback helper if release automation is blocked and recovery is explicitly documented.
 - Do not hard reset, force-push, or mutate protected branches directly.
 
 Abandoned or exhausted immutable versions are skipped only through a normal release-eligible commit/PR with a

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,11 @@
         },
         {
           "type": "json",
+          "path": ".release-please-manifest.premain.json",
+          "jsonpath": "$['.']"
+        },
+        {
+          "type": "json",
           "path": "ts/package.json",
           "jsonpath": "$.version"
         },

--- a/scripts/prepare-stable-promotion.sh
+++ b/scripts/prepare-stable-promotion.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Normalize RC-owned files on a stable-promotion branch before it is proposed to main.
+# Diagnostic/fallback helper for inspecting or normalizing RC-owned files during stable-promotion recovery.
 #
-# Expected use:
-#   1. Create a promotion branch from origin/main.
-#   2. Merge origin/premain into that branch without pushing to main.
-#   3. Run this script in dry-run mode, then with --write after reviewing the plan.
-#   4. Open a PR from the normalized promotion branch to main.
+# Normal stable releases are CI/release-please driven:
+#   staging -> premain -> generated/published RC -> main -> generated/published stable release.
+#
+# Use this script only for diagnostics, or as an explicitly documented fallback when release automation is blocked.
 #
 # This script does not create branches, merge refs, push, tag, or publish releases.
 
 usage() {
   cat <<'USAGE'
 Usage: bash scripts/prepare-stable-promotion.sh [--check|--write] [--expected-version X.Y.Z]
+
+Diagnostic/fallback helper only. The normal stable release path leaves version and changelog edits to release-please.
 
 Options:
   --check                 Print the normalization plan only. This is the default.

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -371,6 +371,31 @@ if [[ -f "ts/package.json" ]]; then
   done
 fi
 
+if [[ -f "release-please-config.json" ]]; then
+  if ! python3 - <<'PY'
+import json
+from pathlib import Path
+
+config = json.loads(Path("release-please-config.json").read_text(encoding="utf-8"))
+extra_files = config.get("packages", {}).get(".", {}).get("extra-files", [])
+
+for entry in extra_files:
+    if (
+        isinstance(entry, dict)
+        and entry.get("type") == "json"
+        and entry.get("path") == ".release-please-manifest.premain.json"
+        and entry.get("jsonpath") == "$['.']"
+    ):
+        raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+  then
+    echo "branch-release: release-please-config.json must normalize .release-please-manifest.premain.json through stable release-please"
+    failures=$((failures + 1))
+  fi
+fi
+
 if [[ -f "py/pyproject.toml" ]]; then
   for cfg in "release-please-config.premain.json" "release-please-config.json"; do
     if [[ ! -f "${cfg}" ]]; then


### PR DESCRIPTION
## Summary

Carry the CI-driven stable-promotion release-cycle fix that already landed on `staging` in PR #250 into `premain` before the generated `v1.9.3-rc.1` release-please PR is merged.

## Why this PR exists

- PR #248 landed the release-eligible recovery commit with `Release-As: 1.9.3-rc.1`.
- PR #249 moved `staging -> premain` before PR #250 landed.
- PR #250 then landed the missing process fix on `staging`: stable release-please now normalizes `.release-please-manifest.premain.json`, and the release docs describe the fully automated path.
- This PR keeps the no-hack release path intact by moving that fix through the normal protected-branch PR flow.

## Required order

1. Merge this PR into `premain` after checks pass.
2. Let release-please update/regenerate PR #251 for `v1.9.3-rc.1` if needed.
3. Review and merge PR #251 only after it is based on the updated `premain` and all checks pass.
4. Continue with `premain -> main -> stable release` through CI/release-please only.

## Non-goals

No tags, no hard resets, no manual release creation, no manifest/package/changelog edits outside release-please.
