### PR TITLE
fix: harden release hygiene and derived key contracts

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -57,6 +57,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: dummy
           DYNAMODB_ENDPOINT: http://localhost:8000
           GOSEC_SARIF_PATH: gosec.sarif
+          NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS: "true"
         run: make rubric
 
       - name: Rubric report (stdout)

--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -13,88 +13,108 @@ jobs:
   hygiene:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout trusted release scripts
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-release
+          persist-credentials: false
 
-      - name: Validate release-lane source branch
+      - name: Verify release-lane same-repository provenance
         if: github.event_name == 'pull_request'
         env:
+          GH_TOKEN: ${{ github.token }}
           BASE_REF: ${{ github.base_ref }}
           HEAD_REF: ${{ github.head_ref }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
 
-          python3 - <<'PY'
-          import os
-          import re
-          import sys
+          bash trusted-release/scripts/verify-release-lane-provenance.sh \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base "${BASE_REF}" \
+            --head "${HEAD_REF}" \
+            --base-repo "${BASE_REPOSITORY}" \
+            --head-repo "${HEAD_REPOSITORY}" \
+            --base-sha "${BASE_SHA}" \
+            --head-sha "${HEAD_SHA}" \
+            --title "${PR_TITLE}"
 
-          base = os.environ["BASE_REF"]
-          head = os.environ["HEAD_REF"]
-          title = os.environ["PR_TITLE"]
+      - name: Checkout pull request head after provenance verification
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          persist-credentials: false
 
-
-          def fail(message: str) -> None:
-              print(f"release-hygiene: FAIL ({message})", file=sys.stderr)
-              raise SystemExit(1)
-
-
-          if base == "premain":
-              if head == "staging":
-                  print("release-hygiene: source branch OK (staging -> premain)")
-                  raise SystemExit(0)
-              if head == "release-please--branches--premain":
-                  if re.fullmatch(r"chore\(premain\): release \d+\.\d+\.\d+-rc\.\d+", title):
-                      print("release-hygiene: source branch OK (premain release-please RC PR)")
-                      raise SystemExit(0)
-                  fail(f"premain release-please PR must advertise an RC version, got {title!r}")
-              fail(f"premain PR head must be staging, got {head!r}")
-
-          if base == "main":
-              if re.search(r"\d+\.\d+\.\d+-rc(?:[.\-\w]*)?", title):
-                  fail(f"main PR must not advertise an RC version, got {title!r}")
-              if head == "premain":
-                  print("release-hygiene: source branch OK (premain -> main)")
-                  raise SystemExit(0)
-              if head == "release-please--branches--main":
-                  if re.fullmatch(r"chore\(main\): release \d+\.\d+\.\d+", title):
-                      print("release-hygiene: source branch OK (main stable release-please PR)")
-                      raise SystemExit(0)
-                  fail(f"main release-please PR must advertise a stable version, got {title!r}")
-              fail(f"main PR head must be premain, got {head!r}")
-
-          fail(f"unsupported release-hygiene base branch {base!r}")
-          PY
+      - name: Checkout workflow dispatch ref
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Verify human promotion release driver
         if: github.event_name == 'pull_request' && ((github.base_ref == 'premain' && github.head_ref == 'staging') || (github.base_ref == 'main' && github.head_ref == 'premain'))
+        working-directory: pr
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
 
-          bash scripts/verify-promotion-release-driver.sh \
+          bash ../trusted-release/scripts/verify-promotion-release-driver.sh \
             --repo "${GITHUB_REPOSITORY}" \
             --base "${GITHUB_BASE_REF}" \
             --head "${GITHUB_HEAD_REF}" \
             --pr "${PR_NUMBER}"
 
       - name: Verify release cycle state
+        if: github.event_name == 'pull_request'
+        working-directory: pr
         env:
-          RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'premain' && 'true' || 'false' }}
+          RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION: ${{ github.base_ref == 'main' && github.head_ref == 'premain' && 'true' || 'false' }}
+        run: bash ../trusted-release/scripts/verify-release-cycle-state.sh
+
+      - name: Verify release cycle state
+        if: github.event_name != 'pull_request'
+        env:
+          RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION: "false"
         run: bash scripts/verify-release-cycle-state.sh
 
       - name: Verify release supply-chain scaffolding
+        if: github.event_name == 'pull_request'
+        working-directory: pr
+        run: bash ../trusted-release/scripts/verify-branch-release-supply-chain.sh
+
+      - name: Verify release supply-chain scaffolding
+        if: github.event_name != 'pull_request'
         run: bash scripts/verify-branch-release-supply-chain.sh
 
       - name: Forbid RC-shaped main Release PRs
-        if: github.event_name != 'pull_request' || github.base_ref == 'main'
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        working-directory: pr
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          bash ../trusted-release/scripts/verify-main-release-pr-postcondition.sh \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base main \
+            --forbid-rc-only
+
+      - name: Forbid RC-shaped main Release PRs
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,6 +10,8 @@ on:
       - "py/src/theorydb_py/version.json"
       - "ts/package.json"
       - "ts/package-lock.json"
+      - "scripts/release-please-cli/package.json"
+      - "scripts/release-please-cli/package-lock.json"
   workflow_dispatch: {}
 
 permissions:
@@ -25,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Forbid RC-shaped main Release PRs
         env:
@@ -146,7 +150,8 @@ jobs:
 
           args+=(--release-as "${RELEASE_AS}")
 
-          npx --yes "release-please@${RELEASE_PLEASE_CLI_VERSION}" "${args[@]}"
+          npm ci --prefix scripts/release-please-cli --ignore-scripts
+          scripts/release-please-cli/node_modules/.bin/release-please "${args[@]}"
 
       - name: Verify stable Release PR postcondition
         if: steps.cycle.outputs.pending_stable_promotion == 'true'

--- a/contract-tests/generated/key-contracts/v0.1/theorymcp-derived-keys.generated.ts
+++ b/contract-tests/generated/key-contracts/v0.1/theorymcp-derived-keys.generated.ts
@@ -396,7 +396,7 @@ export const tabletheoryModelContract = {
             "client_namespace": "theorycloud",
             "partner_id": "keybank"
           },
-          "expect": "ns=theorycloud|partner=keybank|source=okta|type=subject_pattern|value=user/*"
+          "expect": "ns=theorycloud|partner=keybank|source=okta|type=subject_pattern|value=user%2F%2A"
         },
         {
           "name": "wildcard_namespace_and_partner",

--- a/contract-tests/key-contracts/v0.1/theorymcp-derived-keys.yml
+++ b/contract-tests/key-contracts/v0.1/theorymcp-derived-keys.yml
@@ -131,7 +131,7 @@ derived_keys:
           auth_source: " okta "
           binding_type: "subject_pattern"
           binding_value: " user/* "
-        expect: "ns=theorycloud|partner=keybank|source=okta|type=subject_pattern|value=user/*"
+        expect: "ns=theorycloud|partner=keybank|source=okta|type=subject_pattern|value=user%2F%2A"
       - name: "wildcard_namespace_and_partner"
         input:
           client_namespace: ""

--- a/gov-infra/planning/theorydb-visible-npm-audit-findings.json
+++ b/gov-infra/planning/theorydb-visible-npm-audit-findings.json
@@ -10,6 +10,7 @@
       "visibility": "visible",
       "status": "upstream-bundled-pending-fix",
       "reviewed_on": "2026-05-30",
+      "expires_on": "2026-07-30",
       "current_upstream_package": "aws-cdk-lib",
       "current_upstream_version": "2.257.0",
       "current_bundled_version": "5.0.5",

--- a/pkg/keycontract/contract_test.go
+++ b/pkg/keycontract/contract_test.go
@@ -52,6 +52,50 @@ func TestEvaluateDerivedKeyTransformsDefaultsAndOmission(t *testing.T) {
 	require.Equal(t, "scope=keybank", got)
 }
 
+func TestEvaluateDerivedKeyEscapesUserSuppliedReservedBytes(t *testing.T) {
+	t.Parallel()
+
+	key := DerivedKey{
+		Name: "Composite",
+		Join: "|",
+		Inputs: []Input{
+			{Name: "tenant"},
+			{Name: "resource"},
+		},
+		Segments: []Segment{
+			{Name: "tenant", Prefix: "tenant=", Value: ValueSource{Input: "tenant"}, Transforms: []string{TransformTrim}},
+			{Name: "resource", Prefix: "resource=", Value: ValueSource{Input: "resource"}, Transforms: []string{TransformTrim}},
+		},
+	}
+
+	left, err := EvaluateDerivedKey(key, map[string]any{"tenant": "a|resource=b", "resource": "c"})
+	require.NoError(t, err)
+	require.Equal(t, "tenant=a%7Cresource%3Db|resource=c", left)
+
+	right, err := EvaluateDerivedKey(key, map[string]any{"tenant": "a", "resource": "b|resource=c"})
+	require.NoError(t, err)
+	require.Equal(t, "tenant=a|resource=b%7Cresource%3Dc", right)
+	require.NotEqual(t, left, right)
+
+	got, err := EvaluateDerivedKey(key, map[string]any{"tenant": "user/*", "resource": "café"})
+	require.NoError(t, err)
+	require.Equal(t, "tenant=user%2F%2A|resource=caf%C3%A9", got)
+}
+
+func TestEvaluateDerivedKeyRejectsExplicitNullInput(t *testing.T) {
+	t.Parallel()
+
+	key := DerivedKey{
+		Name:     "Required",
+		Segments: []Segment{{Value: ValueSource{Input: "id"}}},
+	}
+
+	_, err := EvaluateDerivedKey(key, map[string]any{"id": nil})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `input "id"`)
+	require.Contains(t, err.Error(), "must not be null")
+}
+
 func TestScalarToStringCanonicalNumberFormat(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/keycontract/coverage_test.go
+++ b/pkg/keycontract/coverage_test.go
@@ -65,7 +65,6 @@ func TestScalarToStringCoversSupportedScalars(t *testing.T) {
 		value any
 		want  string
 	}{
-		{nil, ""},
 		{"x", "x"},
 		{false, "false"},
 		{float32(1.5), "1.5"},
@@ -88,7 +87,11 @@ func TestScalarToStringCoversSupportedScalars(t *testing.T) {
 		require.Equal(t, tc.want, got)
 	}
 
-	_, err := scalarToString([]string{"not", "scalar"})
+	_, err := scalarToString(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must not be null")
+
+	_, err = scalarToString([]string{"not", "scalar"})
 	require.Error(t, err)
 }
 

--- a/pkg/keycontract/evaluate.go
+++ b/pkg/keycontract/evaluate.go
@@ -62,17 +62,20 @@ func VerifyFixtures(contract *Contract) error {
 func evaluateSegment(keyName string, index int, segment Segment, input map[string]any) (value string, omit bool, err error) {
 	label := segmentLabel(segment, index)
 
-	value, present, err := resolveSegmentValue(segment, input)
+	resolved, err := resolveSegmentValue(segment, input)
 	if err != nil {
 		return "", false, fmt.Errorf("derived key %s segment %s: %w", keyName, label, err)
 	}
-	if shouldOmitMissingSegment(present, segment) {
+	if shouldOmitMissingSegment(resolved.present, segment) {
 		return "", true, nil
 	}
 
-	value, err = applyTransforms(value, segment.Transforms)
+	value, generatedWildcard, err := applyTransforms(resolved.value, segment.Transforms)
 	if err != nil {
 		return "", false, fmt.Errorf("derived key %s segment %s: %w", keyName, label, err)
+	}
+	if resolved.fromInput && !generatedWildcard {
+		value = escapeDerivedKeyInputValue(value)
 	}
 	value = applyDefault(value, segment)
 
@@ -104,7 +107,8 @@ func applyDefault(value string, segment Segment) string {
 	return value
 }
 
-func applyTransforms(value string, transforms []string) (string, error) {
+func applyTransforms(value string, transforms []string) (string, bool, error) {
+	generatedWildcard := false
 	for _, transform := range transforms {
 		switch transform {
 		case TransformTrim:
@@ -112,35 +116,42 @@ func applyTransforms(value string, transforms []string) (string, error) {
 		case TransformWildcardEmpty:
 			if value == "" {
 				value = "*"
+				generatedWildcard = true
 			}
 		default:
-			return "", fmt.Errorf("unsupported transform %q", transform)
+			return "", false, fmt.Errorf("unsupported transform %q", transform)
 		}
 	}
-	return value, nil
+	return value, generatedWildcard, nil
 }
 
-func resolveSegmentValue(segment Segment, input map[string]any) (string, bool, error) {
+type resolvedSegmentValue struct {
+	value     string
+	present   bool
+	fromInput bool
+}
+
+func resolveSegmentValue(segment Segment, input map[string]any) (resolvedSegmentValue, error) {
 	switch {
 	case segment.Literal != nil:
-		return *segment.Literal, true, nil
+		return resolvedSegmentValue{value: *segment.Literal, present: true}, nil
 	case segment.Value.Literal != nil:
-		return *segment.Value.Literal, true, nil
+		return resolvedSegmentValue{value: *segment.Value.Literal, present: true}, nil
 	case segment.Value.Input != "":
 		value, ok := input[segment.Value.Input]
 		if !ok {
 			if segment.Default != nil || segment.Optional {
-				return "", false, nil
+				return resolvedSegmentValue{}, nil
 			}
-			return "", false, fmt.Errorf("missing required input %q", segment.Value.Input)
+			return resolvedSegmentValue{}, fmt.Errorf("missing required input %q", segment.Value.Input)
 		}
 		out, err := scalarToString(value)
 		if err != nil {
-			return "", true, fmt.Errorf("input %q: %w", segment.Value.Input, err)
+			return resolvedSegmentValue{present: true, fromInput: true}, fmt.Errorf("input %q: %w", segment.Value.Input, err)
 		}
-		return out, true, nil
+		return resolvedSegmentValue{value: out, present: true, fromInput: true}, nil
 	default:
-		return "", false, fmt.Errorf("missing value source")
+		return resolvedSegmentValue{}, fmt.Errorf("missing value source")
 	}
 }
 
@@ -162,7 +173,7 @@ func shouldOmitSegment(value string, segment Segment) bool {
 func scalarToString(value any) (string, error) {
 	switch v := value.(type) {
 	case nil:
-		return "", nil
+		return "", fmt.Errorf("must not be null")
 	case string:
 		return v, nil
 	case bool:
@@ -176,6 +187,30 @@ func scalarToString(value any) (string, error) {
 		return out, nil
 	}
 	return "", fmt.Errorf("unsupported non-scalar value %T", value)
+}
+
+func escapeDerivedKeyInputValue(value string) string {
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		if isDerivedKeyUnreservedByte(b) {
+			out.WriteByte(b)
+			continue
+		}
+		out.WriteByte('%')
+		out.WriteByte(upperHex[b>>4])
+		out.WriteByte(upperHex[b&0x0f])
+	}
+	return out.String()
+}
+
+const upperHex = "0123456789ABCDEF"
+
+func isDerivedKeyUnreservedByte(b byte) bool {
+	return b >= 'A' && b <= 'Z' ||
+		b >= 'a' && b <= 'z' ||
+		b >= '0' && b <= '9' ||
+		b == '-' || b == '.' || b == '_' || b == '~'
 }
 
 func integerScalarToString(value any) (string, bool) {

--- a/scripts/check-npm-audit-allowlist.mjs
+++ b/scripts/check-npm-audit-allowlist.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 
 const [reportPath, allowlistPath, projectPathArg, visiblePolicyPath] = process.argv.slice(2);
+const acceptVisibleFindings = process.env.NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS === 'true';
 
 if (!reportPath || !allowlistPath || !projectPathArg) {
   console.error(
@@ -45,6 +46,22 @@ function requirePolicyString(entry, index, field) {
   return value.trim();
 }
 
+function requirePolicyDate(entry, index, field) {
+  const value = requirePolicyString(entry, index, field);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    policyError(`findings[${index}].${field} must be YYYY-MM-DD`);
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || value !== parsed.toISOString().slice(0, 10)) {
+    policyError(`findings[${index}].${field} must be a valid calendar date`);
+  }
+  return value;
+}
+
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10);
+}
+
 function loadVisiblePolicy(policyPath) {
   if (!policyPath || !fs.existsSync(policyPath)) {
     return new Map();
@@ -75,6 +92,14 @@ function loadVisiblePolicy(policyPath) {
     const visibility = requirePolicyString(entry, index, 'visibility');
     if (visibility !== 'visible') {
       policyError(`findings[${index}].visibility must be "visible"`);
+    }
+    requirePolicyString(entry, index, 'status');
+    requirePolicyDate(entry, index, 'reviewed_on');
+    const expiresOn = requirePolicyDate(entry, index, 'expires_on');
+    requirePolicyString(entry, index, 'remove_when');
+    requirePolicyString(entry, index, 'justification');
+    if (expiresOn < todayUtc()) {
+      policyError(`findings[${index}].expires_on ${expiresOn} is expired`);
     }
 
     const id = findingId(
@@ -210,9 +235,17 @@ if (allowlistedFindings.length > 0) {
 }
 
 if (visibleMissing.length > 0) {
-  console.log(`npm-audit: ${visibleMissing.length} visible unallowlisted finding(s) in ${projectPath}`);
-  console.log('npm-audit: visible findings remain in SEC-2 evidence and are not supply-chain allowlist suppressions');
+  const method = acceptVisibleFindings ? 'accepted' : 'not accepted';
+  const stream = acceptVisibleFindings ? console.log : console.error;
+  stream(`npm-audit: ${visibleMissing.length} visible unallowlisted finding(s) in ${projectPath} (${method})`);
+  stream('npm-audit: visible findings remain in SEC-2 evidence and are not supply-chain allowlist suppressions');
   for (const finding of visibleMissing) {
-    console.log(`  ${finding}`);
+    stream(`  ${finding}`);
+  }
+  if (!acceptVisibleFindings) {
+    console.error(
+      'npm-audit: set NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS=true only in reviewed CI contexts that intentionally accept visible, expiring findings',
+    );
+    process.exit(1);
   }
 }

--- a/scripts/release-please-cli/package-lock.json
+++ b/scripts/release-please-cli/package-lock.json
@@ -1,0 +1,1978 @@
+{
+  "name": "@theory-cloud/tabletheory-release-please-cli",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@theory-cloud/tabletheory-release-please-cli",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "release-please": "17.3.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@conventional-commits/parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@conventional-commits/parser/-/parser-0.4.1.tgz",
+      "integrity": "sha512-H2ZmUVt6q+KBccXfMBhbBF14NlANeqHTXL4qCL6QGbMzrc4HDXyzWuxPxPNbz71f/5UkR5DrycP5VO9u7crahg==",
+      "license": "ISC",
+      "dependencies": {
+        "unist-util-visit": "^2.0.3",
+        "unist-util-visit-parents": "^3.1.1"
+      }
+    },
+    "node_modules/@google-automations/git-file-utils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@google-automations/git-file-utils/-/git-file-utils-3.0.1.tgz",
+      "integrity": "sha512-vlQZ8DlBcippB5zTY0M5Rib8tKT4yQ7oBKbs6kcWAzp70oyillKinXLZwlIgNTmfzzZx1J6cez3M0EmrpXFRcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@octokit/rest": "^20.1.1",
+        "@octokit/types": "^13.0.0",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
+      "license": "ISC"
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.4.4-cjs.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+      "integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+      "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.3.2-cjs.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+      "integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.8.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+      "integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "license": "MIT"
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/npm-package-arg": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/npm-package-arg/-/npm-package-arg-6.1.4.tgz",
+      "integrity": "sha512-vDgdbMy2QXHnAruzlv68pUtXCjmqUk3WrBAsRboRovsOmxbfn/WiYCjmecyKjGztnMps5dWp4Uq2prp+Ilo17Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.11.tgz",
+      "integrity": "sha512-sbtvk8wDN+JvEdabmZExoW/HNr1cB7D/j4LT08rMiuikfA7m/JNJg7ATQcgzs34zHnoScDkY0ZRSl29Fkmk36g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "license": "MIT"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "license": "MIT"
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/code-suggester": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/code-suggester/-/code-suggester-5.0.1.tgz",
+      "integrity": "sha512-8qJiiSCfkbPNWvjEFzdG1UW3axL+Bs0ldV1/TdlBKmF9I/a/WooSQZQCi9M44HoXbVTQesn/IQr6+nIWNnVIWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@octokit/rest": "^20.1.2",
+        "@types/yargs": "^16.0.0",
+        "async-retry": "^1.3.1",
+        "diff": "^8.0.3",
+        "glob": "^7.1.6",
+        "parse-diff": "^0.11.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "code-suggester": "build/src/bin/code-suggester.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/code-suggester/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/code-suggester/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
+      "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.1.tgz",
+      "integrity": "sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-filter": "^3.0.0",
+        "dateformat": "^3.0.3",
+        "handlebars": "^4.7.7",
+        "json-stringify-safe": "^5.0.1",
+        "meow": "^8.1.2",
+        "semver": "^7.0.0",
+        "split": "^1.0.1"
+      },
+      "bin": {
+        "conventional-changelog-writer": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
+      "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "license": "MIT",
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
+    },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-diff": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.11.1.tgz",
+      "integrity": "sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-github-repo-url": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+      "integrity": "sha512-bSWyzBKqcSL4RrncTpGsEKoJ7H8a4L3++ifTAbTFeMHyq2wRV+42DGmQcHIrJIvdcacjIOxEuKH/w4tthF17gg==",
+      "license": "MIT"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "license": "ISC"
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/release-please": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-17.3.0.tgz",
+      "integrity": "sha512-dB7HsFUpAvU1Wj9RGCINUz8Zi2qQDZiGbDEEVnJ7baNfJmk5XdYhuUFL6RcuDGjReGhp1gzY8Tc2g7vHlM4zpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@conventional-commits/parser": "^0.4.1",
+        "@google-automations/git-file-utils": "^3.0.0",
+        "@iarna/toml": "^3.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/rest": "^20.1.1",
+        "@types/npm-package-arg": "^6.1.0",
+        "@xmldom/xmldom": "^0.8.4",
+        "chalk": "^4.0.0",
+        "code-suggester": "^5.0.0",
+        "conventional-changelog-conventionalcommits": "^6.0.0",
+        "conventional-changelog-writer": "^6.0.0",
+        "conventional-commits-filter": "^3.0.0",
+        "detect-indent": "^6.1.0",
+        "diff": "^8.0.3",
+        "figures": "^3.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "js-yaml": "^4.0.0",
+        "jsonpath-plus": "^10.0.0",
+        "node-html-parser": "^6.0.0",
+        "parse-github-repo-url": "^1.4.1",
+        "semver": "^7.5.3",
+        "type-fest": "^3.0.0",
+        "typescript": "^4.6.4",
+        "unist-util-visit": "^2.0.3",
+        "unist-util-visit-parents": "^3.1.1",
+        "xpath": "^0.0.34",
+        "yaml": "^2.2.2",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "release-please": "build/src/bin/release-please.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xpath": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/scripts/release-please-cli/package.json
+++ b/scripts/release-please-cli/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@theory-cloud/tabletheory-release-please-cli",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Locked release-please CLI toolchain for TableTheory release-pr workflow.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "dependencies": {
+    "release-please": "17.3.0"
+  }
+}

--- a/scripts/test-npm-audit-policy.sh
+++ b/scripts/test-npm-audit-policy.sh
@@ -43,11 +43,24 @@ cat >"${tmpdir}/visible.json" <<'JSON'
       "advisory": "GHSA-jxxr-4gwj-5jf2",
       "node": "node_modules/aws-cdk-lib/node_modules/brace-expansion",
       "visibility": "visible",
-      "status": "upstream-bundled-pending-fix"
+      "status": "upstream-bundled-pending-fix",
+      "reviewed_on": "2026-06-18",
+      "expires_on": "2099-12-31",
+      "remove_when": "Remove when aws-cdk-lib bundles a fixed brace-expansion.",
+      "justification": "Synthetic test fixture for visible npm audit policy handling."
     }
   ]
 }
 JSON
+
+cp "${tmpdir}/visible.json" "${tmpdir}/expired-visible.json"
+node - "${tmpdir}/expired-visible.json" <<'NODE'
+const fs = require('node:fs');
+const path = process.argv[2];
+const policy = JSON.parse(fs.readFileSync(path, 'utf8'));
+policy.findings[0].expires_on = '2000-01-01';
+fs.writeFileSync(path, `${JSON.stringify(policy, null, 2)}\n`);
+NODE
 
 : >"${tmpdir}/empty-allowlist.txt"
 
@@ -85,9 +98,17 @@ expect_failure_contains() {
   fi
 }
 
-expect_success_contains \
+expect_failure_contains \
   "visible unallowlisted finding(s)" \
   node "${checker}" "${tmpdir}/audit.json" "${tmpdir}/empty-allowlist.txt" examples/cdk-multilang "${tmpdir}/visible.json"
+
+expect_success_contains \
+  "visible unallowlisted finding(s)" \
+  env NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS=true node "${checker}" "${tmpdir}/audit.json" "${tmpdir}/empty-allowlist.txt" examples/cdk-multilang "${tmpdir}/visible.json"
+
+expect_failure_contains \
+  "expires_on 2000-01-01 is expired" \
+  env NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS=true node "${checker}" "${tmpdir}/audit.json" "${tmpdir}/empty-allowlist.txt" examples/cdk-multilang "${tmpdir}/expired-visible.json"
 
 expect_failure_contains \
   "unallowlisted finding(s)" \
@@ -129,6 +150,7 @@ const hasVisibleBracePolicy = policy.findings?.some(
     finding.advisory === 'GHSA-jxxr-4gwj-5jf2' &&
     finding.node === 'node_modules/aws-cdk-lib/node_modules/brace-expansion' &&
     finding.visibility === 'visible' &&
+    typeof finding.expires_on === 'string' &&
     finding.current_upstream_version === '2.257.0' &&
     finding.current_bundled_version === '5.0.5',
 );

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+checker="scripts/verify-release-lane-provenance.sh"
+base_sha="1111111111111111111111111111111111111111"
+head_sha="2222222222222222222222222222222222222222"
+repo="theory-cloud/TableTheory"
+
+expect_success_contains() {
+  local expected="$1"
+  shift
+
+  local output
+  if ! output="$("$@" 2>&1)"; then
+    printf '%s\n' "${output}"
+    echo "release-hygiene-policy-test: expected command to succeed"
+    exit 1
+  fi
+  if ! grep -Fq "${expected}" <<<"${output}"; then
+    printf '%s\n' "${output}"
+    echo "release-hygiene-policy-test: expected output to contain: ${expected}"
+    exit 1
+  fi
+}
+
+expect_failure_contains() {
+  local expected="$1"
+  shift
+
+  local output
+  if output="$("$@" 2>&1)"; then
+    printf '%s\n' "${output}"
+    echo "release-hygiene-policy-test: expected command to fail"
+    exit 1
+  fi
+  if ! grep -Fq "${expected}" <<<"${output}"; then
+    printf '%s\n' "${output}"
+    echo "release-hygiene-policy-test: expected failure output to contain: ${expected}"
+    exit 1
+  fi
+}
+
+common_args=(
+  --repo "${repo}"
+  --base premain
+  --head staging
+  --base-repo "${repo}"
+  --head-repo "${repo}"
+  --base-sha "${base_sha}"
+  --head-sha "${head_sha}"
+  --title "Promote staging to premain"
+  --ref "refs/heads/premain=${base_sha}"
+  --ref "refs/heads/staging=${head_sha}"
+)
+
+expect_success_contains \
+  "release-lane-provenance: PASS" \
+  bash "${checker}" "${common_args[@]}"
+
+expect_failure_contains \
+  "same-repository" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head staging \
+    --base-repo "${repo}" \
+    --head-repo "attacker/TableTheory" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "Promote staging to premain" \
+    --ref "refs/heads/premain=${base_sha}" \
+    --ref "refs/heads/staging=${head_sha}"
+
+expect_failure_contains \
+  "head SHA" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head staging \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "3333333333333333333333333333333333333333" \
+    --title "Promote staging to premain" \
+    --ref "refs/heads/premain=${base_sha}" \
+    --ref "refs/heads/staging=${head_sha}"
+
+expect_failure_contains \
+  "numbered RC version" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head release-please--branches--premain \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "chore(premain): release 1.9.3-rc" \
+    --ref "refs/heads/premain=${base_sha}" \
+    --ref "refs/heads/release-please--branches--premain=${head_sha}"
+
+expect_failure_contains \
+  "X.Y.Z-rc.N" \
+  bash scripts/verify-promotion-release-driver.sh \
+    --base premain \
+    --head staging \
+    --title "Promote staging to premain" \
+    --body "Release-As: 1.9.3-rc" \
+    --dry-run
+
+expect_success_contains \
+  "RC Release-As 1.9.3-rc.1" \
+  bash scripts/verify-promotion-release-driver.sh \
+    --base premain \
+    --head staging \
+    --title "Promote staging to premain" \
+    --body "Release-As: 1.9.3-rc.1" \
+    --dry-run
+
+expect_failure_contains \
+  "numbered RC-shaped X.Y.Z-rc.N" \
+  bash scripts/verify-prerelease-pr-postcondition.sh \
+    --expected-version 1.9.3-rc \
+    --dry-run
+
+expect_failure_contains \
+  "non-numbered-RC tag_name" \
+  bash scripts/verify-release-created-postcondition.sh \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-rc \
+    --commit-message "Merge pull request from release-please--branches--premain"
+
+expect_success_contains \
+  "published v1.9.3-rc.1" \
+  bash scripts/verify-release-created-postcondition.sh \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-rc.1 \
+    --commit-message "chore(premain): release 1.9.3-rc.1"
+
+if grep -Fq "secrets.RELEASE_PLEASE_TOKEN" .github/workflows/release-hygiene.yml; then
+  echo "release-hygiene-policy-test: release hygiene must not expose release-please token"
+  exit 1
+fi
+
+grep -Fq "persist-credentials: false" .github/workflows/release-hygiene.yml || {
+  echo "release-hygiene-policy-test: release hygiene checkouts must disable persisted credentials"
+  exit 1
+}
+
+grep -Fq "../trusted-release/scripts/verify-promotion-release-driver.sh" .github/workflows/release-hygiene.yml || {
+  echo "release-hygiene-policy-test: promotion driver must run from trusted checkout"
+  exit 1
+}
+
+echo "release-hygiene-policy-test: PASS"

--- a/scripts/test-release-pr-tool-policy.sh
+++ b/scripts/test-release-pr-tool-policy.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/release-pr.yml"
+tool_dir="scripts/release-please-cli"
+
+if grep -Fq "npx --yes" "${workflow}"; then
+  echo "release-pr-tool-policy-test: release-pr workflow must not run npx --yes in the privileged release token path"
+  exit 1
+fi
+
+grep -Fq "npm ci --prefix ${tool_dir} --ignore-scripts" "${workflow}" || {
+  echo "release-pr-tool-policy-test: release-pr workflow must install the locked CLI with npm ci --ignore-scripts"
+  exit 1
+}
+
+grep -Fq "${tool_dir}/node_modules/.bin/release-please" "${workflow}" || {
+  echo "release-pr-tool-policy-test: release-pr workflow must execute the locked local release-please binary"
+  exit 1
+}
+
+node <<'NODE'
+const fs = require('node:fs');
+
+const pkg = JSON.parse(fs.readFileSync('scripts/release-please-cli/package.json', 'utf8'));
+if (pkg.private !== true) {
+  throw new Error('release-please CLI tool package must remain private');
+}
+if (pkg.dependencies?.['release-please'] !== '17.3.0') {
+  throw new Error(`release-please dependency must be exactly 17.3.0, got ${pkg.dependencies?.['release-please'] ?? 'missing'}`);
+}
+
+const lock = JSON.parse(fs.readFileSync('scripts/release-please-cli/package-lock.json', 'utf8'));
+const rootVersion = lock.packages?.['']?.dependencies?.['release-please'];
+if (rootVersion !== '17.3.0') {
+  throw new Error(`lockfile root dependency must be release-please 17.3.0, got ${rootVersion ?? 'missing'}`);
+}
+
+const locked = lock.packages?.['node_modules/release-please'];
+if (locked?.version !== '17.3.0') {
+  throw new Error(`lockfile must pin node_modules/release-please to 17.3.0, got ${locked?.version ?? 'missing'}`);
+}
+if (typeof locked.integrity !== 'string' || !locked.integrity.startsWith('sha512-')) {
+  throw new Error('lockfile release-please entry must include sha512 integrity');
+}
+NODE
+
+echo "release-pr-tool-policy-test: PASS"

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -58,8 +58,11 @@ required_files=(
   "scripts/sync-post-stable-release-baselines.sh"
   "scripts/verify-main-release-pr-postcondition.sh"
   "scripts/verify-prerelease-pr-postcondition.sh"
+  "scripts/verify-release-lane-provenance.sh"
   "scripts/verify-promotion-release-driver.sh"
   "scripts/verify-release-created-postcondition.sh"
+  "scripts/release-please-cli/package.json"
+  "scripts/release-please-cli/package-lock.json"
   "scripts/watch-release-cycle.sh"
 )
 
@@ -111,13 +114,21 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
   h=".github/workflows/release-hygiene.yml"
   require_fixed 'branches: ["premain", "main"]' "${h}" \
     "release-hygiene must target premain and main PRs"
-  require_fixed 'head == "staging"' "${h}" \
-    "release-hygiene must validate staging -> premain promotion PRs"
-  require_fixed 'head == "premain"' "${h}" \
-    "release-hygiene must validate premain -> main promotion PRs"
-  require_fixed 'release-please--branches--premain' "${h}" \
+  require_fixed "trusted-release/scripts/verify-release-lane-provenance.sh" "${h}" \
+    "release-hygiene must verify release-lane same-repository provenance from trusted scripts"
+  require_fixed "github.event.pull_request.base.sha" "${h}" \
+    "release-hygiene must check out trusted release scripts from the PR base SHA"
+  require_fixed "github.event.pull_request.head.sha" "${h}" \
+    "release-hygiene must check out the PR head by exact SHA after provenance verification"
+  require_fixed "persist-credentials: false" "${h}" \
+    "release-hygiene checkouts must not persist GitHub credentials"
+  require_fixed 'HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}' "${h}" \
+    "release-hygiene must pass PR head repository metadata to provenance guard"
+  require_fixed 'BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}' "${h}" \
+    "release-hygiene must pass PR base repository metadata to provenance guard"
+  require_fixed 'release-please--branches--premain' "scripts/verify-release-lane-provenance.sh" \
     "release-hygiene must explicitly gate generated premain release-please PRs"
-  require_fixed 'release-please--branches--main' "${h}" \
+  require_fixed 'release-please--branches--main' "scripts/verify-release-lane-provenance.sh" \
     "release-hygiene must explicitly gate generated main release-please PRs"
   require_fixed "scripts/verify-release-cycle-state.sh" "${h}" \
     "release-hygiene must verify release-cycle state"
@@ -131,6 +142,11 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
     "release-hygiene must run the release driver guard on staging -> premain PRs"
   require_fixed "github.base_ref == 'main' && github.head_ref == 'premain'" "${h}" \
     "release-hygiene must run the release driver guard on premain -> main PRs"
+  require_fixed "../trusted-release/scripts/verify-promotion-release-driver.sh" "${h}" \
+    "release-hygiene must run the promotion driver from trusted checkout"
+  if grep -Fq "secrets.RELEASE_PLEASE_TOKEN" "${h}"; then
+    fail "release-hygiene must not expose release-please token"
+  fi
   if grep -Eq 'make rubric|verify-rubric' "${h}"; then
     fail "release-hygiene must not run the full rubric"
   fi
@@ -295,8 +311,12 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
     "release-pr paths-ignore must include .release-please-manifest.premain.json and compute RC baseline"
   require_fixed 'RELEASE_PLEASE_CLI_VERSION: "17.3.0"' "${rp}" \
     "release-pr workflow must pin release-please CLI to v17.3.0"
-  require_fixed 'npx --yes "release-please@${RELEASE_PLEASE_CLI_VERSION}"' "${rp}" \
-    "release-pr workflow must invoke the pinned release-please CLI"
+  require_fixed "npm ci --prefix scripts/release-please-cli --ignore-scripts" "${rp}" \
+    "release-pr workflow must install release-please from a lockfile without lifecycle scripts"
+  require_fixed "scripts/release-please-cli/node_modules/.bin/release-please" "${rp}" \
+    "release-pr workflow must invoke the locked release-please CLI"
+  require_fixed "persist-credentials: false" "${rp}" \
+    "release-pr checkout must not persist GitHub credentials"
   require_fixed "release-pr" "${rp}" \
     "release-pr workflow must run the release-pr CLI command"
   require_regex '--target-branch[[:space:]]+main' "${rp}" \
@@ -363,6 +383,18 @@ if [[ -f "scripts/verify-promotion-release-driver.sh" ]]; then
     "promotion release driver guard must name release-please no-op as a failed precondition"
   require_fixed "do not use tags, resets, manual manifests" "${driver}" \
     "promotion release driver guard must instruct normal PR-flow remediation"
+  require_fixed "X.Y.Z-rc.N" "${driver}" \
+    "promotion release driver guard must require numbered RC syntax"
+fi
+
+if [[ -f "scripts/verify-release-lane-provenance.sh" ]]; then
+  provenance="scripts/verify-release-lane-provenance.sh"
+  require_fixed "release-lane PRs must be same-repository" "${provenance}" \
+    "release-lane provenance guard must reject fork/name-spoofed PRs"
+  require_fixed "does not match same-repository refs/heads" "${provenance}" \
+    "release-lane provenance guard must verify exact branch SHAs"
+  require_fixed "-rc\\.[0-9]+" "${provenance}" \
+    "release-lane provenance guard must require numbered RC release-please PR titles"
 fi
 
 if [[ -f "scripts/verify-prerelease-pr-postcondition.sh" ]]; then
@@ -371,10 +403,32 @@ if [[ -f "scripts/verify-prerelease-pr-postcondition.sh" ]]; then
     "prerelease PR postcondition must require the generated premain head branch"
   require_fixed "rc_title_re = re.compile" "${prerelease_postcondition}" \
     "prerelease PR postcondition must require RC-shaped release titles"
-  require_fixed "-rc(?:\\.\\d+)?" "${prerelease_postcondition}" \
-    "prerelease PR postcondition must accept bare and numbered RC version syntax"
+  require_fixed "-rc\\.\\d+" "${prerelease_postcondition}" \
+    "prerelease PR postcondition must require numbered RC version syntax"
   require_fixed ".release-please-manifest.premain.json" "${prerelease_postcondition}" \
     "prerelease PR postcondition must require the prerelease manifest"
+fi
+
+if [[ -f "scripts/release-please-cli/package-lock.json" ]]; then
+  if ! python3 - <<'PY'
+import json
+from pathlib import Path
+
+package = json.loads(Path("scripts/release-please-cli/package.json").read_text(encoding="utf-8"))
+lock = json.loads(Path("scripts/release-please-cli/package-lock.json").read_text(encoding="utf-8"))
+release_please = lock.get("packages", {}).get("node_modules/release-please", {})
+if package.get("private") is not True:
+    raise SystemExit(1)
+if package.get("dependencies", {}).get("release-please") != "17.3.0":
+    raise SystemExit(1)
+if release_please.get("version") != "17.3.0":
+    raise SystemExit(1)
+if not str(release_please.get("integrity", "")).startswith("sha512-"):
+    raise SystemExit(1)
+PY
+  then
+    fail "release-please CLI lockfile must pin release-please 17.3.0 with sha512 integrity"
+  fi
 fi
 
 if [[ -f "scripts/sync-post-stable-release-baselines.sh" ]]; then

--- a/scripts/verify-prerelease-pr-postcondition.sh
+++ b/scripts/verify-prerelease-pr-postcondition.sh
@@ -12,7 +12,7 @@ Options:
   --repo OWNER/REPO         GitHub repository. Defaults to $GITHUB_REPOSITORY or theory-cloud/TableTheory.
   --base BRANCH            Release PR base branch. Defaults to premain.
   --head BRANCH            Release-please PR head branch. Defaults to release-please--branches--premain.
-  --expected-version VER   Optional RC version the PR must advertise, e.g. 1.9.4-rc or 1.9.4-rc.1.
+  --expected-version VER   Optional numbered RC version the PR must advertise, e.g. 1.9.4-rc.1.
   --dry-run                Read-only local validation mode; no GitHub state is changed.
   -h, --help               Show this help.
 
@@ -82,8 +82,8 @@ fail() {
   exit 1
 }
 
-if [[ -n "${expected_version}" && ! "${expected_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]; then
-  fail "expected version must be RC-shaped X.Y.Z-rc or X.Y.Z-rc.N, got ${expected_version}"
+if [[ -n "${expected_version}" && ! "${expected_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+  fail "expected version must be numbered RC-shaped X.Y.Z-rc.N, got ${expected_version}"
 fi
 
 if ! command -v gh >/dev/null 2>&1; then
@@ -120,7 +120,7 @@ from pathlib import Path
 
 path, expected_version, base, head = sys.argv[1:5]
 prs = json.loads(Path(path).read_text(encoding="utf-8"))
-rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
+rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc\.\d+$")
 
 
 def fail(message: str) -> None:
@@ -140,7 +140,7 @@ if bad:
     details = ", ".join(
         f"#{pr.get('number')} {pr.get('title')} {pr.get('url')}" for pr in bad
     )
-    fail(f"generated premain release-please PR is not RC-shaped: {details}")
+    fail(f"generated premain release-please PR is not numbered RC-shaped: {details}")
 
 if expected_version:
     expected = expected_version[1:] if expected_version.startswith("v") else expected_version
@@ -181,7 +181,7 @@ from pathlib import Path
 
 path, base, head = sys.argv[1:4]
 pr = json.loads(Path(path).read_text(encoding="utf-8"))
-rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
+rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc\.\d+$")
 required_paths = {
     ".release-please-manifest.premain.json",
     "py/src/theorydb_py/version.json",
@@ -203,7 +203,7 @@ if pr.get("headRefName") != head:
     fail(f"PR #{pr.get('number')} head {pr.get('headRefName')!r} != {head!r}")
 
 if not rc_title_re.fullmatch(pr.get("title", "")):
-    fail(f"PR #{pr.get('number')} title is not RC-shaped: {pr.get('title')!r}")
+    fail(f"PR #{pr.get('number')} title is not numbered RC-shaped: {pr.get('title')!r}")
 
 paths = {entry.get("path", "") for entry in pr.get("files", [])}
 missing = sorted(required_paths - paths)

--- a/scripts/verify-promotion-release-driver.sh
+++ b/scripts/verify-promotion-release-driver.sh
@@ -181,9 +181,9 @@ metadata_path = Path(sys.argv[1])
 base = os.environ["BASE_REF"]
 head = os.environ["HEAD_REF"]
 
-rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc(?:\.\d+)?$")
+rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc\.\d+$")
 stable_version_re = re.compile(r"^v?\d+\.\d+\.\d+$")
-rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
+rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc\.\d+$")
 stable_title_re = re.compile(r"^chore\(main\): release \d+\.\d+\.\d+$")
 any_rc_re = re.compile(r"\d+\.\d+\.\d+-rc(?:[.\-\w]*)?")
 
@@ -292,7 +292,7 @@ def pending_stable_promotion_version() -> str:
     if not isinstance(first_version, str) or not rc_version_re.match(first_version):
         fail(
             "premain -> main promotion must carry an RC pending stable "
-            f"promotion state; {first_label} is {first_version!r}"
+            f"promotion state with numbered -rc.N syntax; {first_label} is {first_version!r}"
         )
     for label, version in pending_files.items():
         if version != first_version:
@@ -313,7 +313,7 @@ aggregate = "\n\n".join([title, body, *commits])
 
 if base == "premain" and head == "release-please--branches--premain":
     if not rc_title_re.fullmatch(title):
-        fail(f"generated premain release-please PR must be RC-shaped, got {title!r}")
+        fail(f"generated premain release-please PR must be numbered RC-shaped, got {title!r}")
     print(f"promotion-release-driver: PASS (generated premain RC PR {title!r})")
     raise SystemExit(0)
 
@@ -331,7 +331,7 @@ if base == "premain":
     if invalid:
         fail(
             "staging -> premain Release-As footers must be RC-shaped "
-            f"X.Y.Z-rc or X.Y.Z-rc.N, got {', '.join(invalid)}"
+            f"X.Y.Z-rc.N, got {', '.join(invalid)}"
         )
     if versions:
         print(

--- a/scripts/verify-release-created-postcondition.sh
+++ b/scripts/verify-release-created-postcondition.sh
@@ -121,7 +121,7 @@ if [[ "${kind}" == "prerelease" ]]; then
   if [[ "${commit_message}" == *"release-please--branches--premain"* ]]; then
     generated=1
   fi
-  if [[ "${commit_message}" =~ chore\(premain\):[[:space:]]release[[:space:]]([0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?) ]]; then
+  if [[ "${commit_message}" =~ chore\(premain\):[[:space:]]release[[:space:]]([0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+) ]]; then
     generated=1
     release_version="${BASH_REMATCH[1]}"
   fi
@@ -142,8 +142,8 @@ if [[ "${kind}" == "prerelease" ]]; then
     fail "generated RC release PR merge created a release without tag_name"
   fi
 
-  if [[ ! "${tag_name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]; then
-    fail "generated RC release PR merge produced non-RC tag_name ${tag_name}"
+  if [[ ! "${tag_name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+    fail "generated RC release PR merge produced non-numbered-RC tag_name ${tag_name}"
   fi
 
   if [[ -n "${release_version}" ]]; then

--- a/scripts/verify-release-lane-provenance.sh
+++ b/scripts/verify-release-lane-provenance.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only provenance guard for release-lane pull requests. It rejects branch
+# name spoofing by requiring the PR head/base repositories to be this repository
+# and the PR head/base SHAs to match the live same-repository branch refs.
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/verify-release-lane-provenance.sh [options]
+
+Options:
+  --repo OWNER/REPO        Expected repository. Defaults to $GITHUB_REPOSITORY or theory-cloud/TableTheory.
+  --base BRANCH           PR base branch. Defaults to $GITHUB_BASE_REF.
+  --head BRANCH           PR head branch. Defaults to $GITHUB_HEAD_REF.
+  --base-repo OWNER/REPO  PR base repository full name.
+  --head-repo OWNER/REPO  PR head repository full name.
+  --base-sha SHA          PR base SHA.
+  --head-sha SHA          PR head SHA.
+  --title TITLE           PR title for generated release-please PR validation.
+  --ref REF=SHA           Test-only ref override, e.g. refs/heads/staging=<sha>.
+  -h, --help              Show this help.
+
+This command uses read-only GitHub ref lookups unless --ref supplies all needed
+refs. It never creates, updates, merges, tags, publishes, uploads, deletes, or
+pushes anything.
+USAGE
+}
+
+repo="${GITHUB_REPOSITORY:-theory-cloud/TableTheory}"
+base="${GITHUB_BASE_REF:-}"
+head="${GITHUB_HEAD_REF:-}"
+base_repo="${BASE_REPOSITORY:-}"
+head_repo="${HEAD_REPOSITORY:-}"
+base_sha="${BASE_SHA:-}"
+head_sha="${HEAD_SHA:-}"
+title="${PR_TITLE:-}"
+ref_overrides=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--repo requires a value)" >&2; exit 2; }
+      repo="$2"
+      shift 2
+      ;;
+    --base)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--base requires a value)" >&2; exit 2; }
+      base="$2"
+      shift 2
+      ;;
+    --head)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--head requires a value)" >&2; exit 2; }
+      head="$2"
+      shift 2
+      ;;
+    --base-repo)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--base-repo requires a value)" >&2; exit 2; }
+      base_repo="$2"
+      shift 2
+      ;;
+    --head-repo)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--head-repo requires a value)" >&2; exit 2; }
+      head_repo="$2"
+      shift 2
+      ;;
+    --base-sha)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--base-sha requires a value)" >&2; exit 2; }
+      base_sha="$2"
+      shift 2
+      ;;
+    --head-sha)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--head-sha requires a value)" >&2; exit 2; }
+      head_sha="$2"
+      shift 2
+      ;;
+    --title)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--title requires a value)" >&2; exit 2; }
+      title="$2"
+      shift 2
+      ;;
+    --ref)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--ref requires a value)" >&2; exit 2; }
+      ref_overrides+=("$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "release-lane-provenance: FAIL (unknown argument: $1)" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+fail() {
+  echo "release-lane-provenance: FAIL ($1)" >&2
+  exit 1
+}
+
+require_sha() {
+  local label="$1"
+  local value="$2"
+
+  if [[ ! "${value}" =~ ^[0-9a-f]{40}$ ]]; then
+    fail "${label} must be a 40-character lowercase git SHA, got ${value:-<empty>}"
+  fi
+}
+
+ref_override_sha() {
+  local ref="$1"
+  local entry
+
+  for entry in "${ref_overrides[@]}"; do
+    if [[ "${entry}" == "${ref}="* ]]; then
+      printf '%s\n' "${entry#*=}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+lookup_ref_sha() {
+  local branch="$1"
+  local ref="refs/heads/${branch}"
+  local override
+
+  if override="$(ref_override_sha "${ref}")"; then
+    printf '%s\n' "${override}"
+    return 0
+  fi
+
+  command -v gh >/dev/null 2>&1 || fail "gh is required for ${ref} lookup"
+  gh auth status >/dev/null 2>&1 || fail "gh authentication is required for ${ref} lookup"
+
+  local refs_json
+  refs_json="$(gh api "repos/${repo}/git/matching-refs/heads/${branch}")"
+  python3 -c '
+import json
+import sys
+
+want = sys.argv[1]
+refs = json.load(sys.stdin)
+for entry in refs:
+    if entry.get("ref") == want:
+        print(entry.get("object", {}).get("sha", ""))
+        raise SystemExit(0)
+raise SystemExit(1)
+' "${ref}" <<<"${refs_json}"
+}
+
+if [[ -z "${repo}" || -z "${base}" || -z "${head}" ]]; then
+  fail "missing repository or PR base/head branch"
+fi
+if [[ -z "${base_repo}" || -z "${head_repo}" ]]; then
+  fail "missing PR base/head repository metadata"
+fi
+if [[ "${base_repo}" != "${repo}" || "${head_repo}" != "${repo}" ]]; then
+  fail "release-lane PRs must be same-repository (${head_repo} -> ${base_repo}, expected ${repo})"
+fi
+
+require_sha "base SHA" "${base_sha}"
+require_sha "head SHA" "${head_sha}"
+
+if [[ "${base}" == "premain" ]]; then
+  if [[ "${head}" == "staging" ]]; then
+    :
+  elif [[ "${head}" == "release-please--branches--premain" ]]; then
+    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]] ||
+      fail "premain release-please PR must advertise a numbered RC version, got ${title@Q}"
+  else
+    fail "premain PR head must be staging or release-please--branches--premain, got ${head@Q}"
+  fi
+elif [[ "${base}" == "main" ]]; then
+  if [[ "${title}" =~ [0-9]+\.[0-9]+\.[0-9]+-rc([.\-[:alnum:]])* ]]; then
+    fail "main PR must not advertise an RC version, got ${title@Q}"
+  fi
+  if [[ "${head}" == "premain" ]]; then
+    :
+  elif [[ "${head}" == "release-please--branches--main" ]]; then
+    [[ "${title}" =~ ^chore\(main\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+      fail "main release-please PR must advertise a stable version, got ${title@Q}"
+  else
+    fail "main PR head must be premain or release-please--branches--main, got ${head@Q}"
+  fi
+else
+  fail "unsupported release-hygiene base branch ${base@Q}"
+fi
+
+expected_base_sha="$(lookup_ref_sha "${base}")" || fail "could not resolve refs/heads/${base}"
+expected_head_sha="$(lookup_ref_sha "${head}")" || fail "could not resolve refs/heads/${head}"
+
+require_sha "resolved base ref SHA" "${expected_base_sha}"
+require_sha "resolved head ref SHA" "${expected_head_sha}"
+
+if [[ "${base_sha}" != "${expected_base_sha}" ]]; then
+  fail "base SHA ${base_sha} does not match same-repository refs/heads/${base} ${expected_base_sha}"
+fi
+if [[ "${head_sha}" != "${expected_head_sha}" ]]; then
+  fail "head SHA ${head_sha} does not match same-repository refs/heads/${head} ${expected_head_sha}"
+fi
+
+echo "release-lane-provenance: PASS (${head}@${head_sha} -> ${base}@${base_sha})"

--- a/ts/src/key-contract.ts
+++ b/ts/src/key-contract.ts
@@ -2,12 +2,7 @@ import YAML from 'yaml';
 
 import { TheorydbError } from './errors.js';
 
-export type KeyContractInputValue =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined;
+export type KeyContractInputValue = string | number | boolean;
 export type KeyContractTransform = 'trim' | 'wildcard_empty';
 
 export interface DerivedKeyContract {
@@ -391,13 +386,17 @@ function evaluateSegment(
   }
 
   let value = resolved.value;
+  let generatedWildcard = false;
   for (const transform of segment.transforms ?? []) {
     switch (transform) {
       case 'trim':
         value = trimContractWhitespace(value);
         break;
       case 'wildcard_empty':
-        if (value === '') value = '*';
+        if (value === '') {
+          value = '*';
+          generatedWildcard = true;
+        }
         break;
       default:
         throw new TheorydbError(
@@ -405,6 +404,10 @@ function evaluateSegment(
           `Derived key ${keyName} segment ${label}: unsupported transform ${String(transform)}`,
         );
     }
+  }
+
+  if (resolved.fromInput && !generatedWildcard) {
+    value = escapeDerivedKeyInputValue(value);
   }
 
   if (value === '' && segment.default !== undefined) {
@@ -425,17 +428,17 @@ function resolveSegmentValue(
   input: Record<string, KeyContractInputValue>,
   keyName: string,
   label: string,
-): { value: string; present: boolean } {
+): { value: string; present: boolean; fromInput: boolean } {
   if (segment.literal !== undefined)
-    return { value: segment.literal, present: true };
+    return { value: segment.literal, present: true, fromInput: false };
   if (segment.value?.literal !== undefined) {
-    return { value: segment.value.literal, present: true };
+    return { value: segment.value.literal, present: true, fromInput: false };
   }
   const inputName = segment.value?.input;
   if (inputName) {
     if (!Object.prototype.hasOwnProperty.call(input, inputName)) {
       if (segment.default !== undefined || segment.optional) {
-        return { value: '', present: false };
+        return { value: '', present: false, fromInput: false };
       }
       throw new TheorydbError(
         'ErrInvalidModel',
@@ -445,6 +448,7 @@ function resolveSegmentValue(
     return {
       value: scalarToString(input[inputName], inputName),
       present: true,
+      fromInput: true,
     };
   }
   throw new TheorydbError(
@@ -469,7 +473,12 @@ function shouldOmitSegment(value: string, segment: DerivedKeySegment): boolean {
 }
 
 function scalarToString(value: unknown, inputName: string): string {
-  if (value === null || value === undefined) return '';
+  if (value === null || value === undefined) {
+    throw new TheorydbError(
+      'ErrInvalidModel',
+      `Derived key input ${inputName} must not be null or undefined`,
+    );
+  }
   switch (typeof value) {
     case 'string':
       return value;
@@ -489,6 +498,30 @@ function scalarToString(value: unknown, inputName: string): string {
         `Derived key input ${inputName} must be a scalar`,
       );
   }
+}
+
+function escapeDerivedKeyInputValue(value: string): string {
+  let out = '';
+  for (const byte of Buffer.from(value, 'utf8')) {
+    if (isDerivedKeyUnreservedByte(byte)) {
+      out += String.fromCharCode(byte);
+      continue;
+    }
+    out += `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+  }
+  return out;
+}
+
+function isDerivedKeyUnreservedByte(byte: number): boolean {
+  return (
+    (byte >= 0x41 && byte <= 0x5a) ||
+    (byte >= 0x61 && byte <= 0x7a) ||
+    (byte >= 0x30 && byte <= 0x39) ||
+    byte === 0x2d ||
+    byte === 0x2e ||
+    byte === 0x5f ||
+    byte === 0x7e
+  );
 }
 
 const contractTrimWhitespaceCodePoints = new Set<number>([

--- a/ts/test/unit/key-contract.test.ts
+++ b/ts/test/unit/key-contract.test.ts
@@ -97,6 +97,65 @@ const fixture = parseDerivedKeyContract(readFileSync(fixturePath, 'utf8'));
 
 {
   const key: DerivedKeyDefinition = {
+    name: 'Composite',
+    join: '|',
+    inputs: [
+      { name: 'tenant', type: 'string' },
+      { name: 'resource', type: 'string' },
+    ],
+    segments: [
+      {
+        name: 'tenant',
+        prefix: 'tenant=',
+        value: { input: 'tenant' },
+        transforms: ['trim'],
+      },
+      {
+        name: 'resource',
+        prefix: 'resource=',
+        value: { input: 'resource' },
+        transforms: ['trim'],
+      },
+    ],
+  };
+
+  const left = evaluateDerivedKeyDefinition(key, {
+    tenant: 'a|resource=b',
+    resource: 'c',
+  });
+  const right = evaluateDerivedKeyDefinition(key, {
+    tenant: 'a',
+    resource: 'b|resource=c',
+  });
+  assert.equal(left, 'tenant=a%7Cresource%3Db|resource=c');
+  assert.equal(right, 'tenant=a|resource=b%7Cresource%3Dc');
+  assert.notEqual(left, right);
+  assert.equal(
+    evaluateDerivedKeyDefinition(key, {
+      tenant: 'user/*',
+      resource: 'café',
+    }),
+    'tenant=user%2F%2A|resource=caf%C3%A9',
+  );
+}
+
+{
+  assert.throws(
+    () =>
+      evaluateDerivedKey(fixture, 'ScalarNumberKey', {
+        value: null as never,
+      }),
+    (err) => {
+      assert.ok(err instanceof TheorydbError);
+      assert.equal(err.code, 'ErrInvalidModel');
+      assert.match(err.message, /must not be null or undefined/);
+      return true;
+    },
+  );
+}
+
+{
+  const key: DerivedKeyDefinition = {
     name: 'NumberKey',
     join: '',
     inputs: [{ name: 'value', type: 'number' }],


### PR DESCRIPTION
## Summary

- Hardens release hygiene PR checks with same-repository branch provenance and exact SHA verification before PR checkout, and runs tokened release-driver checks from trusted base-branch scripts with checkout credentials disabled.
- Replaces privileged `release-pr.yml` ad hoc `npx` release-please execution with a repo-owned locked CLI package installed via `npm ci --ignore-scripts`.
- Makes derived key inputs injective across Go and TypeScript by percent-escaping user-supplied key parts and rejecting explicit null/undefined input.
- Makes visible npm audit findings fail closed unless explicitly accepted via `NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS=true`, with expiring visible policy metadata.
- Aligns release verifier scripts on numbered RC syntax (`-rc.N`).

References THE-2101

## Validation

- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/test-release-pr-tool-policy.sh`
- `bash scripts/test-npm-audit-policy.sh`
- `go test ./pkg/keycontract`
- `npm --prefix ts run format:check`
- `npm --prefix ts run typecheck`
- `npm --prefix ts run test:unit -- --test-name-pattern key-contract`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/verify-generated-ts-key-contract.sh`
- `npm --prefix scripts/release-please-cli audit --package-lock-only --audit-level=low`
- `bash scripts/verify-release-cycle-state.sh`
- `bash scripts/verify-branch-version-sync.sh` (SKIP on factory branch)
- `PATH=/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin:/home/aron/go/bin make test-unit`

## Notes

- No release, tag, or package publish performed.
- `make test-unit` needed a sanitized PATH because the ambient PATH contains earlier non-executable `go` directory entries that make `/bin/sh` report `go: Permission denied` during Makefile expansion.
