### PR TITLE
fix(security): clear TableTheory example dependency alerts

### DIFF
--- a/examples/cdk-multilang/lambdas/python/requirements.txt
+++ b/examples/cdk-multilang/lambdas/python/requirements.txt
@@ -1,2 +1,2 @@
-cryptography==46.0.7
+cryptography==49.0.0
 PyYAML==6.0.3

--- a/examples/cdk-multilang/package-lock.json
+++ b/examples/cdk-multilang/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-dynamodb": "3.1053.0",
         "@aws-sdk/client-kms": "3.1053.0",
         "@aws-sdk/client-s3": "3.1053.0",
-        "aws-cdk-lib": "2.257.0",
+        "aws-cdk-lib": "2.260.0",
         "constructs": "10.6.0"
       },
       "devDependencies": {
@@ -25,21 +25,21 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.273",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.27.0.tgz",
-      "integrity": "sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==",
+      "version": "54.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.4.0.tgz",
+      "integrity": "sha512-v04S/TkvlL+/SWw5BoBYy0XaCQCNdcgELmN2ACJqEbGxzCEzzFcTQNE8WH/6j0c+uKkOXXsdoCG0/3Z73BqzDQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -47,7 +47,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -62,7 +62,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.0",
+      "version": "7.8.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1308,9 +1308,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.257.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
-      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
+      "version": "2.260.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.260.0.tgz",
+      "integrity": "sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -1327,19 +1327,19 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.4",
-        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "table": "^6.9.0",
         "yaml": "1.10.3"
       },
@@ -1351,7 +1351,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.4",
+      "version": "2.2.5",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1362,18 +1362,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.8.0",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -1382,7 +1371,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1435,7 +1424,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1495,7 +1484,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1534,7 +1523,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1607,7 +1596,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {

--- a/examples/cdk-multilang/package.json
+++ b/examples/cdk-multilang/package.json
@@ -9,15 +9,15 @@
   },
   "scripts": {
     "prep": "npm --prefix ../../ts ci && npm --prefix ../../ts run build",
-    "synth": "npm run prep && npx -y aws-cdk@2.1124.1 synth",
-    "deploy": "npm run prep && npx -y aws-cdk@2.1124.1 deploy --require-approval never",
+    "synth": "npm run prep && npx -y aws-cdk@2.1128.0 synth",
+    "deploy": "npm run prep && npx -y aws-cdk@2.1128.0 deploy --require-approval never",
     "test": "tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1053.0",
     "@aws-sdk/client-kms": "3.1053.0",
     "@aws-sdk/client-s3": "3.1053.0",
-    "aws-cdk-lib": "2.257.0",
+    "aws-cdk-lib": "2.260.0",
     "constructs": "10.6.0"
   },
   "devDependencies": {

--- a/gov-infra/planning/theorydb-visible-npm-audit-findings.json
+++ b/gov-infra/planning/theorydb-visible-npm-audit-findings.json
@@ -1,21 +1,5 @@
 {
   "$schema": "https://theory.cloud/tabletheory/schemas/visible-npm-audit-findings.schema.json",
   "purpose": "Findings listed here are intentionally visible in SEC-2 evidence and are not supply-chain allowlist suppressions.",
-  "findings": [
-    {
-      "project": "examples/cdk-multilang",
-      "package": "brace-expansion",
-      "advisory": "GHSA-jxxr-4gwj-5jf2",
-      "node": "node_modules/aws-cdk-lib/node_modules/brace-expansion",
-      "visibility": "visible",
-      "status": "upstream-bundled-pending-fix",
-      "reviewed_on": "2026-05-30",
-      "expires_on": "2026-07-30",
-      "current_upstream_package": "aws-cdk-lib",
-      "current_upstream_version": "2.257.0",
-      "current_bundled_version": "5.0.5",
-      "remove_when": "Remove this visible finding policy once aws-cdk-lib publishes a bundle with brace-expansion >= 5.0.6.",
-      "justification": "aws-cdk-lib@2.257.0 is still the latest npm package and bundles brace-expansion@5.0.5 through minimatch@10.2.5. npm audit fix reports that the bundled dependency cannot be fixed automatically and must be fixed by an aws-cdk-lib update."
-    }
-  ]
+  "findings": []
 }

--- a/scripts/test-npm-audit-policy.sh
+++ b/scripts/test-npm-audit-policy.sh
@@ -136,30 +136,39 @@ node <<'NODE'
 const fs = require('node:fs');
 
 const lock = JSON.parse(fs.readFileSync('examples/cdk-multilang/package-lock.json', 'utf8'));
+
+function versionAtLeast(actual, minimum) {
+  if (typeof actual !== 'string') return false;
+  const actualParts = actual.split('.').map((part) => Number(part));
+  const minimumParts = minimum.split('.').map((part) => Number(part));
+  if (actualParts.length !== 3 || minimumParts.length !== 3 || actualParts.some(Number.isNaN)) {
+    return false;
+  }
+  for (let i = 0; i < 3; i += 1) {
+    if (actualParts[i] > minimumParts[i]) return true;
+    if (actualParts[i] < minimumParts[i]) return false;
+  }
+  return true;
+}
+
 const cdkLib = lock.packages?.['node_modules/aws-cdk-lib'];
-if (cdkLib?.version !== '2.257.0') {
-  throw new Error(`expected aws-cdk-lib lock entry to remain 2.257.0 while the visible policy is active, got ${cdkLib?.version ?? 'missing'}`);
+if (!versionAtLeast(cdkLib?.version, '2.260.0')) {
+  throw new Error(`expected aws-cdk-lib lock entry to be at least 2.260.0, got ${cdkLib?.version ?? 'missing'}`);
 }
 
 const bundledBrace = lock.packages?.['node_modules/aws-cdk-lib/node_modules/brace-expansion'];
-if (bundledBrace?.version !== '5.0.5') {
-  throw new Error(`expected aws-cdk-lib bundled brace-expansion lock entry to remain 5.0.5, got ${bundledBrace?.version ?? 'missing'}`);
+if (!versionAtLeast(bundledBrace?.version, '5.0.6')) {
+  throw new Error(`expected aws-cdk-lib bundled brace-expansion lock entry to be at least 5.0.6, got ${bundledBrace?.version ?? 'missing'}`);
 }
 
 const policy = JSON.parse(fs.readFileSync('gov-infra/planning/theorydb-visible-npm-audit-findings.json', 'utf8'));
 const hasVisibleBracePolicy = policy.findings?.some(
   (finding) =>
-    finding.project === 'examples/cdk-multilang' &&
     finding.package === 'brace-expansion' &&
-    finding.advisory === 'GHSA-jxxr-4gwj-5jf2' &&
-    finding.node === 'node_modules/aws-cdk-lib/node_modules/brace-expansion' &&
-    finding.visibility === 'visible' &&
-    typeof finding.expires_on === 'string' &&
-    finding.current_upstream_version === '2.257.0' &&
-    finding.current_bundled_version === '5.0.5',
+    finding.node === 'node_modules/aws-cdk-lib/node_modules/brace-expansion'
 );
-if (!hasVisibleBracePolicy) {
-  throw new Error('expected visible THE-1757 brace-expansion policy for bundled version 5.0.5');
+if (hasVisibleBracePolicy) {
+  throw new Error('expected no visible brace-expansion policy after dependency update');
 }
 NODE
 


### PR DESCRIPTION
## Summary
- Bumps the CDK multilang example to `aws-cdk-lib@2.260.0`, which bundles `brace-expansion@5.0.6`.
- Pins the example CDK CLI scripts to existing `aws-cdk@2.1128.0` so `npm run synth` works with the patched library.
- Bumps the example Python Lambda requirement to `cryptography==49.0.0`.
- Removes the stale visible npm audit exception now that the example lockfile is patched.

## Impact
These changes are limited to example/development surfaces and gov-infra audit policy coverage. They do not change the published Go, TypeScript, or Python TableTheory runtime packages.

## Validation
- `git diff --check origin/staging...HEAD`
- Node lockfile proof: `examples/cdk-multilang/package-lock.json` has `node_modules/aws-cdk-lib/node_modules/brace-expansion=5.0.6`
- Python requirement proof: `examples/cdk-multilang/lambdas/python/requirements.txt` has `cryptography==49.0.0`
- `bash scripts/test-npm-audit-policy.sh`
- `bash scripts/sec-npm-audit.sh`
- `bash scripts/sec-pip-audit.sh`
- `make rubric`

## Notes
`gov-infra/evidence/gov-rubric-report.json` was restored and is not included because the successful rubric run changed only the generated timestamp; the terminal validation output records the pass without adding timestamp-only churn.
