### PR TITLE
fix: bootstrap premain release hygiene provenance

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -35,15 +35,92 @@ jobs:
         run: |
           set -euo pipefail
 
-          bash trusted-release/scripts/verify-release-lane-provenance.sh \
-            --repo "${GITHUB_REPOSITORY}" \
-            --base "${BASE_REF}" \
-            --head "${HEAD_REF}" \
-            --base-repo "${BASE_REPOSITORY}" \
-            --head-repo "${HEAD_REPOSITORY}" \
-            --base-sha "${BASE_SHA}" \
-            --head-sha "${HEAD_SHA}" \
-            --title "${PR_TITLE}"
+          trusted_provenance_checker="trusted-release/scripts/verify-release-lane-provenance.sh"
+
+          if [[ -f "${trusted_provenance_checker}" ]]; then
+            bash "${trusted_provenance_checker}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base "${BASE_REF}" \
+              --head "${HEAD_REF}" \
+              --base-repo "${BASE_REPOSITORY}" \
+              --head-repo "${HEAD_REPOSITORY}" \
+              --base-sha "${BASE_SHA}" \
+              --head-sha "${HEAD_SHA}" \
+              --title "${PR_TITLE}"
+            exit 0
+          fi
+
+          # Bootstrap compatibility for the first staging -> premain promotion
+          # where premain predates the trusted provenance helper. Keep this
+          # inline, read-only, and narrower than the trusted helper.
+          if [[ "${BASE_REF}" != "premain" || "${HEAD_REF}" != "staging" ]]; then
+            echo "release-lane-provenance: FAIL (trusted provenance checker missing on base checkout; bootstrap fallback only supports staging -> premain)" >&2
+            exit 1
+          fi
+
+          echo "release-lane-provenance: trusted checker missing on base checkout; using one-time staging -> premain bootstrap verifier"
+
+          fail() {
+            echo "release-lane-provenance: FAIL ($1)" >&2
+            exit 1
+          }
+
+          require_sha() {
+            local label="$1"
+            local value="$2"
+
+            if [[ ! "${value}" =~ ^[0-9a-f]{40}$ ]]; then
+              fail "${label} must be a 40-character lowercase git SHA, got ${value:-<empty>}"
+            fi
+          }
+
+          lookup_ref_sha() {
+            local branch="$1"
+            local ref="refs/heads/${branch}"
+
+            command -v gh >/dev/null 2>&1 || fail "gh is required for ${ref} lookup"
+            gh auth status >/dev/null 2>&1 || fail "gh authentication is required for ${ref} lookup"
+
+            local refs_json
+            refs_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/${branch}")"
+            python3 -c '
+          import json
+          import sys
+
+          want = sys.argv[1]
+          refs = json.load(sys.stdin)
+          for entry in refs:
+              if entry.get("ref") == want:
+                  print(entry.get("object", {}).get("sha", ""))
+                  raise SystemExit(0)
+          raise SystemExit(1)
+          ' "${ref}" <<<"${refs_json}"
+          }
+
+          if [[ -z "${GITHUB_REPOSITORY}" || -z "${BASE_REPOSITORY}" || -z "${HEAD_REPOSITORY}" ]]; then
+            fail "missing repository metadata"
+          fi
+          if [[ "${BASE_REPOSITORY}" != "${GITHUB_REPOSITORY}" || "${HEAD_REPOSITORY}" != "${GITHUB_REPOSITORY}" ]]; then
+            fail "release-lane PRs must be same-repository (${HEAD_REPOSITORY} -> ${BASE_REPOSITORY}, expected ${GITHUB_REPOSITORY})"
+          fi
+
+          require_sha "base SHA" "${BASE_SHA}"
+          require_sha "head SHA" "${HEAD_SHA}"
+
+          expected_base_sha="$(lookup_ref_sha "${BASE_REF}")" || fail "could not resolve refs/heads/${BASE_REF}"
+          expected_head_sha="$(lookup_ref_sha "${HEAD_REF}")" || fail "could not resolve refs/heads/${HEAD_REF}"
+
+          require_sha "resolved base ref SHA" "${expected_base_sha}"
+          require_sha "resolved head ref SHA" "${expected_head_sha}"
+
+          if [[ "${BASE_SHA}" != "${expected_base_sha}" ]]; then
+            fail "base SHA ${BASE_SHA} does not match same-repository refs/heads/${BASE_REF} ${expected_base_sha}"
+          fi
+          if [[ "${HEAD_SHA}" != "${expected_head_sha}" ]]; then
+            fail "head SHA ${HEAD_SHA} does not match same-repository refs/heads/${HEAD_REF} ${expected_head_sha}"
+          fi
+
+          echo "release-lane-provenance: PASS (${HEAD_REF}@${HEAD_SHA} -> ${BASE_REF}@${BASE_SHA})"
 
       - name: Checkout pull request head after provenance verification
         if: github.event_name == 'pull_request'

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -156,4 +156,126 @@ grep -Fq "../trusted-release/scripts/verify-promotion-release-driver.sh" .github
   exit 1
 }
 
+grep -Fq "bootstrap fallback only supports staging -> premain" .github/workflows/release-hygiene.yml || {
+  echo "release-hygiene-policy-test: premain bootstrap fallback must be tightly scoped"
+  exit 1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+python3 - <<'PY' >"${tmpdir}/provenance-step.sh"
+from pathlib import Path
+
+workflow = Path(".github/workflows/release-hygiene.yml").read_text(encoding="utf-8").splitlines()
+in_step = False
+for index, line in enumerate(workflow):
+    if "name: Verify release-lane same-repository provenance" in line:
+        in_step = True
+        continue
+    if in_step and line.strip() == "run: |":
+        run_indent = len(line) - len(line.lstrip())
+        block_indent = None
+        for block_line in workflow[index + 1:]:
+            if block_line.strip() and len(block_line) - len(block_line.lstrip()) <= run_indent:
+                raise SystemExit(0)
+            if not block_line.strip():
+                print()
+                continue
+            if block_indent is None:
+                block_indent = len(block_line) - len(block_line.lstrip())
+            print(block_line[block_indent:])
+        raise SystemExit(0)
+raise SystemExit("could not extract release-lane provenance workflow step")
+PY
+
+mkdir -p "${tmpdir}/bin" "${tmpdir}/trusted-release/scripts"
+cat >"${tmpdir}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" == "auth" && "$2" == "status" ]]; then
+  exit 0
+fi
+
+if [[ "$1" == "api" ]]; then
+  case "$2" in
+    repos/theory-cloud/TableTheory/git/matching-refs/heads/premain)
+      printf '%s\n' '[{"ref":"refs/heads/premain","object":{"sha":"1111111111111111111111111111111111111111"}}]'
+      exit 0
+      ;;
+    repos/theory-cloud/TableTheory/git/matching-refs/heads/staging)
+      printf '%s\n' '[{"ref":"refs/heads/staging","object":{"sha":"2222222222222222222222222222222222222222"}}]'
+      exit 0
+      ;;
+  esac
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+SH
+chmod +x "${tmpdir}/bin/gh"
+
+workflow_env=(
+  env
+  "PATH=${tmpdir}/bin:${PATH}"
+  GITHUB_REPOSITORY="${repo}"
+  BASE_REF=premain
+  HEAD_REF=staging
+  BASE_REPOSITORY="${repo}"
+  HEAD_REPOSITORY="${repo}"
+  BASE_SHA="${base_sha}"
+  HEAD_SHA="${head_sha}"
+  PR_TITLE="Promote staging to premain"
+)
+
+expect_success_contains \
+  "one-time staging -> premain bootstrap verifier" \
+  bash -c 'cd "$1" && shift && "$@"' _ "${tmpdir}" "${workflow_env[@]}" bash "${tmpdir}/provenance-step.sh"
+
+expect_failure_contains \
+  "same-repository" \
+  bash -c 'cd "$1" && shift && "$@"' _ "${tmpdir}" \
+    env \
+      "PATH=${tmpdir}/bin:${PATH}" \
+      GITHUB_REPOSITORY="${repo}" \
+      BASE_REF=premain \
+      HEAD_REF=staging \
+      BASE_REPOSITORY="${repo}" \
+      HEAD_REPOSITORY="attacker/TableTheory" \
+      BASE_SHA="${base_sha}" \
+      HEAD_SHA="${head_sha}" \
+      PR_TITLE="Promote staging to premain" \
+      bash "${tmpdir}/provenance-step.sh"
+
+expect_failure_contains \
+  "head SHA" \
+  bash -c 'cd "$1" && shift && "$@"' _ "${tmpdir}" \
+    env \
+      "PATH=${tmpdir}/bin:${PATH}" \
+      GITHUB_REPOSITORY="${repo}" \
+      BASE_REF=premain \
+      HEAD_REF=staging \
+      BASE_REPOSITORY="${repo}" \
+      HEAD_REPOSITORY="${repo}" \
+      BASE_SHA="${base_sha}" \
+      HEAD_SHA="3333333333333333333333333333333333333333" \
+      PR_TITLE="Promote staging to premain" \
+      bash "${tmpdir}/provenance-step.sh"
+
+expect_failure_contains \
+  "bootstrap fallback only supports staging -> premain" \
+  bash -c 'cd "$1" && shift && "$@"' _ "${tmpdir}" \
+    env \
+      "PATH=${tmpdir}/bin:${PATH}" \
+      GITHUB_REPOSITORY="${repo}" \
+      BASE_REF=premain \
+      HEAD_REF=release-please--branches--premain \
+      BASE_REPOSITORY="${repo}" \
+      HEAD_REPOSITORY="${repo}" \
+      BASE_SHA="${base_sha}" \
+      HEAD_SHA="${head_sha}" \
+      PR_TITLE="chore(premain): release 1.9.3-rc.1" \
+      bash "${tmpdir}/provenance-step.sh"
+
 echo "release-hygiene-policy-test: PASS"


### PR DESCRIPTION
## Summary
- Add a fail-closed bootstrap fallback to `Release Hygiene` when the trusted `premain` checkout lacks `scripts/verify-release-lane-provenance.sh`.
- Scope the fallback to exactly same-repository `staging -> premain` and verify live `premain`/`staging` ref SHAs before checking out PR code.
- Extend `scripts/test-release-hygiene-policy.sh` to execute the embedded workflow block with a missing trusted helper and cover success, fork/name spoof rejection, SHA mismatch rejection, and non-bootstrap lane rejection.

## Root Cause
PR #282 runs the new trusted-script workflow from `staging`, but its `premain` base SHA predates `scripts/verify-release-lane-provenance.sh`. The job failed before provenance verification with `No such file or directory`.

## Validation
- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/verify-release-lane-provenance.sh --repo theory-cloud/TableTheory --base premain --head staging --base-repo theory-cloud/TableTheory --head-repo theory-cloud/TableTheory --base-sha 1111111111111111111111111111111111111111 --head-sha 2222222222222222222222222222222222222222 --title "Promote staging to premain" --ref refs/heads/premain=1111111111111111111111111111111111111111 --ref refs/heads/staging=2222222222222222222222222222222222222222`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `git diff --check origin/staging...HEAD`
- Targeted local workflow reproduction: extracted the actual `Verify release-lane same-repository provenance` run block, simulated a `trusted-release` checkout missing the helper, and verified live `origin/premain`/`origin/staging` SHAs via read-only `gh api`.

## Non-Goals
No release, tag, package publish, cloud/account mutation, direct push to `staging`/`premain`/`main`, or release-lane order change.
