### PR TITLE
fix(release): accept release-please RC version shape

### DIFF
--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -365,8 +365,8 @@ if [[ -f "scripts/verify-prerelease-pr-postcondition.sh" ]]; then
     "prerelease PR postcondition must require the generated premain head branch"
   require_fixed "rc_title_re = re.compile" "${prerelease_postcondition}" \
     "prerelease PR postcondition must require RC-shaped release titles"
-  require_fixed "-rc\\.\\d+" "${prerelease_postcondition}" \
-    "prerelease PR postcondition must require RC version syntax"
+  require_fixed "-rc(?:\\.\\d+)?" "${prerelease_postcondition}" \
+    "prerelease PR postcondition must accept bare and numbered RC version syntax"
   require_fixed ".release-please-manifest.premain.json" "${prerelease_postcondition}" \
     "prerelease PR postcondition must require the prerelease manifest"
 fi

--- a/scripts/verify-prerelease-pr-postcondition.sh
+++ b/scripts/verify-prerelease-pr-postcondition.sh
@@ -12,7 +12,7 @@ Options:
   --repo OWNER/REPO         GitHub repository. Defaults to $GITHUB_REPOSITORY or theory-cloud/TableTheory.
   --base BRANCH            Release PR base branch. Defaults to premain.
   --head BRANCH            Release-please PR head branch. Defaults to release-please--branches--premain.
-  --expected-version VER   Optional RC version the PR must advertise, e.g. 1.9.4-rc.1.
+  --expected-version VER   Optional RC version the PR must advertise, e.g. 1.9.4-rc or 1.9.4-rc.1.
   --dry-run                Read-only local validation mode; no GitHub state is changed.
   -h, --help               Show this help.
 
@@ -82,8 +82,8 @@ fail() {
   exit 1
 }
 
-if [[ -n "${expected_version}" && ! "${expected_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
-  fail "expected version must be RC-shaped X.Y.Z-rc.N, got ${expected_version}"
+if [[ -n "${expected_version}" && ! "${expected_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]; then
+  fail "expected version must be RC-shaped X.Y.Z-rc or X.Y.Z-rc.N, got ${expected_version}"
 fi
 
 if ! command -v gh >/dev/null 2>&1; then
@@ -120,7 +120,7 @@ from pathlib import Path
 
 path, expected_version, base, head = sys.argv[1:5]
 prs = json.loads(Path(path).read_text(encoding="utf-8"))
-rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc\.\d+$")
+rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
 
 
 def fail(message: str) -> None:
@@ -181,7 +181,7 @@ from pathlib import Path
 
 path, base, head = sys.argv[1:4]
 pr = json.loads(Path(path).read_text(encoding="utf-8"))
-rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc\.\d+$")
+rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
 required_paths = {
     ".release-please-manifest.premain.json",
     "py/src/theorydb_py/version.json",

--- a/scripts/verify-promotion-release-driver.sh
+++ b/scripts/verify-promotion-release-driver.sh
@@ -181,9 +181,9 @@ metadata_path = Path(sys.argv[1])
 base = os.environ["BASE_REF"]
 head = os.environ["HEAD_REF"]
 
-rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc\.\d+$")
+rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc(?:\.\d+)?$")
 stable_version_re = re.compile(r"^v?\d+\.\d+\.\d+$")
-rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc\.\d+$")
+rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
 stable_title_re = re.compile(r"^chore\(main\): release \d+\.\d+\.\d+$")
 any_rc_re = re.compile(r"\d+\.\d+\.\d+-rc(?:[.\-\w]*)?")
 
@@ -227,7 +227,7 @@ def release_as_versions(text: str) -> list[str]:
     return [
         match.group(1)
         for match in re.finditer(
-            r"(?im)^[ \t]*Release-As:[ \t]*v?([0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?)[ \t]*$",
+            r"(?im)^[ \t]*Release-As:[ \t]*v?([0-9]+\.[0-9]+\.[0-9]+(?:-rc(?:\.[0-9]+)?)?)[ \t]*$",
             text,
         )
     ]
@@ -331,7 +331,7 @@ if base == "premain":
     if invalid:
         fail(
             "staging -> premain Release-As footers must be RC-shaped "
-            f"X.Y.Z-rc.N, got {', '.join(invalid)}"
+            f"X.Y.Z-rc or X.Y.Z-rc.N, got {', '.join(invalid)}"
         )
     if versions:
         print(

--- a/scripts/verify-release-created-postcondition.sh
+++ b/scripts/verify-release-created-postcondition.sh
@@ -121,7 +121,7 @@ if [[ "${kind}" == "prerelease" ]]; then
   if [[ "${commit_message}" == *"release-please--branches--premain"* ]]; then
     generated=1
   fi
-  if [[ "${commit_message}" =~ chore\(premain\):[[:space:]]release[[:space:]]([0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+) ]]; then
+  if [[ "${commit_message}" =~ chore\(premain\):[[:space:]]release[[:space:]]([0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?) ]]; then
     generated=1
     release_version="${BASH_REMATCH[1]}"
   fi
@@ -142,7 +142,7 @@ if [[ "${kind}" == "prerelease" ]]; then
     fail "generated RC release PR merge created a release without tag_name"
   fi
 
-  if [[ ! "${tag_name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+  if [[ ! "${tag_name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]; then
     fail "generated RC release PR merge produced non-RC tag_name ${tag_name}"
   fi
 


### PR DESCRIPTION
## Summary

- Accept both release-please RC shapes in premain guardrails: `X.Y.Z-rc` and `X.Y.Z-rc.N`.
- Keep main stable-only by continuing to reject RC-shaped release messages and tags.
- Align the branch release supply-chain verifier with the broader prerelease PR postcondition pattern.

## Root Cause

`prerelease-pr.yml` generated/opened RC PR #266 as `chore(premain): release 1.9.4-rc`, but the postcondition only accepted numbered RC titles like `1.9.4-rc.1`. The publish postcondition and promotion driver had the same too-narrow numbered-RC assumption.

After this merges to `staging` and is promoted to `premain`, generated RC PR #266 can be updated/merged to publish the next RC.

## Validation

- `git diff --check`
- `bash scripts/verify-release-cycle-state.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/verify-ci-rubric-enforced.sh`
- `bash scripts/verify-prerelease-pr-postcondition.sh --repo theory-cloud/TableTheory --base premain`
- Synthetic prerelease publish PASS: `HEAD_COMMIT_MESSAGE='chore(premain): release 1.9.4-rc' RELEASE_CREATED=true TAG_NAME=v1.9.4-rc ...`
- Synthetic prerelease publish expected FAIL: same generated message with `RELEASE_CREATED=false`
- Synthetic main stable-only expected FAIL checks for `1.9.4-rc` and `1.9.4-rc.1`