### PR TITLE
chore(release): promote premain to main for 1.9.3 stable release

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -19,6 +19,8 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_PLEASE_CLI_VERSION: "17.3.0"
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -92,25 +94,42 @@ jobs:
           echo "release_as=${release_as}" >> "${GITHUB_OUTPUT}"
           echo "release-as: ${release_as:-<none>}"
 
-      - name: Release Please (PR only) (aligned)
-        if: steps.version.outputs.release_as != ''
-        id: release_aligned
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          target-branch: main
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-          release-as: ${{ steps.version.outputs.release_as }}
-          skip-github-release: true
+      - name: Release Please CLI (PR only)
+        env:
+          RELEASE_AS: ${{ steps.version.outputs.release_as }}
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
 
-      - name: Release Please (PR only)
-        if: steps.version.outputs.release_as == ''
-        id: release_default
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          target-branch: main
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-          skip-github-release: true
+          if [[ -z "${RELEASE_PLEASE_TOKEN}" ]]; then
+            echo "release-pr: FAIL (missing release-please token)"
+            exit 1
+          fi
+
+          args=(
+            release-pr
+            --repo-url "${GITHUB_REPOSITORY}"
+            --target-branch main
+            --config-file release-please-config.json
+            --manifest-file .release-please-manifest.json
+            --token "${RELEASE_PLEASE_TOKEN}"
+          )
+
+          if [[ -n "${RELEASE_AS}" ]]; then
+            args+=(--release-as "${RELEASE_AS}")
+          fi
+
+          npx --yes "release-please@${RELEASE_PLEASE_CLI_VERSION}" "${args[@]}"
+
+      - name: Verify stable Release PR postcondition
+        if: steps.version.outputs.release_as != ''
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.release_as }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          bash scripts/verify-main-release-pr-postcondition.sh \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base main \
+            --expected-version "${EXPECTED_VERSION}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,10 +72,10 @@ Release ownership:
 
 - `staging` owns integration-ready code, docs, security/toolchain updates, and the latest stable baseline returned from
   `main`. It must not pretend to cut a release. During active RC reconciliation, it may temporarily carry the current
-  `premain` RC lane in prerelease/SDK files only when the stable manifest stays aligned with `main` and the RC files are
+  `premain` RC phase in prerelease/SDK files only when the stable manifest stays aligned with `main` and the RC files are
   internally consistent and ahead of that stable baseline.
 - `premain` owns RC generation. It may carry `X.Y.Z-rc.N` in the prerelease manifest and SDK version files only while
-  the prerelease lane is active.
+  the RC phase is active.
 - `main` owns stable state only. Outside explicit pending stable promotion, the stable manifest, prerelease manifest, and
   SDK version files on `main` must not contain `-rc`.
 
@@ -85,13 +85,13 @@ Immutable version reuse:
   A deleted immutable release/tag has exhausted that version name for release-cycle purposes.
 - Do not manually recreate tags, hand-publish releases, edit immutable release assets, or hand-edit manifests as recovery.
 - If publishing fails with `tag_name was used by an immutable release`, recover through a normal release-eligible PR and
-  let release-please advance to the next RC/stable version for that lane.
+  let release-please advance to the next RC/stable version for the single release lane.
 - If a version is abandoned or exhausted, skip it only through a normal release-eligible commit/PR with a release-please
   `Release-As` footer for the next allowed version. Do not recover through tags, resets, manual release edits,
   manifest/package-version edits, or reruns of failed exhausted-version workflows.
-- Current THE-1869 lane decision: `1.9.2` is abandoned; the next RC must be `v1.9.3-rc.1`; the next stable release must be
-  `v1.9.3`; the release-eligible recovery commit must carry `Release-As: 1.9.3-rc.1` and that footer must survive the
-  `staging` -> `premain` merge path.
+- Current THE-1869 release-cycle decision: `1.9.2` is abandoned; the next RC must be `v1.9.3-rc.1`; the next stable
+  release must be `v1.9.3`; the release-eligible recovery commit must carry `Release-As: 1.9.3-rc.1` and that footer
+  must survive the `staging` -> `premain` merge path.
 
 Stable promotion path:
 
@@ -102,7 +102,7 @@ Stable promotion path:
   normal path.
 - After the `premain` -> `main` promotion merges, the release cycle may enter a short **pending stable promotion** state:
   `.release-please-manifest.json` remains at the prior stable version while prerelease/SDK files still reflect the
-  promoted RC lane. This state is allowed only until `.github/workflows/release-pr.yml` opens the stable release-please PR
+  promoted RC phase. This state is allowed only until `.github/workflows/release-pr.yml` opens the stable release-please PR
   and that PR merges.
 - Pending stable promotion is explicit automation state only:
   `RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true` may be used by the release workflows to verify the promotion
@@ -127,7 +127,7 @@ Release watchpoints and stop conditions:
 - Stop if `main` stable files contain `-rc` outside explicit pending stable promotion, or if
   `.release-please-manifest.json` is an RC version.
 - Stop if `premain` stable manifest is behind `origin/main`, or if `staging` lacks the latest stable baseline after a
-  stable release, or if `staging` keeps RC reconciliation files after the active lane has normalized to stable.
+  stable release, or if `staging` keeps RC reconciliation files after the active RC phase has normalized to stable.
 - Stop if SEC-2/govulncheck still observes Go `1.26.3`, COM-8 branch/version sync fails, or release-please opens a
   stable PR for an RC version.
 - Stop if `main` remains in pending stable promotion and no stable release-please PR opens for the computed stable

--- a/docs/development/planning/templates/high-risk-branch-release-policy.template.md
+++ b/docs/development/planning/templates/high-risk-branch-release-policy.template.md
@@ -1,6 +1,8 @@
 # Branch + Release Policy Template (High-Risk Domains)
 
 This template is intended to be copied and filled per project.
+Use one release lane with an RC phase followed by a stable phase. Branches can separate integration, RC generation, and
+stable publishing duties, but they must not create a second release path for the same product.
 
 ## Branches
 
@@ -10,7 +12,7 @@ This template is intended to be copied and filled per project.
 Define exactly what each branch owns. For a three-branch model, document:
 
 - `[integration-branch]` owns normal work and the latest stable baseline after release. During active RC reconciliation,
-  it may temporarily carry the current `[prerelease-branch]` RC lane in prerelease manifests and SDK/package files, but
+  it may temporarily carry the current `[prerelease-branch]` RC phase in prerelease manifests and SDK/package files, but
   only while the stable manifest remains aligned with `[release-branch]` and the RC files are internally consistent and
   ahead of that stable baseline.
 - `[prerelease-branch]` owns RC state and may carry `X.Y.Z-rc.N` in prerelease manifests and SDK/package files.
@@ -26,7 +28,7 @@ Define exactly what each branch owns. For a three-branch model, document:
 If the project uses separate integration, prerelease, and stable branches, prefer this stable-promotion flow:
 
 1. Work lands on `[integration-branch]`.
-2. `[integration-branch]` -> `[prerelease-branch]` PR starts the prerelease lane.
+2. `[integration-branch]` -> `[prerelease-branch]` PR starts the RC phase.
 3. Prerelease automation produces `vX.Y.Z-rc.N` on `[prerelease-branch]`.
 4. Verify the intended RC is published and asset-complete, then open and merge the `[prerelease-branch]` ->
    `[release-branch]` promotion PR.
@@ -70,9 +72,9 @@ Document forbidden stable-branch states:
 
 Document immutable release version reuse explicitly. Treat published release tag names as one-time-use even if the release
 or tag is later deleted. If a publish step fails with `tag_name was used by an immutable release`, recovery must go through
-a normal release-eligible PR and the release tool must advance to the next RC/stable version for that lane.
+a normal release-eligible PR and the release tool must advance to the next RC/stable version for the single release lane.
 
-Document abandoned or exhausted lane recovery explicitly. A skipped immutable version must advance only through a normal
+Document abandoned or exhausted version recovery explicitly. A skipped immutable version must advance only through a normal
 release-eligible commit/PR with the release tool's explicit version override footer, for example
 `Release-As: [next-version-or-rc]` when using release-please. The footer must survive the integration -> prerelease merge
 path. Do not recover by creating tags, rerunning failed exhausted-version workflows, editing immutable releases, patching
@@ -110,7 +112,7 @@ Pause before merge or release when:
 - stable-branch files contain `-rc` outside explicit pending stable promotion.
 - prerelease stable baseline is behind the release branch.
 - integration branch lacks the latest stable baseline after a stable release, or keeps RC reconciliation files after the
-  active lane has been normalized to stable.
+  active RC phase has been normalized to stable.
 - security/governance checks still observe a vulnerable toolchain or dependency state.
 - branch/version sync checks fail.
 - an abandoned/exhausted version recovery lacks the required release-eligible commit footer or tries to skip the release

--- a/docs/development/planning/theorydb-branch-release-policy.md
+++ b/docs/development/planning/theorydb-branch-release-policy.md
@@ -1,6 +1,8 @@
 # TableTheory: Branch + Release Policy (main release, premain prerelease)
 
 This document defines the intended branch strategy and release automation for TableTheory in high-risk usage contexts.
+TableTheory has one release lane: `staging` -> `premain` -> RC -> `main` -> stable release. `premain` owns the RC
+phase of that lane, and `main` owns the stable phase; neither branch starts a separate release path.
 
 ## Branches
 
@@ -11,9 +13,9 @@ This document defines the intended branch strategy and release automation for Ta
 ## Ownership
 
 - `staging` owns integration-ready code, docs, security/toolchain updates, and release-cycle guardrails before they enter
-  prerelease or stable lanes. After a stable release, `staging` must receive the latest stable baseline from `main` so the
+  the RC or stable phases. After a stable release, `staging` must receive the latest stable baseline from `main` so the
   next cycle starts from the released state. During active RC reconciliation, `staging` may temporarily carry the current
-  `premain` RC lane in `.release-please-manifest.premain.json` and SDK version files, but only while the stable manifest
+  `premain` RC phase in `.release-please-manifest.premain.json` and SDK version files, but only while the stable manifest
   remains aligned with `main` and the RC files are internally consistent and ahead of that stable baseline.
 - `premain` owns prerelease state. The prerelease manifest `.release-please-manifest.premain.json` and SDK version files
   (`ts/package.json`, `ts/package-lock.json`, `py/src/theorydb_py/version.json`) may carry `X.Y.Z-rc.N` while an RC is in
@@ -73,7 +75,7 @@ a replacement release by hand, edit immutable release assets, or patch manifests
 
 If a publish step fails with `tag_name was used by an immutable release`, recover through the normal PR-driven release
 flow: land a release-eligible change, promote it through the documented branch path, and let release-please advance to the
-next RC or stable version for that lane.
+next RC or stable version for the single release lane.
 
 If a version is abandoned or otherwise exhausted before a healthy release is available, skip it only through a normal
 release-eligible commit/PR with a release-please `Release-As` footer for the next allowed version. The footer must survive
@@ -178,7 +180,7 @@ Run `bash scripts/watch-release-cycle.sh` during a release and rerun with `--str
 - `.release-please-manifest.json` set to an RC version.
 - `origin/premain` stable manifest behind `origin/main`.
 - `origin/staging` missing the latest stable baseline after a stable release, or carrying RC reconciliation files after
-  the active RC lane has been normalized to stable.
+  the active RC phase has been normalized to stable.
 - SEC-2/govulncheck still observing Go `1.26.3`.
 - COM-8 branch/version sync failing.
 - release-please opening a stable PR for an RC version.

--- a/docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md
+++ b/docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md
@@ -1,12 +1,13 @@
-# TableTheory Release-Cycle Recovery: 1.9.3 Lane
+# TableTheory Release-Cycle Recovery: 1.9.3
 
-This record documents the THE-1869 release-cycle recovery decision for the abandoned `1.9.2` lane.
+This record documents the THE-1869 release-cycle recovery decision for the abandoned `1.9.2` version in TableTheory's
+one release lane: `staging` -> `premain` -> RC -> `main` -> stable release.
 
 ## Decision
 
 - `1.9.2` is abandoned and must not be released as an RC or as a stable release.
-- The next prerelease lane is `v1.9.3-rc.1`.
-- The eventual stable release for this lane is `v1.9.3`.
+- The next RC is `v1.9.3-rc.1`.
+- The stable release for the same semver base is `v1.9.3`.
 
 ## Required Recovery Path
 
@@ -33,7 +34,7 @@ Recovery must stay inside the normal protected-branch and release-please flow:
 
 During this recovery, a reconciliation PR to `staging` may merge current `premain` first to surface promotion conflicts
 before they reach `main`. That PR may carry `.release-please-manifest.premain.json`, `ts/package*.json`, and
-`py/src/theorydb_py/version.json` at the active `1.9.3-rc.1` lane as merge-carried state only. The stable manifest must
+`py/src/theorydb_py/version.json` at the active `1.9.3-rc.1` RC phase as merge-carried state only. The stable manifest must
 remain on the current `main` baseline, the RC files must be internally consistent and ahead of that baseline, and the
 state must be removed by the stable release-please PR plus post-stable sync after `v1.9.3` publishes.
 
@@ -50,4 +51,4 @@ state must be removed by the stable release-please PR plus post-stable sync afte
 
 Abandoned or exhausted immutable versions are skipped only through a normal release-eligible commit/PR with a
 release-please `Release-As` footer. For this recovery, the footer must survive the `staging` merge and later
-`staging` -> `premain` promotion so release-please advances the prerelease lane to `v1.9.3-rc.1` instead of `1.9.2`.
+`staging` -> `premain` promotion so release-please advances the RC phase to `v1.9.3-rc.1` instead of `1.9.2`.

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -20,6 +20,7 @@ required_files=(
   ".release-please-manifest.premain.json"
   ".release-please-manifest.json"
   "scripts/sync-post-stable-release-baselines.sh"
+  "scripts/verify-main-release-pr-postcondition.sh"
   "docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md"
 )
 
@@ -71,7 +72,7 @@ grep -Fq "tag_name was used by an immutable release" \
   failures=$((failures + 1))
 }
 grep -Fq "Release-As:" "docs/development/planning/templates/high-risk-branch-release-policy.template.md" || {
-  echo "branch-release: high-risk branch policy template must document release-please Release-As lane recovery"
+  echo "branch-release: high-risk branch policy template must document release-please Release-As version recovery"
   failures=$((failures + 1))
 }
 grep -Fq "Release-As: 1.9.3-rc.1" "AGENTS.md" || {
@@ -81,7 +82,7 @@ grep -Fq "Release-As: 1.9.3-rc.1" "AGENTS.md" || {
 if [[ -f "docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md" ]]; then
   recovery_doc="docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md"
   grep -Fq "1.9.2" "${recovery_doc}" || {
-    echo "branch-release: recovery doc must record the abandoned 1.9.2 lane"
+    echo "branch-release: recovery doc must record the abandoned 1.9.2 release-cycle decision"
     failures=$((failures + 1))
   }
   grep -Fq "v1.9.3-rc.1" "${recovery_doc}" || {
@@ -287,15 +288,31 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
     echo "branch-release: release-pr workflow must target main"
     failures=$((failures + 1))
   }
-  grep -Eq 'googleapis/release-please-action@[0-9a-fA-F]{40}.*\bv4\b' ".github/workflows/release-pr.yml" || {
-    echo "branch-release: release-pr workflow must pin release-please v4 by commit SHA"
+  if grep -Fq "googleapis/release-please-action" ".github/workflows/release-pr.yml"; then
+    echo "branch-release: release-pr workflow must use pinned release-please CLI, not release-please-action, so release-as is honored in manifest mode"
+    failures=$((failures + 1))
+  fi
+  grep -Fq 'RELEASE_PLEASE_CLI_VERSION: "17.3.0"' ".github/workflows/release-pr.yml" || {
+    echo "branch-release: release-pr workflow must pin release-please CLI to v17.3.0"
     failures=$((failures + 1))
   }
-  grep -Eq 'config-file:\s*release-please-config\.json' ".github/workflows/release-pr.yml" || {
+  grep -Fq 'npx --yes "release-please@${RELEASE_PLEASE_CLI_VERSION}"' ".github/workflows/release-pr.yml" || {
+    echo "branch-release: release-pr workflow must invoke the pinned release-please CLI"
+    failures=$((failures + 1))
+  }
+  grep -Fq "release-pr" ".github/workflows/release-pr.yml" || {
+    echo "branch-release: release-pr workflow must run the release-pr CLI command"
+    failures=$((failures + 1))
+  }
+  grep -Eq -- '--target-branch[[:space:]]+main' ".github/workflows/release-pr.yml" || {
+    echo "branch-release: release-pr workflow must target main through the CLI"
+    failures=$((failures + 1))
+  }
+  grep -Eq -- '--config-file[[:space:]]+release-please-config\.json' ".github/workflows/release-pr.yml" || {
     echo "branch-release: release-pr workflow must reference release-please-config.json"
     failures=$((failures + 1))
   }
-  grep -Eq 'manifest-file:\s*\.release-please-manifest\.json' ".github/workflows/release-pr.yml" || {
+  grep -Eq -- '--manifest-file[[:space:]]+\.release-please-manifest\.json' ".github/workflows/release-pr.yml" || {
     echo "branch-release: release-pr workflow must reference .release-please-manifest.json"
     failures=$((failures + 1))
   }
@@ -311,8 +328,8 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
     echo "branch-release: release-pr workflow must document pending promotion PR generation"
     failures=$((failures + 1))
   }
-  grep -Eq 'skip-github-release:\s*true' ".github/workflows/release-pr.yml" || {
-    echo "branch-release: release-pr workflow must set skip-github-release: true"
+  grep -Fq "scripts/verify-main-release-pr-postcondition.sh" ".github/workflows/release-pr.yml" || {
+    echo "branch-release: release-pr workflow must verify the stable Release PR postcondition"
     failures=$((failures + 1))
   }
 
@@ -320,6 +337,10 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
   # so the stable line never lags behind the prerelease line.
   grep -Fq "release-as:" ".github/workflows/release-pr.yml" || {
     echo "branch-release: release-pr workflow must set release-as to promote the premain RC baseline"
+    failures=$((failures + 1))
+  }
+  grep -Fq -- "--release-as" ".github/workflows/release-pr.yml" || {
+    echo "branch-release: release-pr workflow must pass release-as to the pinned CLI"
     failures=$((failures + 1))
   }
   grep -Fq "steps.version.outputs.release_as" ".github/workflows/release-pr.yml" || {
@@ -330,6 +351,46 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
     echo "branch-release: release-pr workflow must read .release-please-manifest.premain.json to align versions"
     failures=$((failures + 1))
   }
+fi
+
+if [[ -f "scripts/verify-main-release-pr-postcondition.sh" ]]; then
+  postcondition="scripts/verify-main-release-pr-postcondition.sh"
+  grep -Fq "expected version must be stable X.Y.Z" "${postcondition}" || {
+    echo "branch-release: main Release PR postcondition must reject RC-valued expected versions"
+    failures=$((failures + 1))
+  }
+  grep -Fq "advertises an RC version" "${postcondition}" || {
+    echo "branch-release: main Release PR postcondition must reject open RC-valued main release PRs"
+    failures=$((failures + 1))
+  }
+  for path in \
+    ".release-please-manifest.json" \
+    ".release-please-manifest.premain.json" \
+    "py/src/theorydb_py/version.json" \
+    "ts/package.json" \
+    "ts/package-lock.json" \
+    "CHANGELOG.md"; do
+    grep -Fq "${path}" "${postcondition}" || {
+      echo "branch-release: main Release PR postcondition must require ${path}"
+      failures=$((failures + 1))
+    }
+  done
+fi
+
+grep -Fq "one release lane" "docs/development/planning/theorydb-branch-release-policy.md" || {
+  echo "branch-release: TableTheory branch release policy must describe one release lane"
+  failures=$((failures + 1))
+}
+grep -Fq "one release lane" "docs/development/planning/templates/high-risk-branch-release-policy.template.md" || {
+  echo "branch-release: high-risk branch policy template must describe one release lane"
+  failures=$((failures + 1))
+}
+if grep -RInE 'two release lanes|separate release lanes' \
+  AGENTS.md docs/development/planning/theorydb-branch-release-policy.md \
+  docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md \
+  docs/development/planning/templates/high-risk-branch-release-policy.template.md; then
+  echo "branch-release: docs must not describe TableTheory as having two release lanes"
+  failures=$((failures + 1))
 fi
 
 for wf in ".github/workflows/quality-gates.yml" ".github/workflows/codeql.yml"; do

--- a/scripts/verify-main-release-pr-postcondition.sh
+++ b/scripts/verify-main-release-pr-postcondition.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only postcondition for the main Release PR workflow. It verifies that
+# pending stable promotion produced a stable release-please PR, not an RC PR,
+# and that the PR includes the files that normalize prerelease SDK state.
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/verify-main-release-pr-postcondition.sh --expected-version X.Y.Z [options]
+
+Options:
+  --expected-version X.Y.Z  Stable version the main release PR must advertise.
+  --repo OWNER/REPO         GitHub repository. Defaults to $GITHUB_REPOSITORY or theory-cloud/TableTheory.
+  --base BRANCH            Release PR base branch. Defaults to main.
+  --head BRANCH            Release-please PR head branch. Defaults to release-please--branches--main.
+  --dry-run                Read-only local validation mode; no GitHub state is changed.
+  -h, --help               Show this help.
+
+This command uses only read-only gh queries. It never creates, updates, closes,
+merges, tags, publishes, uploads, or deletes anything.
+USAGE
+}
+
+repo="${GITHUB_REPOSITORY:-theory-cloud/TableTheory}"
+base="main"
+head="release-please--branches--main"
+expected_version="${RELEASE_PR_EXPECTED_VERSION:-}"
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expected-version)
+      if [[ $# -lt 2 ]]; then
+        echo "release-pr-postcondition: FAIL (--expected-version requires a value)" >&2
+        exit 2
+      fi
+      expected_version="$2"
+      shift 2
+      ;;
+    --repo)
+      if [[ $# -lt 2 ]]; then
+        echo "release-pr-postcondition: FAIL (--repo requires a value)" >&2
+        exit 2
+      fi
+      repo="$2"
+      shift 2
+      ;;
+    --base)
+      if [[ $# -lt 2 ]]; then
+        echo "release-pr-postcondition: FAIL (--base requires a value)" >&2
+        exit 2
+      fi
+      base="$2"
+      shift 2
+      ;;
+    --head)
+      if [[ $# -lt 2 ]]; then
+        echo "release-pr-postcondition: FAIL (--head requires a value)" >&2
+        exit 2
+      fi
+      head="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "release-pr-postcondition: FAIL (unknown argument: $1)" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+fail() {
+  echo "release-pr-postcondition: FAIL ($1)" >&2
+  exit 1
+}
+
+if [[ -z "${expected_version}" ]]; then
+  fail "missing --expected-version"
+fi
+
+if [[ ! "${expected_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  fail "expected version must be stable X.Y.Z, got ${expected_version}"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  fail "gh is required"
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  fail "gh is not authenticated"
+fi
+
+if [[ "${dry_run}" -eq 1 ]]; then
+  echo "release-pr-postcondition: dry-run/read-only mode"
+fi
+
+open_prs="$(mktemp)"
+candidate_number_file="$(mktemp)"
+details="$(mktemp)"
+cleanup() {
+  rm -f "${open_prs}" "${candidate_number_file}" "${details}"
+}
+trap cleanup EXIT
+
+gh pr list \
+  --repo "${repo}" \
+  --base "${base}" \
+  --state open \
+  --json number,title,headRefName,url >"${open_prs}"
+
+python3 - "${open_prs}" "${expected_version}" "${base}" "${head}" >"${candidate_number_file}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+path, expected_version, base, head = sys.argv[1:5]
+prs = json.loads(Path(path).read_text(encoding="utf-8"))
+expected_title = f"chore({base}): release {expected_version}"
+
+
+def fail(message: str) -> None:
+    print(f"release-pr-postcondition: FAIL ({message})", file=sys.stderr)
+    raise SystemExit(1)
+
+
+rc_release_prs = [
+    pr
+    for pr in prs
+    if "release" in pr.get("title", "").lower()
+    and re.search(r"\d+\.\d+\.\d+-rc(?:[.\-\w]*)?", pr.get("title", ""))
+]
+if rc_release_prs:
+    details = ", ".join(
+        f"#{pr.get('number')} {pr.get('title')} {pr.get('url')}"
+        for pr in rc_release_prs
+    )
+    fail(f"open {base} release PR advertises an RC version: {details}")
+
+head_matches = [pr for pr in prs if pr.get("headRefName") == head]
+title_matches = [pr for pr in prs if pr.get("title") == expected_title]
+candidates = head_matches or title_matches
+if not candidates:
+    fail(
+        "no open main release PR found for "
+        f"{expected_title!r} or head {head!r}"
+    )
+
+if len(candidates) > 1:
+    details = ", ".join(
+        f"#{pr.get('number')} {pr.get('title')} {pr.get('url')}"
+        for pr in candidates
+    )
+    fail(f"multiple candidate release PRs found: {details}")
+
+candidate = candidates[0]
+if candidate.get("title") != expected_title:
+    fail(
+        f"release PR #{candidate.get('number')} title "
+        f"{candidate.get('title')!r} != {expected_title!r}"
+    )
+
+print(candidate["number"])
+print(
+    "release-pr-postcondition: candidate "
+    f"#{candidate.get('number')} {candidate.get('title')} {candidate.get('url')}",
+    file=sys.stderr,
+)
+PY
+
+candidate_number="$(cat "${candidate_number_file}")"
+
+gh pr view "${candidate_number}" \
+  --repo "${repo}" \
+  --json number,title,headRefName,baseRefName,url,files >"${details}"
+
+python3 - "${details}" "${expected_version}" "${base}" "${head}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, expected_version, base, head = sys.argv[1:5]
+pr = json.loads(Path(path).read_text(encoding="utf-8"))
+expected_title = f"chore({base}): release {expected_version}"
+required_paths = {
+    ".release-please-manifest.json",
+    ".release-please-manifest.premain.json",
+    "py/src/theorydb_py/version.json",
+    "ts/package.json",
+    "ts/package-lock.json",
+    "CHANGELOG.md",
+}
+
+
+def fail(message: str) -> None:
+    print(f"release-pr-postcondition: FAIL ({message})", file=sys.stderr)
+    raise SystemExit(1)
+
+
+if pr.get("baseRefName") != base:
+    fail(f"PR #{pr.get('number')} base {pr.get('baseRefName')!r} != {base!r}")
+
+if pr.get("headRefName") != head:
+    fail(f"PR #{pr.get('number')} head {pr.get('headRefName')!r} != {head!r}")
+
+if pr.get("title") != expected_title:
+    fail(f"PR #{pr.get('number')} title {pr.get('title')!r} != {expected_title!r}")
+
+if "-rc" in pr.get("title", ""):
+    fail(f"PR #{pr.get('number')} title is prerelease-shaped: {pr.get('title')}")
+
+paths = {entry.get("path", "") for entry in pr.get("files", [])}
+missing = sorted(required_paths - paths)
+if missing:
+    fail(f"PR #{pr.get('number')} missing normalization files: {', '.join(missing)}")
+
+print(
+    "release-pr-postcondition: PASS "
+    f"(#{pr.get('number')} {expected_title}; normalization files present)"
+)
+PY


### PR DESCRIPTION
Promotes the verified RC line from `premain` to `main` as the stable-release phase of the single release lane:

`staging -> premain -> RC -> main -> stable release`

Context:
- `v1.9.3-rc.1` is the verified RC for this release cycle.
- `1.9.2` is abandoned and must not be released.
- PR #256 was the unsafe generated main Release PR and is closed.
- PR #257 fixed stable Release PR generation to use pinned `release-please@17.3.0` CLI with `--release-as` plus a postcondition that rejects RC-valued main Release PRs.
- PR #258 promoted that fix from `staging` to `premain`.

Expected after this PR merges:
- `main` may temporarily be in explicit pending stable promotion state.
- `.github/workflows/release-pr.yml` must generate/update the stable release-please PR as `chore(main): release 1.9.3`.
- That generated PR must include the stable normalization file set:
  - `.release-please-manifest.json`
  - `.release-please-manifest.premain.json`
  - `py/src/theorydb_py/version.json`
  - `ts/package.json`
  - `ts/package-lock.json`
  - `CHANGELOG.md`

Do not merge this PR until the `premain` push checks and this PR's checks are green.
No manual tags, no hard resets, no manual release edits, no manifest/package/CHANGELOG hand edits.