### PR TITLE
fix(release): allow cycle-state bootstrap repair

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -45,6 +45,7 @@ jobs:
               scripts/verify-release-lane-provenance.sh|\
               scripts/verify-promotion-release-driver.sh|\
               scripts/test-release-hygiene-policy.sh|\
+              scripts/verify-release-cycle-state.sh|\
               scripts/verify-branch-release-supply-chain.sh)
                 ;;
               *)

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -303,4 +303,10 @@ grep -Fq "pulls/\${PR_NUMBER}/files" "${repo_root}/.github/workflows/release-hyg
   exit 1
 }
 
+bootstrap_scope_section="$(sed -n '/Verify release-hygiene bootstrap scope/,/Verify release-lane same-repository provenance/p' "${repo_root}/.github/workflows/release-hygiene.yml")"
+grep -Fq "scripts/verify-release-cycle-state.sh" <<<"${bootstrap_scope_section}" || {
+  echo "release-hygiene-policy-test: main bootstrap guard must allow verify-release-cycle-state bootstrap repairs"
+  exit 1
+}
+
 echo "release-hygiene-policy-test: PASS"


### PR DESCRIPTION
## Summary
- expands the trusted main bootstrap allowlist for the release-hygiene bootstrap lane to include `scripts/verify-release-cycle-state.sh`
- adds a policy-test assertion so the scoped guard continues allowing that exact cycle-state repair file

## Why
PR #299 is blocked because the trusted main release-hygiene verifier validates the base checkout instead of the checked-out PR head. The actual target-root fix must touch `scripts/verify-release-cycle-state.sh`, which the current trusted main bootstrap guard does not yet allow. This PR is the narrow first-stage scope expansion only.

## Validation
- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/verify-release-cycle-state.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/verify-branch-version-sync.sh`
- `bash scripts/watch-release-cycle.sh --strict`

## Notes
Draft intentionally. Merge only through normal branch protection; do not bypass Release Hygiene.
