### PR TITLE
chore(release): bootstrap promotion hygiene verifier

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -31,6 +31,9 @@ jobs:
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_STATE: ${{ github.event.pull_request.state }}
+          PR_MERGED: ${{ github.event.pull_request.merged || false }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -21,8 +21,43 @@ jobs:
           path: trusted-release
           persist-credentials: false
 
+      - name: Verify release-hygiene bootstrap scope
+        if: github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'fix/release-hygiene-main-bootstrap-') && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t changed_files < <(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --jq '.[].filename'
+          )
+
+          if [[ "${#changed_files[@]}" -eq 0 ]]; then
+            echo "release-hygiene-bootstrap: FAIL (bootstrap PR has no changed files)" >&2
+            exit 1
+          fi
+
+          for changed_file in "${changed_files[@]}"; do
+            case "${changed_file}" in
+              .github/workflows/release-hygiene.yml|\
+              scripts/verify-release-lane-provenance.sh|\
+              scripts/verify-promotion-release-driver.sh|\
+              scripts/test-release-hygiene-policy.sh|\
+              scripts/verify-branch-release-supply-chain.sh)
+                ;;
+              *)
+                echo "release-hygiene-bootstrap: FAIL (unexpected bootstrap file ${changed_file})" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          echo "release-hygiene-bootstrap: PASS (${#changed_files[@]} file(s))"
+
       - name: Verify release-lane same-repository provenance
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !(github.base_ref == 'main' && startsWith(github.head_ref, 'fix/release-hygiene-main-bootstrap-') && github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GH_TOKEN: ${{ github.token }}
           BASE_REF: ${{ github.base_ref }}

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -288,4 +288,19 @@ grep -Fq "../trusted-release/scripts/verify-promotion-release-driver.sh" "${repo
   exit 1
 }
 
+grep -Fq "Verify release-hygiene bootstrap scope" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: main bootstrap PRs must have a scoped hygiene guard"
+  exit 1
+}
+
+grep -Fq "fix/release-hygiene-main-bootstrap-" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: main bootstrap guard must be branch-scoped"
+  exit 1
+}
+
+grep -Fq "pulls/\${PR_NUMBER}/files" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: main bootstrap guard must inspect PR changed files"
+  exit 1
+}
+
 echo "release-hygiene-policy-test: PASS"

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-checker="scripts/verify-release-lane-provenance.sh"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+checker="${repo_root}/scripts/verify-release-lane-provenance.sh"
 base_sha="1111111111111111111111111111111111111111"
 head_sha="2222222222222222222222222222222222222222"
+advanced_base_sha="3333333333333333333333333333333333333333"
 repo="theory-cloud/TableTheory"
+tmpdirs=()
+
+cleanup() {
+  local tmpdir
+  for tmpdir in "${tmpdirs[@]}"; do
+    rm -rf "${tmpdir}"
+  done
+}
+trap cleanup EXIT
 
 expect_success_contains() {
   local expected="$1"
@@ -86,6 +97,20 @@ expect_failure_contains \
     --ref "refs/heads/staging=${head_sha}"
 
 expect_failure_contains \
+  "base SHA" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head staging \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "Promote staging to premain" \
+    --ref "refs/heads/premain=${advanced_base_sha}" \
+    --ref "refs/heads/staging=${head_sha}"
+
+expect_failure_contains \
   "numbered RC version" \
   bash "${checker}" \
     --repo "${repo}" \
@@ -99,9 +124,41 @@ expect_failure_contains \
     --ref "refs/heads/premain=${base_sha}" \
     --ref "refs/heads/release-please--branches--premain=${head_sha}"
 
+expect_success_contains \
+  "stale merged premain release-please RC PR" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head release-please--branches--premain \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --pr-state MERGED \
+    --pr-merged true \
+    --title "chore(premain): release 1.10.1-rc.1" \
+    --ref "refs/heads/premain=${advanced_base_sha}" \
+    --ref "refs/heads/release-please--branches--premain=${head_sha}"
+
+expect_failure_contains \
+  "base SHA" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head release-please--branches--premain \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --pr-state OPEN \
+    --pr-merged false \
+    --title "chore(premain): release 1.10.1-rc.1" \
+    --ref "refs/heads/premain=${advanced_base_sha}" \
+    --ref "refs/heads/release-please--branches--premain=${head_sha}"
+
 expect_failure_contains \
   "X.Y.Z-rc.N" \
-  bash scripts/verify-promotion-release-driver.sh \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
     --base premain \
     --head staging \
     --title "Promote staging to premain" \
@@ -110,22 +167,97 @@ expect_failure_contains \
 
 expect_success_contains \
   "RC Release-As 1.9.3-rc.1" \
-  bash scripts/verify-promotion-release-driver.sh \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
     --base premain \
     --head staging \
     --title "Promote staging to premain" \
     --body "Release-As: 1.9.3-rc.1" \
     --dry-run
 
+pending_fixture="$(mktemp -d)"
+tmpdirs+=("${pending_fixture}")
+mkdir -p "${pending_fixture}/ts" "${pending_fixture}/py/src/theorydb_py"
+cat >"${pending_fixture}/.release-please-manifest.json" <<'JSON'
+{".":"1.10.0"}
+JSON
+cat >"${pending_fixture}/.release-please-manifest.premain.json" <<'JSON'
+{".":"1.10.1-rc.1"}
+JSON
+cat >"${pending_fixture}/ts/package.json" <<'JSON'
+{"version":"1.10.1-rc.1"}
+JSON
+cat >"${pending_fixture}/ts/package-lock.json" <<'JSON'
+{"version":"1.10.1-rc.1","packages":{"":{"version":"1.10.1-rc.1"}}}
+JSON
+cat >"${pending_fixture}/py/src/theorydb_py/version.json" <<'JSON'
+{"version":"1.10.1-rc.1"}
+JSON
+
+run_in_pending_fixture() (
+  cd "${pending_fixture}"
+  "$@"
+)
+
+expect_success_contains \
+  "premain -> main pending stable promotion 1.10.1-rc.1 -> 1.10.1" \
+  run_in_pending_fixture \
+    bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+      --base main \
+      --head premain \
+      --title "Promote premain to main" \
+      --body "Release-As: 1.10.1" \
+      --commit-message $'fix(security): recover release cycle\n\nRelease-As: 1.10.1-rc.1' \
+      --dry-run
+
+expect_failure_contains \
+  "premain -> main Release-As footers must be stable X.Y.Z" \
+  run_in_pending_fixture \
+    bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+      --base main \
+      --head premain \
+      --title "Promote premain to main" \
+      --body "Release-As: 1.10.1-rc.1" \
+      --dry-run
+
+expect_failure_contains \
+  "premain -> main PR title must not be RC-shaped" \
+  run_in_pending_fixture \
+    bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+      --base main \
+      --head premain \
+      --title "Promote 1.10.1-rc.1 to main" \
+      --body "Release-As: 1.10.1" \
+      --dry-run
+
+expect_failure_contains \
+  "pending RC base 1.10.1" \
+  run_in_pending_fixture \
+    bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+      --base main \
+      --head premain \
+      --title "Promote premain to main" \
+      --body "Release-As: 1.10.2" \
+      --dry-run
+
+expect_failure_contains \
+  "requires a stable Release-As footer" \
+  run_in_pending_fixture \
+    bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+      --base main \
+      --head premain \
+      --title "Promote premain to main" \
+      --body "" \
+      --dry-run
+
 expect_failure_contains \
   "numbered RC-shaped X.Y.Z-rc.N" \
-  bash scripts/verify-prerelease-pr-postcondition.sh \
+  bash "${repo_root}/scripts/verify-prerelease-pr-postcondition.sh" \
     --expected-version 1.9.3-rc \
     --dry-run
 
 expect_failure_contains \
   "non-numbered-RC tag_name" \
-  bash scripts/verify-release-created-postcondition.sh \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
     --kind prerelease \
     --branch premain \
     --release-created true \
@@ -134,24 +266,24 @@ expect_failure_contains \
 
 expect_success_contains \
   "published v1.9.3-rc.1" \
-  bash scripts/verify-release-created-postcondition.sh \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
     --kind prerelease \
     --branch premain \
     --release-created true \
     --tag-name v1.9.3-rc.1 \
     --commit-message "chore(premain): release 1.9.3-rc.1"
 
-if grep -Fq "secrets.RELEASE_PLEASE_TOKEN" .github/workflows/release-hygiene.yml; then
+if grep -Fq "secrets.RELEASE_PLEASE_TOKEN" "${repo_root}/.github/workflows/release-hygiene.yml"; then
   echo "release-hygiene-policy-test: release hygiene must not expose release-please token"
   exit 1
 fi
 
-grep -Fq "persist-credentials: false" .github/workflows/release-hygiene.yml || {
+grep -Fq "persist-credentials: false" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene checkouts must disable persisted credentials"
   exit 1
 }
 
-grep -Fq "../trusted-release/scripts/verify-promotion-release-driver.sh" .github/workflows/release-hygiene.yml || {
+grep -Fq "../trusted-release/scripts/verify-promotion-release-driver.sh" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: promotion driver must run from trusted checkout"
   exit 1
 }

--- a/scripts/verify-promotion-release-driver.sh
+++ b/scripts/verify-promotion-release-driver.sh
@@ -16,6 +16,7 @@ Options:
   --pr NUMBER           Pull request number for read-only GitHub metadata lookup.
   --title TITLE         PR title fallback when --pr/gh is unavailable.
   --body BODY           PR body fallback when --pr/gh is unavailable.
+  --commit-message MSG  Local/test fallback commit message; repeatable.
   --dry-run             Print that local read-only mode is being used.
   -h, --help            Show this help.
 
@@ -31,6 +32,7 @@ pr_number="${PR_NUMBER:-}"
 title="${PR_TITLE:-}"
 body="${PR_BODY:-}"
 dry_run=0
+commit_messages=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -80,6 +82,14 @@ while [[ $# -gt 0 ]]; do
         exit 2
       fi
       body="$2"
+      shift 2
+      ;;
+    --commit-message)
+      if [[ $# -lt 2 ]]; then
+        echo "promotion-release-driver: FAIL (--commit-message requires a value)" >&2
+        exit 2
+      fi
+      commit_messages+=("$2")
       shift 2
       ;;
     --dry-run)
@@ -143,15 +153,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-python3 - "${fallback_file}" "${title}" "${body}" <<'PY'
+python3 - "${fallback_file}" "${title}" "${body}" "${commit_messages[@]}" <<'PY'
 import json
 import subprocess
 import sys
 from pathlib import Path
 
-path, title, body = sys.argv[1:4]
-commits = []
-if not title.strip() and not body.strip():
+path, title, body, *commits = sys.argv[1:]
+if not commits and not title.strip() and not body.strip():
     try:
         out = subprocess.check_output(
             ["git", "log", "--format=%s%n%b%x1e", "--max-count=50"],
@@ -310,6 +319,7 @@ def pending_stable_promotion_version() -> str:
 
 title, body, commits = read_metadata()
 aggregate = "\n\n".join([title, body, *commits])
+pr_text = "\n\n".join([title, body])
 
 if base == "premain" and head == "release-please--branches--premain":
     if not rc_title_re.fullmatch(title):
@@ -357,13 +367,15 @@ if base == "main":
         fail(f"main promotion PR head must be premain, got {head!r}")
     if any_rc_re.search(title):
         fail(f"premain -> main PR title must not be RC-shaped, got {title!r}")
-    versions = release_as_versions(aggregate)
+    versions = release_as_versions(pr_text)
     rc_versions = [version for version in versions if rc_version_re.match(version)]
     if rc_versions:
         fail(
             "premain -> main Release-As footers must be stable X.Y.Z, "
             f"not RC-shaped ({', '.join(rc_versions)})"
         )
+    if any_rc_re.search(pr_text):
+        fail("premain -> main PR title/body must not be RC-shaped")
     invalid = [
         version
         for version in versions
@@ -373,6 +385,11 @@ if base == "main":
         fail(f"invalid Release-As footer(s): {', '.join(invalid)}")
     pending_rc = pending_stable_promotion_version()
     pending_stable = pending_rc.split("-", 1)[0]
+    if not versions:
+        fail(
+            "premain -> main promotion requires a stable Release-As footer "
+            f"matching the pending RC base {pending_stable}"
+        )
     mismatched = [version for version in versions if version != pending_stable]
     if mismatched:
         fail(

--- a/scripts/verify-release-lane-provenance.sh
+++ b/scripts/verify-release-lane-provenance.sh
@@ -17,6 +17,9 @@ Options:
   --head-repo OWNER/REPO  PR head repository full name.
   --base-sha SHA          PR base SHA.
   --head-sha SHA          PR head SHA.
+  --pr NUMBER             PR number for current lifecycle lookup.
+  --pr-state STATE        PR state from the event payload or test fixture.
+  --pr-merged BOOL        Whether the PR is known merged from the event payload or test fixture.
   --title TITLE           PR title for generated release-please PR validation.
   --ref REF=SHA           Test-only ref override, e.g. refs/heads/staging=<sha>.
   -h, --help              Show this help.
@@ -34,6 +37,9 @@ base_repo="${BASE_REPOSITORY:-}"
 head_repo="${HEAD_REPOSITORY:-}"
 base_sha="${BASE_SHA:-}"
 head_sha="${HEAD_SHA:-}"
+pr_number="${PR_NUMBER:-}"
+pr_state="${PR_STATE:-}"
+pr_merged="${PR_MERGED:-}"
 title="${PR_TITLE:-}"
 ref_overrides=()
 
@@ -72,6 +78,21 @@ while [[ $# -gt 0 ]]; do
     --head-sha)
       [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--head-sha requires a value)" >&2; exit 2; }
       head_sha="$2"
+      shift 2
+      ;;
+    --pr)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--pr requires a value)" >&2; exit 2; }
+      pr_number="$2"
+      shift 2
+      ;;
+    --pr-state)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--pr-state requires a value)" >&2; exit 2; }
+      pr_state="$2"
+      shift 2
+      ;;
+    --pr-merged)
+      [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--pr-merged requires a value)" >&2; exit 2; }
+      pr_merged="$2"
       shift 2
       ;;
     --title)
@@ -152,6 +173,67 @@ raise SystemExit(1)
 ' "${ref}" <<<"${refs_json}"
 }
 
+refresh_pr_lifecycle() {
+  if [[ -z "${pr_number}" ]]; then
+    return 0
+  fi
+  command -v gh >/dev/null 2>&1 || return 0
+  gh auth status >/dev/null 2>&1 || return 0
+
+  local pr_json
+  if ! pr_json="$(gh pr view "${pr_number}" --repo "${repo}" --json state,mergedAt,closed 2>/dev/null)"; then
+    return 0
+  fi
+
+  local parsed live_state live_merged
+  if ! parsed="$(python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+state = str(data.get("state") or "")
+merged_at = data.get("mergedAt")
+print(state, "true" if merged_at else "false")
+' <<<"${pr_json}")"; then
+    return 0
+  fi
+  read -r live_state live_merged <<<"${parsed}"
+  if [[ -n "${live_state}" ]]; then
+    pr_state="${live_state}"
+  fi
+  if [[ -n "${live_merged}" ]]; then
+    pr_merged="${live_merged}"
+  fi
+}
+
+pr_is_merged() {
+  local state="${pr_state,,}"
+  local merged="${pr_merged,,}"
+
+  [[ "${state}" == "merged" ]] || [[ "${merged}" == "true" ]]
+}
+
+is_premain_release_please_rc_pr() {
+  [[ "${base}" == "premain" ]] &&
+    [[ "${head}" == "release-please--branches--premain" ]] &&
+    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]
+}
+
+stale_merged_rc_pr_allowed=0
+allow_stale_merged_rc_pr() {
+  if [[ "${stale_merged_rc_pr_allowed}" -eq 1 ]]; then
+    return 0
+  fi
+  return 1
+}
+
+pass_stale_merged_rc_pr() {
+  local reason="$1"
+
+  echo "release-lane-provenance: PASS (stale merged premain release-please RC PR; ${reason})"
+  exit 0
+}
+
 if [[ -z "${repo}" || -z "${base}" || -z "${head}" ]]; then
   fail "missing repository or PR base/head branch"
 fi
@@ -190,16 +272,37 @@ else
   fail "unsupported release-hygiene base branch ${base@Q}"
 fi
 
-expected_base_sha="$(lookup_ref_sha "${base}")" || fail "could not resolve refs/heads/${base}"
-expected_head_sha="$(lookup_ref_sha "${head}")" || fail "could not resolve refs/heads/${head}"
+refresh_pr_lifecycle
+if is_premain_release_please_rc_pr && pr_is_merged; then
+  stale_merged_rc_pr_allowed=1
+fi
+
+expected_base_sha="$(lookup_ref_sha "${base}")" || {
+  if allow_stale_merged_rc_pr; then
+    pass_stale_merged_rc_pr "could not resolve live refs/heads/${base} after merge"
+  fi
+  fail "could not resolve refs/heads/${base}"
+}
+expected_head_sha="$(lookup_ref_sha "${head}")" || {
+  if allow_stale_merged_rc_pr; then
+    pass_stale_merged_rc_pr "could not resolve live refs/heads/${head} after merge"
+  fi
+  fail "could not resolve refs/heads/${head}"
+}
 
 require_sha "resolved base ref SHA" "${expected_base_sha}"
 require_sha "resolved head ref SHA" "${expected_head_sha}"
 
 if [[ "${base_sha}" != "${expected_base_sha}" ]]; then
+  if allow_stale_merged_rc_pr; then
+    pass_stale_merged_rc_pr "base ref advanced from ${base_sha} to ${expected_base_sha}"
+  fi
   fail "base SHA ${base_sha} does not match same-repository refs/heads/${base} ${expected_base_sha}"
 fi
 if [[ "${head_sha}" != "${expected_head_sha}" ]]; then
+  if allow_stale_merged_rc_pr; then
+    pass_stale_merged_rc_pr "head ref advanced from ${head_sha} to ${expected_head_sha}"
+  fi
   fail "head SHA ${head_sha} does not match same-repository refs/heads/${head} ${expected_head_sha}"
 fi
 


### PR DESCRIPTION
## Summary
- bootstrap the base-trusted Release Hygiene verifier/workflow on `main` so the next premain -> main stable promotion can use the fixed promotion guard
- carry the same release-hygiene verifier/workflow/test repair as the staging PR, without touching release state, manifests, package versions, changelog release sections, tags, releases, or assets
- add a narrow same-repository `fix/release-hygiene-main-bootstrap-*` workflow lane that file-scopes this non-release bootstrap PR while preserving strict provenance for active release-lane PRs

## Why this targets `main`
Release Hygiene executes trusted verifier scripts from the PR base SHA. A staging-only fix cannot repair the first premain -> main promotion because `main` would still provide the old verifier that rejects historical RC `Release-As` footers from premain commits.

## Validation on this branch
- `bash scripts/test-release-hygiene-policy.sh` — PASS
- `bash scripts/verify-release-cycle-state.sh` — PASS
- `bash scripts/verify-branch-release-supply-chain.sh` — PASS
- `bash scripts/verify-branch-version-sync.sh` — SKIP
- `bash scripts/watch-release-cycle.sh --strict` — PASS with WARN: no `--tag` supplied; skipped GitHub release asset check
- `make rubric` — FAIL on pre-existing `SEC-2` in the `main` baseline: `examples/cdk-multilang` has visible unallowlisted `brace-expansion` GHSA-jxxr-4gwj-5jf2 via `aws-cdk-lib/node_modules/brace-expansion`. This is outside the authorized bootstrap write scope; the same rubric passed on the staging carry-forward branch.

## Operator note
This is a non-release bootstrap PR. If merged, use a non-release squash title (for example `chore(release): bootstrap promotion hygiene verifier`) so this PR does not claim or cut a release.
