### PR TITLE
fix: close TableTheory M1 correctness traps

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -150,9 +150,23 @@ Creates a fluent query builder for the given entity.
 
 #### `Transaction(fn func(*Tx) error) error`
 
-Executes a function within a simple transaction scope.
+Executes a function with the legacy `*Tx` wrapper. This helper is **not
+atomic**: writes performed through `*Tx` are sent as independent DynamoDB
+requests.
 
 - **fn**: Closure receiving a `*Tx` handle.
+
+> **Deprecated:** use [`Transact()`](#transact-transactionbuilder) for DynamoDB
+> `TransactWriteItems` atomicity. `Transaction` is a compatibility helper and is
+> planned for removal in v2.
+
+#### `TransactionFunc(fn func(any) error) error`
+
+Executes a function with the legacy transaction context.
+
+> **Deprecated:** use [`Transact()`](#transact-transactionbuilder) for DynamoDB
+> `TransactWriteItems` atomicity. `TransactionFunc` is a compatibility helper
+> and is planned for removal in v2.
 
 #### `Transact() TransactionBuilder`
 

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -58,8 +58,11 @@ err := db.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
 
 > Use `db.TransactWrite(ctx, func(core.TransactionBuilder) error)` or the
 > fluent `db.Transact()` builder followed by `Execute()` for DynamoDB
-> transactions. The older `db.Transaction(func(*core.Tx) error)` helper is only
-> a compatibility wrapper and is not the canonical full-transaction API.
+> transactions. The older `db.Transaction(func(*core.Tx) error)` helper is
+> non-atomic (writes issued through `*core.Tx` are independent DynamoDB
+> requests). `db.Transaction(...)` and `db.TransactionFunc(...)` are deprecated
+> compatibility helpers; use `Transact()` instead. Both helpers are planned for
+> removal in v2.
 
 ## TypeScript
 

--- a/internal/theorydb/lambda.go
+++ b/internal/theorydb/lambda.go
@@ -309,6 +309,8 @@ func (ldb *LambdaDB) OptimizeForMemory() {
 	}
 
 	if ldb.db != nil {
+		ldb.db.mu.Lock()
+		defer ldb.db.mu.Unlock()
 		ldb.db.lambdaTimeoutBuffer = buffer
 	}
 }

--- a/internal/theorydb/lambda.go
+++ b/internal/theorydb/lambda.go
@@ -26,8 +26,9 @@ import (
 
 var (
 	// Global Lambda-optimized DB for connection reuse
-	globalLambdaDB *LambdaDB
-	lambdaOnce     sync.Once
+	globalLambdaDB    *LambdaDB
+	globalLambdaDBErr error
+	lambdaOnce        sync.Once
 
 	benchmarkLoadDefaultConfig = config.LoadDefaultConfig
 	benchmarkNewDynamoDBClient = dynamodb.NewFromConfig
@@ -92,12 +93,15 @@ func NewLambdaOptimized() (*LambdaDB, error) {
 		return globalLambdaDB, nil
 	}
 
-	var err error
 	lambdaOnce.Do(func() {
-		globalLambdaDB, err = createLambdaDB()
+		globalLambdaDB, globalLambdaDBErr = createLambdaDB()
 	})
 
-	return globalLambdaDB, err
+	if globalLambdaDBErr != nil {
+		return nil, globalLambdaDBErr
+	}
+
+	return globalLambdaDB, nil
 }
 
 // createLambdaDB creates the actual Lambda DB instance

--- a/internal/theorydb/lambda_cov4_test.go
+++ b/internal/theorydb/lambda_cov4_test.go
@@ -100,9 +100,11 @@ func TestLambdaInitAndMetricsString_COV4(t *testing.T) {
 	})
 
 	globalLambdaDB = nil
+	globalLambdaDBErr = nil
 	lambdaOnce = sync.Once{}
 	t.Cleanup(func() {
 		globalLambdaDB = nil
+		globalLambdaDBErr = nil
 		lambdaOnce = sync.Once{}
 	})
 

--- a/internal/theorydb/lambda_cov6_test.go
+++ b/internal/theorydb/lambda_cov6_test.go
@@ -290,6 +290,48 @@ func TestLambdaDB_WithLambdaTimeoutConfig_AppliesConfiguredBufferOnce_COV6(t *te
 	require.Error(t, (&queryExecutor{db: soonTimed.db}).checkLambdaTimeout())
 }
 
+func TestLambdaDB_OptimizeForMemorySynchronizesTimeoutBufferWithLambdaTimeout_COV6(t *testing.T) {
+	db := &DB{}
+	ldb := &LambdaDB{
+		ExtendedDB:     db,
+		db:             db,
+		modelCache:     &sync.Map{},
+		lambdaMemoryMB: 1024,
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+	t.Cleanup(cancel)
+
+	const workers = 8
+	const iterations = 100
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				ldb.OptimizeForMemory()
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				if got := ldb.WithLambdaTimeout(ctx); got == nil {
+					t.Errorf("WithLambdaTimeout returned nil")
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}
+
 func TestLambdaDB_WithLambdaTimeoutConfig_NonPositiveBufferUsesDefault_COV6(t *testing.T) {
 	db := &DB{}
 	ldb := &LambdaDB{ExtendedDB: db, db: db, modelCache: &sync.Map{}}

--- a/internal/theorydb/lambda_cov6_test.go
+++ b/internal/theorydb/lambda_cov6_test.go
@@ -21,6 +21,7 @@ func TestBenchmarkColdStart_CoversSuccessAndErrorPaths_COV6(t *testing.T) {
 
 	t.Cleanup(func() {
 		globalLambdaDB = nil
+		globalLambdaDBErr = nil
 		lambdaOnce = sync.Once{}
 		benchmarkLoadDefaultConfig = origLoad
 		benchmarkNewDynamoDBClient = origNewClient
@@ -28,6 +29,7 @@ func TestBenchmarkColdStart_CoversSuccessAndErrorPaths_COV6(t *testing.T) {
 
 	resetGlobals := func() {
 		globalLambdaDB = nil
+		globalLambdaDBErr = nil
 		lambdaOnce = sync.Once{}
 	}
 
@@ -101,10 +103,12 @@ func TestBenchmarkColdStart_CoversSuccessAndErrorPaths_COV6(t *testing.T) {
 func TestNewLambdaOptimized_WarmStartReturnsGlobal_COV6(t *testing.T) {
 	t.Cleanup(func() {
 		globalLambdaDB = nil
+		globalLambdaDBErr = nil
 		lambdaOnce = sync.Once{}
 	})
 
 	globalLambdaDB = &LambdaDB{}
+	globalLambdaDBErr = nil
 	lambdaOnce = sync.Once{}
 
 	got, err := NewLambdaOptimized()
@@ -112,13 +116,47 @@ func TestNewLambdaOptimized_WarmStartReturnsGlobal_COV6(t *testing.T) {
 	require.Same(t, globalLambdaDB, got)
 }
 
-func TestNewLambdaOptimized_ReadsKMSKeyARNFromEnv_COV6(t *testing.T) {
+func TestNewLambdaOptimized_ReturnsCachedInitErrorAfterFailedColdStart_COV6(t *testing.T) {
 	t.Cleanup(func() {
 		globalLambdaDB = nil
+		globalLambdaDBErr = nil
 		lambdaOnce = sync.Once{}
 	})
 
 	globalLambdaDB = nil
+	globalLambdaDBErr = nil
+	lambdaOnce = sync.Once{}
+
+	initErr := errors.New("session boom")
+	calls := 0
+	stubSessionConfigLoad(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		calls++
+		if calls == 1 {
+			return aws.Config{}, initErr
+		}
+		return minimalAWSConfig(nil), nil
+	})
+
+	first, firstErr := NewLambdaOptimized()
+	require.Nil(t, first)
+	require.ErrorIs(t, firstErr, initErr)
+
+	second, secondErr := NewLambdaOptimized()
+	require.Nil(t, second)
+	require.Error(t, secondErr)
+	require.EqualError(t, secondErr, firstErr.Error())
+	require.Equal(t, 1, calls, "failed Lambda init must be cached by sync.Once")
+}
+
+func TestNewLambdaOptimized_ReadsKMSKeyARNFromEnv_COV6(t *testing.T) {
+	t.Cleanup(func() {
+		globalLambdaDB = nil
+		globalLambdaDBErr = nil
+		lambdaOnce = sync.Once{}
+	})
+
+	globalLambdaDB = nil
+	globalLambdaDBErr = nil
 	lambdaOnce = sync.Once{}
 
 	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "test-function")

--- a/internal/theorydb/lambda_test.go
+++ b/internal/theorydb/lambda_test.go
@@ -118,10 +118,12 @@ func TestGetRemainingTimeMillis(t *testing.T) {
 func BenchmarkLambdaColdStart(b *testing.B) {
 	// Clear global instance to simulate cold start
 	globalLambdaDB = nil
+	globalLambdaDBErr = nil
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		globalLambdaDB = nil // Reset for each iteration
+		globalLambdaDBErr = nil
 
 		startTime := time.Now()
 		db, err := NewLambdaOptimized()

--- a/internal/theorydb/query_support.go
+++ b/internal/theorydb/query_support.go
@@ -148,7 +148,10 @@ func DefaultBatchGetOptions() *core.BatchGetOptions {
 	return core.DefaultBatchGetOptions()
 }
 
-// TransactionFunc executes a function within a database transaction.
+// TransactionFunc executes fn with the legacy transaction context.
+//
+// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. This
+// compatibility helper is planned for removal in v2.
 func (db *DB) TransactionFunc(fn func(tx any) error) error {
 	tx := transaction.NewTransaction(db.session, db.registry, db.converter)
 	tx = tx.WithContext(db.ctx)

--- a/internal/theorydb/query_support.go
+++ b/internal/theorydb/query_support.go
@@ -150,7 +150,7 @@ func DefaultBatchGetOptions() *core.BatchGetOptions {
 
 // TransactionFunc executes fn with the legacy transaction context.
 //
-// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. This
+// Deprecation notice: use Transact() for DynamoDB TransactWriteItems atomicity. This
 // compatibility helper is planned for removal in v2.
 func (db *DB) TransactionFunc(fn func(tx any) error) error {
 	tx := transaction.NewTransaction(db.session, db.registry, db.converter)

--- a/internal/theorydb/theorydb.go
+++ b/internal/theorydb/theorydb.go
@@ -241,10 +241,12 @@ func (db *DB) Model(model any) core.Query {
 	return q
 }
 
-// Transaction executes a function within a database transaction
+// Transaction executes fn with a legacy Tx wrapper. It is not atomic: operations
+// performed through the Tx are sent as independent DynamoDB requests.
+//
+// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. This
+// compatibility helper is planned for removal in v2.
 func (db *DB) Transaction(fn func(tx *core.Tx) error) error {
-	// For now, we'll use a simple wrapper that doesn't support full transaction features
-	// Users should use TransactionFunc for full transaction support
 	tx := &core.Tx{}
 	// Set the db field to avoid nil pointer panic
 	tx.SetDB(db)

--- a/internal/theorydb/theorydb.go
+++ b/internal/theorydb/theorydb.go
@@ -244,7 +244,7 @@ func (db *DB) Model(model any) core.Query {
 // Transaction executes fn with a legacy Tx wrapper. It is not atomic: operations
 // performed through the Tx are sent as independent DynamoDB requests.
 //
-// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. This
+// Deprecation notice: use Transact() for DynamoDB TransactWriteItems atomicity. This
 // compatibility helper is planned for removal in v2.
 func (db *DB) Transaction(fn func(tx *core.Tx) error) error {
 	tx := &core.Tx{}

--- a/pkg/core/interfaces.go
+++ b/pkg/core/interfaces.go
@@ -17,7 +17,11 @@ type DB interface {
 	// Model returns a new query builder for the given model
 	Model(model any) Query
 
-	// Transaction executes a function within a database transaction
+	// Transaction executes fn with a legacy Tx wrapper. It is not atomic: operations
+	// performed through the Tx are sent as independent DynamoDB requests.
+	//
+	// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. This
+	// compatibility helper is planned for removal in v2.
 	Transaction(fn func(tx *Tx) error) error
 
 	// Migrate runs all pending migrations
@@ -66,8 +70,11 @@ type ExtendedDB interface {
 	// WithLambdaTimeoutBuffer sets a custom timeout buffer for Lambda execution
 	WithLambdaTimeoutBuffer(buffer time.Duration) DB
 
-	// TransactionFunc executes a function within a full transaction context
-	// tx should be of type *transaction.Transaction
+	// TransactionFunc executes fn with the legacy transaction context.
+	// tx should be of type *transaction.Transaction.
+	//
+	// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. This
+	// compatibility helper is planned for removal in v2.
 	TransactionFunc(fn func(tx any) error) error
 
 	// Transact returns a fluent transaction builder for composing TransactWriteItems
@@ -298,32 +305,37 @@ type PaginatedResult struct {
 	HasMore          bool
 }
 
-// Tx represents a database transaction
+// Tx is the legacy wrapper passed to DB.Transaction. It delegates operations to
+// the underlying DB as independent requests and does not provide DynamoDB
+// transaction atomicity.
+//
+// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. Tx is
+// planned for removal in v2 with DB.Transaction.
 type Tx struct {
 	db DB
 }
 
-// SetDB sets the database reference for the transaction
+// SetDB sets the database reference for the legacy wrapper.
 func (tx *Tx) SetDB(db DB) {
 	tx.db = db
 }
 
-// Model returns a new query builder for the given model within the transaction
+// Model returns a new query builder for the given model through the underlying DB.
 func (tx *Tx) Model(model any) Query {
 	return tx.db.Model(model)
 }
 
-// Create creates a new item within the transaction
+// Create creates a new item as an independent DynamoDB request.
 func (tx *Tx) Create(model any) error {
 	return tx.db.Model(model).Create()
 }
 
-// Update updates an item within the transaction
+// Update updates an item as an independent DynamoDB request.
 func (tx *Tx) Update(model any, fields ...string) error {
 	return tx.db.Model(model).Update(fields...)
 }
 
-// Delete deletes an item within the transaction
+// Delete deletes an item as an independent DynamoDB request.
 func (tx *Tx) Delete(model any) error {
 	return tx.db.Model(model).Delete()
 }

--- a/pkg/core/interfaces.go
+++ b/pkg/core/interfaces.go
@@ -20,7 +20,7 @@ type DB interface {
 	// Transaction executes fn with a legacy Tx wrapper. It is not atomic: operations
 	// performed through the Tx are sent as independent DynamoDB requests.
 	//
-	// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. This
+	// Deprecation notice: use Transact() for DynamoDB TransactWriteItems atomicity. This
 	// compatibility helper is planned for removal in v2.
 	Transaction(fn func(tx *Tx) error) error
 
@@ -73,7 +73,7 @@ type ExtendedDB interface {
 	// TransactionFunc executes fn with the legacy transaction context.
 	// tx should be of type *transaction.Transaction.
 	//
-	// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. This
+	// Deprecation notice: use Transact() for DynamoDB TransactWriteItems atomicity. This
 	// compatibility helper is planned for removal in v2.
 	TransactionFunc(fn func(tx any) error) error
 
@@ -309,7 +309,7 @@ type PaginatedResult struct {
 // the underlying DB as independent requests and does not provide DynamoDB
 // transaction atomicity.
 //
-// Deprecated: use Transact() for DynamoDB TransactWriteItems atomicity. Tx is
+// Deprecation notice: use Transact() for DynamoDB TransactWriteItems atomicity. Tx is
 // planned for removal in v2 with DB.Transaction.
 type Tx struct {
 	db DB

--- a/pkg/mocks/aws_dynamodb.go
+++ b/pkg/mocks/aws_dynamodb.go
@@ -27,6 +27,12 @@ type MockDynamoDBClient struct {
 	mock.Mock
 }
 
+// AssertExpectations reports return type mismatches recorded by
+// MockDynamoDBClient in addition to testify/mock expectation failures.
+func (m *MockDynamoDBClient) AssertExpectations(t mock.TestingT) bool {
+	return assertMockExpectations(t, &m.Mock)
+}
+
 // Table Management Operations
 
 // CreateTable mocks the DynamoDB CreateTable operation
@@ -35,10 +41,7 @@ func (m *MockDynamoDBClient) CreateTable(ctx context.Context, params *dynamodb.C
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.CreateTableOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.CreateTableOutput")
-	}
+	output, _ := typedReturn[*dynamodb.CreateTableOutput](&m.Mock, "CreateTable", 0, "*dynamodb.CreateTableOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -48,10 +51,7 @@ func (m *MockDynamoDBClient) DescribeTable(ctx context.Context, params *dynamodb
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.DescribeTableOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.DescribeTableOutput")
-	}
+	output, _ := typedReturn[*dynamodb.DescribeTableOutput](&m.Mock, "DescribeTable", 0, "*dynamodb.DescribeTableOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -61,10 +61,7 @@ func (m *MockDynamoDBClient) DeleteTable(ctx context.Context, params *dynamodb.D
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.DeleteTableOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.DeleteTableOutput")
-	}
+	output, _ := typedReturn[*dynamodb.DeleteTableOutput](&m.Mock, "DeleteTable", 0, "*dynamodb.DeleteTableOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -74,10 +71,7 @@ func (m *MockDynamoDBClient) UpdateTimeToLive(ctx context.Context, params *dynam
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.UpdateTimeToLiveOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.UpdateTimeToLiveOutput")
-	}
+	output, _ := typedReturn[*dynamodb.UpdateTimeToLiveOutput](&m.Mock, "UpdateTimeToLive", 0, "*dynamodb.UpdateTimeToLiveOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -89,10 +83,7 @@ func (m *MockDynamoDBClient) GetItem(ctx context.Context, params *dynamodb.GetIt
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.GetItemOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.GetItemOutput")
-	}
+	output, _ := typedReturn[*dynamodb.GetItemOutput](&m.Mock, "GetItem", 0, "*dynamodb.GetItemOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -102,10 +93,7 @@ func (m *MockDynamoDBClient) PutItem(ctx context.Context, params *dynamodb.PutIt
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.PutItemOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.PutItemOutput")
-	}
+	output, _ := typedReturn[*dynamodb.PutItemOutput](&m.Mock, "PutItem", 0, "*dynamodb.PutItemOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -115,10 +103,7 @@ func (m *MockDynamoDBClient) DeleteItem(ctx context.Context, params *dynamodb.De
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.DeleteItemOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.DeleteItemOutput")
-	}
+	output, _ := typedReturn[*dynamodb.DeleteItemOutput](&m.Mock, "DeleteItem", 0, "*dynamodb.DeleteItemOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -128,10 +113,7 @@ func (m *MockDynamoDBClient) Query(ctx context.Context, params *dynamodb.QueryIn
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.QueryOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.QueryOutput")
-	}
+	output, _ := typedReturn[*dynamodb.QueryOutput](&m.Mock, "Query", 0, "*dynamodb.QueryOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -141,10 +123,7 @@ func (m *MockDynamoDBClient) Scan(ctx context.Context, params *dynamodb.ScanInpu
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.ScanOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.ScanOutput")
-	}
+	output, _ := typedReturn[*dynamodb.ScanOutput](&m.Mock, "Scan", 0, "*dynamodb.ScanOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -154,10 +133,7 @@ func (m *MockDynamoDBClient) UpdateItem(ctx context.Context, params *dynamodb.Up
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.UpdateItemOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.UpdateItemOutput")
-	}
+	output, _ := typedReturn[*dynamodb.UpdateItemOutput](&m.Mock, "UpdateItem", 0, "*dynamodb.UpdateItemOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -167,10 +143,7 @@ func (m *MockDynamoDBClient) BatchGetItem(ctx context.Context, params *dynamodb.
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.BatchGetItemOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.BatchGetItemOutput")
-	}
+	output, _ := typedReturn[*dynamodb.BatchGetItemOutput](&m.Mock, "BatchGetItem", 0, "*dynamodb.BatchGetItemOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -180,10 +153,7 @@ func (m *MockDynamoDBClient) BatchWriteItem(ctx context.Context, params *dynamod
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*dynamodb.BatchWriteItemOutput)
-	if !ok {
-		panic("unexpected type: expected *dynamodb.BatchWriteItemOutput")
-	}
+	output, _ := typedReturn[*dynamodb.BatchWriteItemOutput](&m.Mock, "BatchWriteItem", 0, "*dynamodb.BatchWriteItemOutput", args.Get(0))
 	return output, args.Error(1)
 }
 

--- a/pkg/mocks/aws_dynamodb_cov6_test.go
+++ b/pkg/mocks/aws_dynamodb_cov6_test.go
@@ -3,6 +3,8 @@ package mocks_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -12,6 +14,24 @@ import (
 
 	"github.com/theory-cloud/tabletheory/pkg/mocks"
 )
+
+type recordingTestingT struct {
+	errors []string
+	logs   []string
+	failed bool
+}
+
+func (r *recordingTestingT) Errorf(format string, args ...interface{}) {
+	r.errors = append(r.errors, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingTestingT) Logf(format string, args ...interface{}) {
+	r.logs = append(r.logs, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingTestingT) FailNow() {
+	r.failed = true
+}
 
 func TestMockDynamoDBClient_AdditionalOperations_COV6(t *testing.T) {
 	mockClient := new(mocks.MockDynamoDBClient)
@@ -66,19 +86,24 @@ func TestMockDynamoDBClient_AdditionalOperations_COV6(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
-func TestMockDynamoDBClient_PanicsOnUnexpectedReturnTypes_COV6(t *testing.T) {
+func TestMockDynamoDBClient_WrongReturnTypeRecordsAssertionFailure_COV6(t *testing.T) {
 	mockClient := new(mocks.MockDynamoDBClient)
 	ctx := context.Background()
 
 	input := &dynamodb.QueryInput{TableName: aws.String("tbl")}
 	mockClient.On("Query", ctx, input, mock.Anything).Return("bad-type", nil).Once()
 
-	assert.Panics(t, func() {
-		_, err := mockClient.Query(ctx, input)
+	assert.NotPanics(t, func() {
+		out, err := mockClient.Query(ctx, input)
 		assert.NoError(t, err)
+		assert.Nil(t, out)
 	})
 
-	mockClient.AssertExpectations(t)
+	recorder := &recordingTestingT{}
+	assert.False(t, mockClient.AssertExpectations(recorder))
+	assert.Contains(t, strings.Join(recorder.errors, "\n"), "Query")
+	assert.Contains(t, strings.Join(recorder.errors, "\n"), "*dynamodb.QueryOutput")
+	assert.False(t, recorder.failed)
 }
 
 func TestMockDynamoDBClient_ErrorBranches_COV6(t *testing.T) {
@@ -182,7 +207,7 @@ func TestMockDynamoDBClient_ErrorBranches_COV6(t *testing.T) {
 	}
 }
 
-func TestMockDynamoDBClient_PanicBranches_COV6(t *testing.T) {
+func TestMockDynamoDBClient_WrongReturnTypeBranches_COV6(t *testing.T) {
 	ctx := context.Background()
 
 	cases := []struct {
@@ -293,8 +318,13 @@ func TestMockDynamoDBClient_PanicBranches_COV6(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := new(mocks.MockDynamoDBClient)
-			assert.Panics(t, func() { tc.call(t, client) })
-			client.AssertExpectations(t)
+			assert.NotPanics(t, func() { tc.call(t, client) })
+
+			recorder := &recordingTestingT{}
+			assert.False(t, client.AssertExpectations(recorder))
+			assert.Contains(t, strings.Join(recorder.errors, "\n"), tc.name)
+			assert.Contains(t, strings.Join(recorder.errors, "\n"), "expected")
+			assert.False(t, recorder.failed)
 		})
 	}
 }

--- a/pkg/mocks/aws_kms.go
+++ b/pkg/mocks/aws_kms.go
@@ -26,15 +26,18 @@ type MockKMSClient struct {
 	mock.Mock
 }
 
+// AssertExpectations reports return type mismatches recorded by MockKMSClient
+// in addition to testify/mock expectation failures.
+func (m *MockKMSClient) AssertExpectations(t mock.TestingT) bool {
+	return assertMockExpectations(t, &m.Mock)
+}
+
 func (m *MockKMSClient) GenerateDataKey(ctx context.Context, params *kms.GenerateDataKeyInput, optFns ...func(*kms.Options)) (*kms.GenerateDataKeyOutput, error) {
 	args := m.Called(ctx, params, optFns)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*kms.GenerateDataKeyOutput)
-	if !ok {
-		panic("unexpected type: expected *kms.GenerateDataKeyOutput")
-	}
+	output, _ := typedReturn[*kms.GenerateDataKeyOutput](&m.Mock, "GenerateDataKey", 0, "*kms.GenerateDataKeyOutput", args.Get(0))
 	return output, args.Error(1)
 }
 
@@ -43,9 +46,6 @@ func (m *MockKMSClient) Decrypt(ctx context.Context, params *kms.DecryptInput, o
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	output, ok := args.Get(0).(*kms.DecryptOutput)
-	if !ok {
-		panic("unexpected type: expected *kms.DecryptOutput")
-	}
+	output, _ := typedReturn[*kms.DecryptOutput](&m.Mock, "Decrypt", 0, "*kms.DecryptOutput", args.Get(0))
 	return output, args.Error(1)
 }

--- a/pkg/mocks/aws_kms_test.go
+++ b/pkg/mocks/aws_kms_test.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -41,18 +42,24 @@ func TestMockKMSClient_GenerateDataKey_NilOutputReturnsError(t *testing.T) {
 	m.AssertExpectations(t)
 }
 
-func TestMockKMSClient_GenerateDataKey_PanicsOnWrongType(t *testing.T) {
+func TestMockKMSClient_GenerateDataKey_WrongReturnTypeRecordsAssertionFailure(t *testing.T) {
 	m := new(MockKMSClient)
 
 	m.On("GenerateDataKey", mock.Anything, mock.Anything, mock.Anything).
 		Return("bad-type", nil).
 		Once()
 
-	require.Panics(t, func() {
-		_, err := m.GenerateDataKey(context.Background(), &kms.GenerateDataKeyInput{})
+	require.NotPanics(t, func() {
+		got, err := m.GenerateDataKey(context.Background(), &kms.GenerateDataKeyInput{})
 		require.NoError(t, err)
+		require.Nil(t, got)
 	})
-	m.AssertExpectations(t)
+
+	recorder := &recordingTestingT{}
+	require.False(t, m.AssertExpectations(recorder))
+	require.Contains(t, strings.Join(recorder.errors, "\n"), "GenerateDataKey")
+	require.Contains(t, strings.Join(recorder.errors, "\n"), "*kms.GenerateDataKeyOutput")
+	require.False(t, recorder.failed)
 }
 
 func TestMockKMSClient_Decrypt(t *testing.T) {
@@ -83,16 +90,22 @@ func TestMockKMSClient_Decrypt_NilOutputReturnsError(t *testing.T) {
 	m.AssertExpectations(t)
 }
 
-func TestMockKMSClient_Decrypt_PanicsOnWrongType(t *testing.T) {
+func TestMockKMSClient_Decrypt_WrongReturnTypeRecordsAssertionFailure(t *testing.T) {
 	m := new(MockKMSClient)
 
 	m.On("Decrypt", mock.Anything, mock.Anything, mock.Anything).
 		Return("bad-type", nil).
 		Once()
 
-	require.Panics(t, func() {
-		_, err := m.Decrypt(context.Background(), &kms.DecryptInput{CiphertextBlob: []byte("edk")})
+	require.NotPanics(t, func() {
+		got, err := m.Decrypt(context.Background(), &kms.DecryptInput{CiphertextBlob: []byte("edk")})
 		require.NoError(t, err)
+		require.Nil(t, got)
 	})
-	m.AssertExpectations(t)
+
+	recorder := &recordingTestingT{}
+	require.False(t, m.AssertExpectations(recorder))
+	require.Contains(t, strings.Join(recorder.errors, "\n"), "Decrypt")
+	require.Contains(t, strings.Join(recorder.errors, "\n"), "*kms.DecryptOutput")
+	require.False(t, recorder.failed)
 }

--- a/pkg/mocks/batch_get_builder.go
+++ b/pkg/mocks/batch_get_builder.go
@@ -14,53 +14,59 @@ type MockBatchGetBuilder struct {
 // Keys sets the keys to retrieve.
 func (m *MockBatchGetBuilder) Keys(keys []any) core.BatchGetBuilder {
 	args := m.Called(keys)
-	return args.Get(0).(core.BatchGetBuilder)
+	return mockBatchGetBuilder(&m.Mock, "Keys", args.Get(0))
 }
 
 // ChunkSize configures the chunk size.
 func (m *MockBatchGetBuilder) ChunkSize(size int) core.BatchGetBuilder {
 	args := m.Called(size)
-	return args.Get(0).(core.BatchGetBuilder)
+	return mockBatchGetBuilder(&m.Mock, "ChunkSize", args.Get(0))
 }
 
 // ConsistentRead enables strongly consistent reads.
 func (m *MockBatchGetBuilder) ConsistentRead() core.BatchGetBuilder {
 	args := m.Called()
-	return args.Get(0).(core.BatchGetBuilder)
+	return mockBatchGetBuilder(&m.Mock, "ConsistentRead", args.Get(0))
 }
 
 // Parallel configures concurrency.
 func (m *MockBatchGetBuilder) Parallel(maxConcurrency int) core.BatchGetBuilder {
 	args := m.Called(maxConcurrency)
-	return args.Get(0).(core.BatchGetBuilder)
+	return mockBatchGetBuilder(&m.Mock, "Parallel", args.Get(0))
 }
 
 // WithRetry overrides the retry policy.
 func (m *MockBatchGetBuilder) WithRetry(policy *core.RetryPolicy) core.BatchGetBuilder {
 	args := m.Called(policy)
-	return args.Get(0).(core.BatchGetBuilder)
+	return mockBatchGetBuilder(&m.Mock, "WithRetry", args.Get(0))
 }
 
 // Select limits the projection.
 func (m *MockBatchGetBuilder) Select(fields ...string) core.BatchGetBuilder {
 	args := m.Called(fields)
-	return args.Get(0).(core.BatchGetBuilder)
+	return mockBatchGetBuilder(&m.Mock, "Select", args.Get(0))
 }
 
 // OnProgress registers a callback for progress updates.
 func (m *MockBatchGetBuilder) OnProgress(callback core.BatchProgressCallback) core.BatchGetBuilder {
 	args := m.Called(callback)
-	return args.Get(0).(core.BatchGetBuilder)
+	return mockBatchGetBuilder(&m.Mock, "OnProgress", args.Get(0))
 }
 
 // OnError registers an error handler.
 func (m *MockBatchGetBuilder) OnError(handler core.BatchChunkErrorHandler) core.BatchGetBuilder {
 	args := m.Called(handler)
-	return args.Get(0).(core.BatchGetBuilder)
+	return mockBatchGetBuilder(&m.Mock, "OnError", args.Get(0))
 }
 
 // Execute performs the batch get operation.
 func (m *MockBatchGetBuilder) Execute(dest any) error {
 	args := m.Called(dest)
 	return args.Error(0)
+}
+
+// AssertExpectations reports return type mismatches recorded by
+// MockBatchGetBuilder in addition to testify/mock expectation failures.
+func (m *MockBatchGetBuilder) AssertExpectations(t mock.TestingT) bool {
+	return assertMockExpectations(t, &m.Mock)
 }

--- a/pkg/mocks/db.go
+++ b/pkg/mocks/db.go
@@ -28,7 +28,10 @@ func (m *MockDB) Model(model any) core.Query {
 	return mustCoreQuery(args.Get(0))
 }
 
-// Transaction executes a function within a database transaction
+// Transaction executes a mocked legacy transaction callback.
+//
+// Deprecated: use Transact() in new code. The production compatibility helper is
+// planned for removal in v2.
 func (m *MockDB) Transaction(fn func(tx *core.Tx) error) error {
 	if fn == nil {
 		args := m.Called(fn)

--- a/pkg/mocks/db.go
+++ b/pkg/mocks/db.go
@@ -25,7 +25,7 @@ type MockDB struct {
 // Model returns a new query builder for the given model
 func (m *MockDB) Model(model any) core.Query {
 	args := m.Called(model)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "Model", args.Get(0))
 }
 
 // Transaction executes a mocked legacy transaction callback.
@@ -87,5 +87,11 @@ func (m *MockDB) Close() error {
 // WithContext returns a new DB instance with the given context
 func (m *MockDB) WithContext(ctx context.Context) core.DB {
 	args := m.Called(ctx)
-	return mustCoreDB(args.Get(0))
+	return mockCoreDB(&m.Mock, "WithContext", args.Get(0))
+}
+
+// AssertExpectations reports return type mismatches recorded by MockDB in
+// addition to testify/mock expectation failures.
+func (m *MockDB) AssertExpectations(t mock.TestingT) bool {
+	return assertMockExpectations(t, &m.Mock)
 }

--- a/pkg/mocks/db.go
+++ b/pkg/mocks/db.go
@@ -30,7 +30,7 @@ func (m *MockDB) Model(model any) core.Query {
 
 // Transaction executes a mocked legacy transaction callback.
 //
-// Deprecated: use Transact() in new code. The production compatibility helper is
+// Deprecation notice: use Transact() in new code. The production compatibility helper is
 // planned for removal in v2.
 func (m *MockDB) Transaction(fn func(tx *core.Tx) error) error {
 	if fn == nil {

--- a/pkg/mocks/extended_db.go
+++ b/pkg/mocks/extended_db.go
@@ -77,18 +77,18 @@ func (m *MockExtendedDB) DescribeTable(model any) (any, error) {
 // WithLambdaTimeout sets a deadline based on Lambda context
 func (m *MockExtendedDB) WithLambdaTimeout(ctx context.Context) core.DB {
 	args := m.Called(ctx)
-	return mockCoreDB(&m.MockDB.Mock, "WithLambdaTimeout", args.Get(0))
+	return mockCoreDB(&m.Mock, "WithLambdaTimeout", args.Get(0))
 }
 
 // WithLambdaTimeoutBuffer sets a custom timeout buffer
 func (m *MockExtendedDB) WithLambdaTimeoutBuffer(buffer time.Duration) core.DB {
 	args := m.Called(buffer)
-	return mockCoreDB(&m.MockDB.Mock, "WithLambdaTimeoutBuffer", args.Get(0))
+	return mockCoreDB(&m.Mock, "WithLambdaTimeoutBuffer", args.Get(0))
 }
 
 // TransactionFunc executes a mocked legacy transaction callback.
 //
-// Deprecated: use Transact() in new code. The production compatibility helper is
+// Deprecation notice: use Transact() in new code. The production compatibility helper is
 // planned for removal in v2.
 func (m *MockExtendedDB) TransactionFunc(fn func(tx any) error) error {
 	if fn == nil {
@@ -124,7 +124,7 @@ func (m *MockExtendedDB) TransactionFunc(fn func(tx any) error) error {
 // Transact returns a transaction builder mock
 func (m *MockExtendedDB) Transact() core.TransactionBuilder {
 	args := m.Called()
-	return mockTransactionBuilder(&m.MockDB.Mock, "Transact", args.Get(0))
+	return mockTransactionBuilder(&m.Mock, "Transact", args.Get(0))
 }
 
 // TransactWrite executes a function with a transaction builder
@@ -233,5 +233,5 @@ func NewMockExtendedDBStrict() *MockExtendedDB {
 // AssertExpectations reports return type mismatches recorded by MockExtendedDB
 // in addition to testify/mock expectation failures.
 func (m *MockExtendedDB) AssertExpectations(t mock.TestingT) bool {
-	return assertMockExpectations(t, &m.MockDB.Mock)
+	return assertMockExpectations(t, &m.Mock)
 }

--- a/pkg/mocks/extended_db.go
+++ b/pkg/mocks/extended_db.go
@@ -77,13 +77,13 @@ func (m *MockExtendedDB) DescribeTable(model any) (any, error) {
 // WithLambdaTimeout sets a deadline based on Lambda context
 func (m *MockExtendedDB) WithLambdaTimeout(ctx context.Context) core.DB {
 	args := m.Called(ctx)
-	return mustCoreDB(args.Get(0))
+	return mockCoreDB(&m.MockDB.Mock, "WithLambdaTimeout", args.Get(0))
 }
 
 // WithLambdaTimeoutBuffer sets a custom timeout buffer
 func (m *MockExtendedDB) WithLambdaTimeoutBuffer(buffer time.Duration) core.DB {
 	args := m.Called(buffer)
-	return mustCoreDB(args.Get(0))
+	return mockCoreDB(&m.MockDB.Mock, "WithLambdaTimeoutBuffer", args.Get(0))
 }
 
 // TransactionFunc executes a mocked legacy transaction callback.
@@ -124,7 +124,7 @@ func (m *MockExtendedDB) TransactionFunc(fn func(tx any) error) error {
 // Transact returns a transaction builder mock
 func (m *MockExtendedDB) Transact() core.TransactionBuilder {
 	args := m.Called()
-	return mustTransactionBuilder(args.Get(0))
+	return mockTransactionBuilder(&m.MockDB.Mock, "Transact", args.Get(0))
 }
 
 // TransactWrite executes a function with a transaction builder
@@ -228,4 +228,10 @@ func NewMockExtendedDB() *MockExtendedDB {
 // expectations. Use this when you want to explicitly set all expectations.
 func NewMockExtendedDBStrict() *MockExtendedDB {
 	return &MockExtendedDB{}
+}
+
+// AssertExpectations reports return type mismatches recorded by MockExtendedDB
+// in addition to testify/mock expectation failures.
+func (m *MockExtendedDB) AssertExpectations(t mock.TestingT) bool {
+	return assertMockExpectations(t, &m.MockDB.Mock)
 }

--- a/pkg/mocks/extended_db.go
+++ b/pkg/mocks/extended_db.go
@@ -86,7 +86,10 @@ func (m *MockExtendedDB) WithLambdaTimeoutBuffer(buffer time.Duration) core.DB {
 	return mustCoreDB(args.Get(0))
 }
 
-// TransactionFunc executes a function within a full transaction context
+// TransactionFunc executes a mocked legacy transaction callback.
+//
+// Deprecated: use Transact() in new code. The production compatibility helper is
+// planned for removal in v2.
 func (m *MockExtendedDB) TransactionFunc(fn func(tx any) error) error {
 	if fn == nil {
 		args := m.Called(fn)

--- a/pkg/mocks/query.go
+++ b/pkg/mocks/query.go
@@ -13,66 +13,104 @@ import (
 )
 
 func mustCoreQuery(v any) core.Query {
+	return mockCoreQuery(nil, "", v)
+}
+
+func mockCoreQuery(m *mock.Mock, method string, v any) core.Query {
 	if v == nil {
 		return nil
 	}
-	q, ok := v.(core.Query)
-	if !ok {
-		panic("unexpected type: expected core.Query")
+	if q, ok := typedReturn[core.Query](m, method, 0, "core.Query", v); ok {
+		return q
 	}
-	return q
+	return nil
 }
 
 func mustCoreDB(v any) core.DB {
+	return mockCoreDB(nil, "", v)
+}
+
+func mockCoreDB(m *mock.Mock, method string, v any) core.DB {
 	if v == nil {
 		return nil
 	}
-	db, ok := v.(core.DB)
-	if !ok {
-		panic("unexpected type: expected core.DB")
+	if db, ok := typedReturn[core.DB](m, method, 0, "core.DB", v); ok {
+		return db
 	}
-	return db
+	return nil
 }
 
 func mustPaginatedResult(v any) *core.PaginatedResult {
+	return mockPaginatedResult(nil, "", v)
+}
+
+func mockPaginatedResult(m *mock.Mock, method string, v any) *core.PaginatedResult {
 	if v == nil {
 		return nil
 	}
-	result, ok := v.(*core.PaginatedResult)
-	if !ok {
-		panic("unexpected type: expected *core.PaginatedResult")
+	if result, ok := typedReturn[*core.PaginatedResult](m, method, 0, "*core.PaginatedResult", v); ok {
+		return result
 	}
-	return result
+	return nil
 }
 
 func mustInt64(v any) int64 {
-	n, ok := v.(int64)
-	if !ok {
-		panic("unexpected type: expected int64")
+	return mockInt64(nil, "", v)
+}
+
+func mockInt64(m *mock.Mock, method string, v any) int64 {
+	if n, ok := typedReturn[int64](m, method, 0, "int64", v); ok {
+		return n
 	}
-	return n
+	return 0
 }
 
 func mustUpdateBuilder(v any) core.UpdateBuilder {
+	return mockUpdateBuilder(nil, "", v)
+}
+
+func mockUpdateBuilder(m *mock.Mock, method string, v any) core.UpdateBuilder {
 	if v == nil {
 		return nil
 	}
-	builder, ok := v.(core.UpdateBuilder)
-	if !ok {
-		panic("unexpected type: expected core.UpdateBuilder")
+	if builder, ok := typedReturn[core.UpdateBuilder](m, method, 0, "core.UpdateBuilder", v); ok {
+		return builder
 	}
-	return builder
+	return nil
 }
 
 func mustTransactionBuilder(v any) core.TransactionBuilder {
+	return mockTransactionBuilder(nil, "", v)
+}
+
+func mockTransactionBuilder(m *mock.Mock, method string, v any) core.TransactionBuilder {
 	if v == nil {
 		return nil
 	}
-	builder, ok := v.(core.TransactionBuilder)
-	if !ok {
-		panic("unexpected type: expected core.TransactionBuilder")
+	if builder, ok := typedReturn[core.TransactionBuilder](m, method, 0, "core.TransactionBuilder", v); ok {
+		return builder
 	}
-	return builder
+	return nil
+}
+
+func mustBatchGetBuilder(v any) core.BatchGetBuilder {
+	return mockBatchGetBuilder(nil, "", v)
+}
+
+func mockBatchGetBuilder(m *mock.Mock, method string, v any) core.BatchGetBuilder {
+	if v == nil {
+		return nil
+	}
+	if builder, ok := typedReturn[core.BatchGetBuilder](m, method, 0, "core.BatchGetBuilder", v); ok {
+		return builder
+	}
+	return nil
+}
+
+// AssertExpectations reports return type mismatches recorded by MockQuery in
+// addition to testify/mock expectation failures.
+func (m *MockQuery) AssertExpectations(t mock.TestingT) bool {
+	return assertMockExpectations(t, &m.Mock)
 }
 
 // MockQuery is a mock implementation of the core.Query interface.
@@ -90,85 +128,85 @@ type MockQuery struct {
 // Where adds a condition to the query
 func (m *MockQuery) Where(field string, op string, value any) core.Query {
 	args := m.Called(field, op, value)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "Where", args.Get(0))
 }
 
 // Index specifies which index to use
 func (m *MockQuery) Index(indexName string) core.Query {
 	args := m.Called(indexName)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "Index", args.Get(0))
 }
 
 // Filter adds a filter expression to the query
 func (m *MockQuery) Filter(field string, op string, value any) core.Query {
 	args := m.Called(field, op, value)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "Filter", args.Get(0))
 }
 
 // OrFilter adds an OR filter expression to the query
 func (m *MockQuery) OrFilter(field string, op string, value any) core.Query {
 	args := m.Called(field, op, value)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "OrFilter", args.Get(0))
 }
 
 // FilterGroup adds a group of filters with AND logic
 func (m *MockQuery) FilterGroup(fn func(core.Query)) core.Query {
 	args := m.Called(fn)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "FilterGroup", args.Get(0))
 }
 
 // OrFilterGroup adds a group of filters with OR logic
 func (m *MockQuery) OrFilterGroup(fn func(core.Query)) core.Query {
 	args := m.Called(fn)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "OrFilterGroup", args.Get(0))
 }
 
 // IfNotExists adds a condition that the item must not exist
 func (m *MockQuery) IfNotExists() core.Query {
 	args := m.Called()
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "IfNotExists", args.Get(0))
 }
 
 // IfExists adds a condition that the item must exist
 func (m *MockQuery) IfExists() core.Query {
 	args := m.Called()
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "IfExists", args.Get(0))
 }
 
 // WithCondition adds a generic condition expression
 func (m *MockQuery) WithCondition(field, operator string, value any) core.Query {
 	args := m.Called(field, operator, value)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "WithCondition", args.Get(0))
 }
 
 // WithConditionExpression adds a raw condition expression
 func (m *MockQuery) WithConditionExpression(expr string, values map[string]any) core.Query {
 	args := m.Called(expr, values)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "WithConditionExpression", args.Get(0))
 }
 
 // OrderBy sets the sort order
 func (m *MockQuery) OrderBy(field string, order string) core.Query {
 	args := m.Called(field, order)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "OrderBy", args.Get(0))
 }
 
 // Limit sets the maximum number of items to return
 func (m *MockQuery) Limit(limit int) core.Query {
 	args := m.Called(limit)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "Limit", args.Get(0))
 }
 
 // Offset sets the starting position for the query
 func (m *MockQuery) Offset(offset int) core.Query {
 	args := m.Called(offset)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "Offset", args.Get(0))
 }
 
 // Select specifies which fields to retrieve
 func (m *MockQuery) Select(fields ...string) core.Query {
 	args := m.Called(fields)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "Select", args.Get(0))
 }
 
 // First retrieves the first matching item
@@ -186,13 +224,13 @@ func (m *MockQuery) All(dest any) error {
 // AllPaginated retrieves all matching items with pagination metadata
 func (m *MockQuery) AllPaginated(dest any) (*core.PaginatedResult, error) {
 	args := m.Called(dest)
-	return mustPaginatedResult(args.Get(0)), args.Error(1)
+	return mockPaginatedResult(&m.Mock, "AllPaginated", args.Get(0)), args.Error(1)
 }
 
 // Count returns the number of matching items
 func (m *MockQuery) Count() (int64, error) {
 	args := m.Called()
-	return mustInt64(args.Get(0)), args.Error(1)
+	return mockInt64(&m.Mock, "Count", args.Get(0)), args.Error(1)
 }
 
 // Create creates a new item
@@ -216,7 +254,7 @@ func (m *MockQuery) Update(fields ...string) error {
 // UpdateBuilder returns a builder for complex update operations
 func (m *MockQuery) UpdateBuilder() core.UpdateBuilder {
 	args := m.Called()
-	return mustUpdateBuilder(args.Get(0))
+	return mockUpdateBuilder(&m.Mock, "UpdateBuilder", args.Get(0))
 }
 
 // Delete deletes the matching items
@@ -234,7 +272,7 @@ func (m *MockQuery) Scan(dest any) error {
 // ParallelScan configures parallel scanning
 func (m *MockQuery) ParallelScan(segment int32, totalSegments int32) core.Query {
 	args := m.Called(segment, totalSegments)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "ParallelScan", args.Get(0))
 }
 
 // ScanAllSegments performs parallel scan across all segments
@@ -258,10 +296,7 @@ func (m *MockQuery) BatchGetWithOptions(keys []any, dest any, opts *core.BatchGe
 // BatchGetBuilder returns a fluent builder for BatchGet
 func (m *MockQuery) BatchGetBuilder() core.BatchGetBuilder {
 	args := m.Called()
-	if builder, ok := args.Get(0).(core.BatchGetBuilder); ok {
-		return builder
-	}
-	return nil
+	return mockBatchGetBuilder(&m.Mock, "BatchGetBuilder", args.Get(0))
 }
 
 // BatchCreate creates multiple items
@@ -279,7 +314,7 @@ func (m *MockQuery) BatchDelete(keys []any) error {
 // Cursor sets the pagination cursor
 func (m *MockQuery) Cursor(cursor string) core.Query {
 	args := m.Called(cursor)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "Cursor", args.Get(0))
 }
 
 // SetCursor sets the cursor from a string
@@ -291,19 +326,19 @@ func (m *MockQuery) SetCursor(cursor string) error {
 // WithContext sets the context for the query
 func (m *MockQuery) WithContext(ctx context.Context) core.Query {
 	args := m.Called(ctx)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "WithContext", args.Get(0))
 }
 
 // ConsistentRead enables strongly consistent reads for Query operations
 func (m *MockQuery) ConsistentRead() core.Query {
 	args := m.Called()
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "ConsistentRead", args.Get(0))
 }
 
 // WithRetry configures retry behavior for eventually consistent reads
 func (m *MockQuery) WithRetry(maxRetries int, initialDelay time.Duration) core.Query {
 	args := m.Called(maxRetries, initialDelay)
-	return mustCoreQuery(args.Get(0))
+	return mockCoreQuery(&m.Mock, "WithRetry", args.Get(0))
 }
 
 // BatchWrite performs mixed batch write operations

--- a/pkg/mocks/query.go
+++ b/pkg/mocks/query.go
@@ -79,10 +79,6 @@ func mockUpdateBuilder(m *mock.Mock, method string, v any) core.UpdateBuilder {
 	return nil
 }
 
-func mustTransactionBuilder(v any) core.TransactionBuilder {
-	return mockTransactionBuilder(nil, "", v)
-}
-
 func mockTransactionBuilder(m *mock.Mock, method string, v any) core.TransactionBuilder {
 	if v == nil {
 		return nil
@@ -91,10 +87,6 @@ func mockTransactionBuilder(m *mock.Mock, method string, v any) core.Transaction
 		return builder
 	}
 	return nil
-}
-
-func mustBatchGetBuilder(v any) core.BatchGetBuilder {
-	return mockBatchGetBuilder(nil, "", v)
 }
 
 func mockBatchGetBuilder(m *mock.Mock, method string, v any) core.BatchGetBuilder {

--- a/pkg/mocks/query_helpers_test.go
+++ b/pkg/mocks/query_helpers_test.go
@@ -1,12 +1,32 @@
 package mocks
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/theory-cloud/tabletheory/pkg/core"
 )
+
+type recordingTestingT struct {
+	errors []string
+	logs   []string
+	failed bool
+}
+
+func (r *recordingTestingT) Errorf(format string, args ...interface{}) {
+	r.errors = append(r.errors, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingTestingT) Logf(format string, args ...interface{}) {
+	r.logs = append(r.logs, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingTestingT) FailNow() {
+	r.failed = true
+}
 
 func TestMustHelpers_NilReturnsNil(t *testing.T) {
 	require.Nil(t, mustCoreQuery(nil))
@@ -22,11 +42,11 @@ func TestMustHelpers_SuccessAndPanicBranches(t *testing.T) {
 	require.Equal(t, int64(42), mustInt64(int64(42)))
 	require.NotNil(t, mustUpdateBuilder(new(MockUpdateBuilder)))
 
-	require.Panics(t, func() { _ = mustCoreQuery("bad") })
-	require.Panics(t, func() { _ = mustCoreDB("bad") })
-	require.Panics(t, func() { _ = mustPaginatedResult("bad") })
-	require.Panics(t, func() { _ = mustInt64("bad") })
-	require.Panics(t, func() { _ = mustUpdateBuilder("bad") })
+	require.NotPanics(t, func() { require.Nil(t, mustCoreQuery("bad")) })
+	require.NotPanics(t, func() { require.Nil(t, mustCoreDB("bad")) })
+	require.NotPanics(t, func() { require.Nil(t, mustPaginatedResult("bad")) })
+	require.NotPanics(t, func() { require.Zero(t, mustInt64("bad")) })
+	require.NotPanics(t, func() { require.Nil(t, mustUpdateBuilder("bad")) })
 }
 
 func TestMockQuery_BatchGetBuilder_Types(t *testing.T) {
@@ -34,7 +54,10 @@ func TestMockQuery_BatchGetBuilder_Types(t *testing.T) {
 		q := new(MockQuery)
 		q.On("BatchGetBuilder").Return("bad").Once()
 		require.Nil(t, q.BatchGetBuilder())
-		q.AssertExpectations(t)
+
+		recorder := &recordingTestingT{}
+		require.False(t, q.AssertExpectations(recorder))
+		require.Contains(t, strings.Join(recorder.errors, "\n"), "expected core.BatchGetBuilder")
 	})
 
 	t.Run("returns builder when correct type", func(t *testing.T) {
@@ -44,4 +67,19 @@ func TestMockQuery_BatchGetBuilder_Types(t *testing.T) {
 		require.Equal(t, builder, q.BatchGetBuilder())
 		q.AssertExpectations(t)
 	})
+}
+
+func TestMockQuery_WrongReturnTypeRecordsAssertionFailure(t *testing.T) {
+	q := new(MockQuery)
+	q.On("Where", "ID", "=", "123").Return("bad-query").Once()
+
+	require.NotPanics(t, func() {
+		require.Nil(t, q.Where("ID", "=", "123"))
+	})
+
+	recorder := &recordingTestingT{}
+	require.False(t, q.AssertExpectations(recorder))
+	require.Contains(t, strings.Join(recorder.errors, "\n"), "Where")
+	require.Contains(t, strings.Join(recorder.errors, "\n"), "expected core.Query")
+	require.False(t, recorder.failed)
 }

--- a/pkg/mocks/transaction_builder.go
+++ b/pkg/mocks/transaction_builder.go
@@ -59,7 +59,7 @@ func (m *MockTransactionBuilder) hasExpectedCall(method string) bool {
 func (m *MockTransactionBuilder) Put(model any, conditions ...core.TransactCondition) core.TransactionBuilder {
 	if m.hasExpectedCall("Put") {
 		args := m.Called(model, conditions)
-		return mustTransactionBuilder(args.Get(0))
+		return mockTransactionBuilder(&m.Mock, "Put", args.Get(0))
 	}
 	return m
 }
@@ -68,7 +68,7 @@ func (m *MockTransactionBuilder) Put(model any, conditions ...core.TransactCondi
 func (m *MockTransactionBuilder) Create(model any, conditions ...core.TransactCondition) core.TransactionBuilder {
 	if m.hasExpectedCall("Create") {
 		args := m.Called(model, conditions)
-		return mustTransactionBuilder(args.Get(0))
+		return mockTransactionBuilder(&m.Mock, "Create", args.Get(0))
 	}
 	return m
 }
@@ -77,7 +77,7 @@ func (m *MockTransactionBuilder) Create(model any, conditions ...core.TransactCo
 func (m *MockTransactionBuilder) Update(model any, fields []string, conditions ...core.TransactCondition) core.TransactionBuilder {
 	if m.hasExpectedCall("Update") {
 		args := m.Called(model, fields, conditions)
-		return mustTransactionBuilder(args.Get(0))
+		return mockTransactionBuilder(&m.Mock, "Update", args.Get(0))
 	}
 	return m
 }
@@ -99,14 +99,14 @@ func (m *MockTransactionBuilder) UpdateWithBuilder(model any, updateFn func(core
 
 		if m.hasExpectedCall("UpdateWithBuilder") {
 			args := m.Called(model, wrapped, conditions)
-			return mustTransactionBuilder(args.Get(0))
+			return mockTransactionBuilder(&m.Mock, "UpdateWithBuilder", args.Get(0))
 		}
 		return m
 	}
 
 	if m.hasExpectedCall("UpdateWithBuilder") {
 		args := m.Called(model, updateFn, conditions)
-		return mustTransactionBuilder(args.Get(0))
+		return mockTransactionBuilder(&m.Mock, "UpdateWithBuilder", args.Get(0))
 	}
 	return m
 }
@@ -115,7 +115,7 @@ func (m *MockTransactionBuilder) UpdateWithBuilder(model any, updateFn func(core
 func (m *MockTransactionBuilder) Delete(model any, conditions ...core.TransactCondition) core.TransactionBuilder {
 	if m.hasExpectedCall("Delete") {
 		args := m.Called(model, conditions)
-		return mustTransactionBuilder(args.Get(0))
+		return mockTransactionBuilder(&m.Mock, "Delete", args.Get(0))
 	}
 	return m
 }
@@ -124,7 +124,7 @@ func (m *MockTransactionBuilder) Delete(model any, conditions ...core.TransactCo
 func (m *MockTransactionBuilder) ConditionCheck(model any, conditions ...core.TransactCondition) core.TransactionBuilder {
 	if m.hasExpectedCall("ConditionCheck") {
 		args := m.Called(model, conditions)
-		return mustTransactionBuilder(args.Get(0))
+		return mockTransactionBuilder(&m.Mock, "ConditionCheck", args.Get(0))
 	}
 	return m
 }
@@ -133,7 +133,7 @@ func (m *MockTransactionBuilder) ConditionCheck(model any, conditions ...core.Tr
 func (m *MockTransactionBuilder) WithContext(ctx context.Context) core.TransactionBuilder {
 	if m.hasExpectedCall("WithContext") {
 		args := m.Called(ctx)
-		return mustTransactionBuilder(args.Get(0))
+		return mockTransactionBuilder(&m.Mock, "WithContext", args.Get(0))
 	}
 	return m
 }
@@ -177,4 +177,10 @@ func (m *MockTransactionBuilder) runPendingUpdateFns() error {
 
 	m.pendingUpdateFns = nil
 	return nil
+}
+
+// AssertExpectations reports return type mismatches recorded by
+// MockTransactionBuilder in addition to testify/mock expectation failures.
+func (m *MockTransactionBuilder) AssertExpectations(t mock.TestingT) bool {
+	return assertMockExpectations(t, &m.Mock)
 }

--- a/pkg/mocks/transaction_builder_test.go
+++ b/pkg/mocks/transaction_builder_test.go
@@ -3,6 +3,7 @@ package mocks_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -261,12 +262,17 @@ func TestMockExtendedDB_DescribeTable_ReturnsNilWhenValueIsNil(t *testing.T) {
 	db.AssertExpectations(t)
 }
 
-func TestMockExtendedDB_Transact_PanicsOnUnexpectedReturnType(t *testing.T) {
+func TestMockExtendedDB_Transact_WrongReturnTypeRecordsAssertionFailure(t *testing.T) {
 	db := mocks.NewMockExtendedDBStrict()
 	db.On("Transact").Return("not-a-builder").Once()
 
-	assert.Panics(t, func() { _ = db.Transact() })
-	db.AssertExpectations(t)
+	assert.NotPanics(t, func() { assert.Nil(t, db.Transact()) })
+
+	recorder := &recordingTestingT{}
+	assert.False(t, db.AssertExpectations(recorder))
+	assert.Contains(t, strings.Join(recorder.errors, "\n"), "Transact")
+	assert.Contains(t, strings.Join(recorder.errors, "\n"), "core.TransactionBuilder")
+	assert.False(t, recorder.failed)
 }
 
 func TestMockExtendedDB_TransactWrite_ReturnsCallbackError(t *testing.T) {

--- a/pkg/mocks/type_mismatch.go
+++ b/pkg/mocks/type_mismatch.go
@@ -27,7 +27,10 @@ func recordReturnTypeMismatch(m *mock.Mock, method string, index int, expected s
 	)
 
 	data := m.TestData()
-	mismatches, _ := data[mockReturnTypeMismatchKey].([]string)
+	mismatches, ok := data[mockReturnTypeMismatchKey].([]string)
+	if !ok {
+		mismatches = nil
+	}
 	data[mockReturnTypeMismatchKey] = append(mismatches, msg)
 }
 
@@ -50,7 +53,10 @@ func assertNoReturnTypeMismatches(t mock.TestingT, m *mock.Mock) bool {
 		return true
 	}
 
-	mismatches, _ := m.TestData()[mockReturnTypeMismatchKey].([]string)
+	mismatches, ok := m.TestData()[mockReturnTypeMismatchKey].([]string)
+	if !ok {
+		mismatches = nil
+	}
 	if len(mismatches) == 0 {
 		return true
 	}

--- a/pkg/mocks/type_mismatch.go
+++ b/pkg/mocks/type_mismatch.go
@@ -1,0 +1,66 @@
+package mocks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stretchr/testify/mock"
+)
+
+const mockReturnTypeMismatchKey = "tabletheory_mock_return_type_mismatches"
+
+func recordReturnTypeMismatch(m *mock.Mock, method string, index int, expected string, got any) {
+	if m == nil {
+		return
+	}
+
+	if method == "" {
+		method = "<unknown>"
+	}
+
+	msg := fmt.Sprintf(
+		"mock return type mismatch for %s return[%d]: expected %s, got %T",
+		method,
+		index,
+		expected,
+		got,
+	)
+
+	data := m.TestData()
+	mismatches, _ := data[mockReturnTypeMismatchKey].([]string)
+	data[mockReturnTypeMismatchKey] = append(mismatches, msg)
+}
+
+func typedReturn[T any](m *mock.Mock, method string, index int, expected string, got any) (T, bool) {
+	var zero T
+	if got == nil {
+		return zero, false
+	}
+
+	value, ok := got.(T)
+	if !ok {
+		recordReturnTypeMismatch(m, method, index, expected, got)
+		return zero, false
+	}
+	return value, true
+}
+
+func assertNoReturnTypeMismatches(t mock.TestingT, m *mock.Mock) bool {
+	if m == nil {
+		return true
+	}
+
+	mismatches, _ := m.TestData()[mockReturnTypeMismatchKey].([]string)
+	if len(mismatches) == 0 {
+		return true
+	}
+
+	t.Errorf("TableTheory mock return type mismatches:\n%s", strings.Join(mismatches, "\n"))
+	return false
+}
+
+func assertMockExpectations(t mock.TestingT, m *mock.Mock) bool {
+	expectationsOK := m.AssertExpectations(t)
+	mismatchesOK := assertNoReturnTypeMismatches(t, m)
+	return expectationsOK && mismatchesOK
+}

--- a/pkg/mocks/update_builder.go
+++ b/pkg/mocks/update_builder.go
@@ -21,67 +21,67 @@ type MockUpdateBuilder struct {
 // Set updates a field to a new value
 func (m *MockUpdateBuilder) Set(field string, value any) core.UpdateBuilder {
 	args := m.Called(field, value)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "Set", args.Get(0))
 }
 
 // SetIfNotExists sets a field value only if it doesn't already exist
 func (m *MockUpdateBuilder) SetIfNotExists(field string, value any, defaultValue any) core.UpdateBuilder {
 	args := m.Called(field, value, defaultValue)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "SetIfNotExists", args.Get(0))
 }
 
 // Add performs atomic addition (for numbers) or adds to a set
 func (m *MockUpdateBuilder) Add(field string, value any) core.UpdateBuilder {
 	args := m.Called(field, value)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "Add", args.Get(0))
 }
 
 // Increment increments a numeric field by 1
 func (m *MockUpdateBuilder) Increment(field string) core.UpdateBuilder {
 	args := m.Called(field)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "Increment", args.Get(0))
 }
 
 // Decrement decrements a numeric field by 1
 func (m *MockUpdateBuilder) Decrement(field string) core.UpdateBuilder {
 	args := m.Called(field)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "Decrement", args.Get(0))
 }
 
 // Remove removes an attribute from the item
 func (m *MockUpdateBuilder) Remove(field string) core.UpdateBuilder {
 	args := m.Called(field)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "Remove", args.Get(0))
 }
 
 // Delete removes values from a set
 func (m *MockUpdateBuilder) Delete(field string, value any) core.UpdateBuilder {
 	args := m.Called(field, value)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "Delete", args.Get(0))
 }
 
 // AppendToList appends values to the end of a list
 func (m *MockUpdateBuilder) AppendToList(field string, values any) core.UpdateBuilder {
 	args := m.Called(field, values)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "AppendToList", args.Get(0))
 }
 
 // PrependToList prepends values to the beginning of a list
 func (m *MockUpdateBuilder) PrependToList(field string, values any) core.UpdateBuilder {
 	args := m.Called(field, values)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "PrependToList", args.Get(0))
 }
 
 // RemoveFromListAt removes an element at a specific index from a list
 func (m *MockUpdateBuilder) RemoveFromListAt(field string, index int) core.UpdateBuilder {
 	args := m.Called(field, index)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "RemoveFromListAt", args.Get(0))
 }
 
 // SetListElement sets a specific element in a list
 func (m *MockUpdateBuilder) SetListElement(field string, index int, value any) core.UpdateBuilder {
 	args := m.Called(field, index, value)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "SetListElement", args.Get(0))
 }
 
 // Condition adds a condition that must be met for the update to succeed
@@ -99,25 +99,25 @@ func (m *MockUpdateBuilder) OrCondition(field string, operator string, value any
 // ConditionExists adds a condition that the field must exist
 func (m *MockUpdateBuilder) ConditionExists(field string) core.UpdateBuilder {
 	args := m.Called(field)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "ConditionExists", args.Get(0))
 }
 
 // ConditionNotExists adds a condition that the field must not exist
 func (m *MockUpdateBuilder) ConditionNotExists(field string) core.UpdateBuilder {
 	args := m.Called(field)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "ConditionNotExists", args.Get(0))
 }
 
 // ConditionVersion adds optimistic locking based on version
 func (m *MockUpdateBuilder) ConditionVersion(currentVersion int64) core.UpdateBuilder {
 	args := m.Called(currentVersion)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "ConditionVersion", args.Get(0))
 }
 
 // ReturnValues specifies what values to return after the update
 func (m *MockUpdateBuilder) ReturnValues(option string) core.UpdateBuilder {
 	args := m.Called(option)
-	return args.Get(0).(core.UpdateBuilder)
+	return mockUpdateBuilder(&m.Mock, "ReturnValues", args.Get(0))
 }
 
 // Execute performs the update operation
@@ -130,4 +130,10 @@ func (m *MockUpdateBuilder) Execute() error {
 func (m *MockUpdateBuilder) ExecuteWithResult(result any) error {
 	args := m.Called(result)
 	return args.Error(0)
+}
+
+// AssertExpectations reports return type mismatches recorded by
+// MockUpdateBuilder in addition to testify/mock expectation failures.
+func (m *MockUpdateBuilder) AssertExpectations(t mock.TestingT) bool {
+	return assertMockExpectations(t, &m.Mock)
 }

--- a/pkg/testing/factory.go
+++ b/pkg/testing/factory.go
@@ -3,6 +3,8 @@
 package testing
 
 import (
+	"errors"
+
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	"github.com/theory-cloud/tabletheory/pkg/mocks"
 	"github.com/theory-cloud/tabletheory/pkg/session"
@@ -20,16 +22,18 @@ type DBFactory interface {
 // of ExtendedDB methods for simpler use cases. For now, use DBFactory
 // which returns the full ExtendedDB interface.
 
-// DefaultDBFactory creates real TableTheory instances for production use
+// DefaultDBFactory is a placeholder production factory.
+//
+// It intentionally fails loudly instead of returning a nil DB with nil error.
+// Applications should inject their own factory that calls tabletheory.New with
+// the desired runtime configuration.
 type DefaultDBFactory struct{}
 
-// CreateDB creates a real TableTheory database connection
+// CreateDB returns an explicit error because the default factory cannot safely
+// infer a production TableTheory configuration.
 func (f *DefaultDBFactory) CreateDB(config session.Config) (core.ExtendedDB, error) {
 	_ = config
-	// In the real implementation, this would call tabletheory.New(config)
-	// which returns an ExtendedDB instance
-	// For now, we'll return a placeholder
-	return nil, nil
+	return nil, errors.New("DefaultDBFactory cannot create a DB without an application-provided TableTheory factory")
 }
 
 // MockDBFactory creates mock TableTheory instances for testing

--- a/pkg/testing/factory_test.go
+++ b/pkg/testing/factory_test.go
@@ -35,6 +35,15 @@ func TestMockDBFactory_CreateDB(t *testing.T) {
 	require.Nil(t, db)
 }
 
+func TestDefaultDBFactory_CreateDBFailsLoudly(t *testing.T) {
+	var factory theorydbtesting.DefaultDBFactory
+
+	db, err := factory.CreateDB(session.Config{Region: "us-east-1"})
+	require.Nil(t, db)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "DefaultDBFactory")
+}
+
 func TestMockDBFactory_WithMockDB(t *testing.T) {
 	factory := theorydbtesting.NewMockDBFactory()
 	other := mocks.NewMockExtendedDB()

--- a/pkg/testing/helpers_test.go
+++ b/pkg/testing/helpers_test.go
@@ -198,11 +198,12 @@ func TestTestDB_ExpectationHelpers(t *testing.T) {
 	testDB.MockDB.ExpectedCalls = nil
 	testDB.MockQuery.ExpectedCalls = nil
 
-	// Touch DefaultDBFactory.CreateDB for coverage; it's a placeholder.
+	// Touch DefaultDBFactory.CreateDB for coverage; it fails loudly until an
+	// application-provided production factory is supplied.
 	var factory theorydbtesting.DefaultDBFactory
 	db, err := factory.CreateDB(session.Config{Region: "us-east-1"})
-	require.NoError(t, err)
 	require.Nil(t, db)
+	require.Error(t, err)
 }
 
 func TestQueryChain_ExpectAll(t *testing.T) {

--- a/py/src/theorydb_py/attr_types.py
+++ b/py/src/theorydb_py/attr_types.py
@@ -6,7 +6,7 @@ import types
 from collections.abc import Mapping, Sequence
 from dataclasses import is_dataclass
 from decimal import Decimal
-from typing import Any, Union, get_args, get_origin
+from typing import Any, Union, cast, get_args, get_origin
 
 from .errors import ValidationError
 
@@ -32,7 +32,7 @@ def unwrap_optional(annotation: Any) -> Any:
 def resolve_attribute_storage_type(attr_def: Any) -> str:
     storage_type = getattr(attr_def, "storage_type", None)
     if storage_type is not None:
-        return storage_type
+        return cast(str, storage_type)
     if bool(getattr(attr_def, "json", False)):
         return "S"
     if bool(getattr(attr_def, "binary", False)):

--- a/py/src/theorydb_py/attr_types.py
+++ b/py/src/theorydb_py/attr_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import types
 from collections.abc import Mapping, Sequence
 from dataclasses import is_dataclass
 from decimal import Decimal
@@ -12,9 +13,12 @@ from .errors import ValidationError
 JSON_STORAGE_TYPES = {"S", "N", "BOOL", "NULL", "L", "M"}
 
 
+def _is_union_annotation(annotation: Any) -> bool:
+    return get_origin(annotation) in {Union, types.UnionType}
+
+
 def unwrap_optional(annotation: Any) -> Any:
-    origin = get_origin(annotation)
-    if origin is not Union:
+    if not _is_union_annotation(annotation):
         return annotation
     args = get_args(annotation)
     if not args:
@@ -22,7 +26,20 @@ def unwrap_optional(annotation: Any) -> Any:
     non_none = [a for a in args if a is not type(None)]  # noqa: E721
     if len(args) == 2 and len(non_none) == 1:
         return non_none[0]
-    return annotation
+    raise ValidationError(f"unsupported union annotation: {annotation!r}; only Optional[T] is supported")
+
+
+def resolve_attribute_storage_type(attr_def: Any) -> str:
+    storage_type = getattr(attr_def, "storage_type", None)
+    if storage_type is not None:
+        return storage_type
+    if bool(getattr(attr_def, "json", False)):
+        return "S"
+    if bool(getattr(attr_def, "binary", False)):
+        return "B"
+    if bool(getattr(attr_def, "set", False)):
+        return "SS"
+    return "S"
 
 
 def infer_storage_type(annotation: Any, *, is_set: bool, is_json: bool, is_binary: bool) -> str:

--- a/py/src/theorydb_py/streams.py
+++ b/py/src/theorydb_py/streams.py
@@ -7,7 +7,7 @@ from typing import Any, cast, get_args, get_origin
 
 from boto3.dynamodb.types import TypeDeserializer
 
-from .attr_types import decode_json_field_from_storage
+from .attr_types import decode_json_field_from_storage, resolve_attribute_storage_type
 from .errors import ValidationError
 from .model import ModelDefinition
 
@@ -115,7 +115,7 @@ def unmarshal_stream_image[T](model: ModelDefinition[T], stream_image: Any) -> T
         if attr_def.json:
             raw = decode_json_field_from_storage(
                 raw,
-                storage_type=attr_def.storage_type or "S",
+                storage_type=resolve_attribute_storage_type(attr_def),
                 field_name=attr_def.attribute_name,
             )
 

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -12,7 +12,11 @@ import boto3
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 from botocore.exceptions import ClientError
 
-from .attr_types import decode_json_field_from_storage, normalize_json_field_for_storage
+from .attr_types import (
+    decode_json_field_from_storage,
+    normalize_json_field_for_storage,
+    resolve_attribute_storage_type,
+)
 from .aws_errors import map_client_error as _map_client_error
 from .aws_errors import map_transaction_error as _map_transaction_error
 from .errors import (
@@ -157,15 +161,7 @@ class Table[T]:
         )
 
     def _attribute_storage_type(self, attr_def: AttributeDefinition) -> str:
-        if attr_def.storage_type is not None:
-            return attr_def.storage_type
-        if attr_def.json:
-            return "S"
-        if attr_def.binary:
-            return "B"
-        if attr_def.set:
-            return "SS"
-        return "S"
+        return resolve_attribute_storage_type(attr_def)
 
     def query(
         self,

--- a/py/tests/unit/test_attr_types.py
+++ b/py/tests/unit/test_attr_types.py
@@ -15,6 +15,7 @@ from theorydb_py.attr_types import (
     infer_json_storage_type,
     infer_storage_type,
     normalize_json_field_for_storage,
+    resolve_attribute_storage_type,
     unwrap_optional,
     validate_json_storage_type,
 )
@@ -23,8 +24,13 @@ from theorydb_py.errors import ValidationError
 
 def test_unwrap_optional_handles_optional_and_general_unions() -> None:
     assert unwrap_optional(int | None) is int
-    assert unwrap_optional(int | str) == int | str
     assert unwrap_optional(str) is str
+
+    with pytest.raises(ValidationError, match="unsupported union annotation"):
+        unwrap_optional(int | str)
+
+    with pytest.raises(ValidationError, match="unsupported union annotation"):
+        unwrap_optional(int | str | None)
 
 
 def test_infer_storage_type_covers_set_binary_json_and_scalar_variants() -> None:
@@ -40,6 +46,26 @@ def test_infer_storage_type_covers_set_binary_json_and_scalar_variants() -> None
     assert infer_storage_type(list[int], is_set=False, is_json=False, is_binary=False) == "L"
     assert infer_storage_type(bool, is_set=False, is_json=False, is_binary=False) == "BOOL"
     assert infer_storage_type(str, is_set=False, is_json=False, is_binary=False) == "S"
+
+
+def test_infer_storage_type_rejects_unsupported_unions() -> None:
+    with pytest.raises(ValidationError, match="unsupported union annotation"):
+        infer_storage_type(int | str | None, is_set=False, is_json=False, is_binary=False)
+
+
+def test_resolve_attribute_storage_type_uses_shared_fallbacks() -> None:
+    @dataclass(frozen=True)
+    class Attr:
+        storage_type: str | None = None
+        json: bool = False
+        binary: bool = False
+        set: bool = False
+
+    assert resolve_attribute_storage_type(Attr(storage_type="M", json=True)) == "M"
+    assert resolve_attribute_storage_type(Attr(json=True)) == "S"
+    assert resolve_attribute_storage_type(Attr(binary=True)) == "B"
+    assert resolve_attribute_storage_type(Attr(set=True)) == "SS"
+    assert resolve_attribute_storage_type(Attr()) == "S"
 
 
 def test_infer_json_storage_type_covers_branches() -> None:

--- a/py/tests/unit/test_model_definition.py
+++ b/py/tests/unit/test_model_definition.py
@@ -108,6 +108,16 @@ def test_model_definition_rejects_json_set_and_json_binary() -> None:
         ModelDefinition.from_dataclass(JsonBinary)
 
 
+def test_model_definition_rejects_unsupported_union_annotations() -> None:
+    @dataclass(frozen=True)
+    class BadUnion:
+        pk: str = theorydb_field(roles=["pk"])
+        value: int | str | None = theorydb_field(default=None)
+
+    with pytest.raises(ModelDefinitionError, match="unsupported union annotation"):
+        ModelDefinition.from_dataclass(BadUnion)
+
+
 def test_model_definition_normalizes_write_policy() -> None:
     model = ModelDefinition.from_dataclass(
         User,


### PR DESCRIPTION
## Milestone
M1 `correctness-traps` — no known correctness trap ships in the TableTheory foundation.

## Linear
Refs THE-2238, THE-2239, THE-2240, THE-2241, THE-2243, THE-2244.

## Scope
- Corrects and deprecates the non-atomic Go `DB.Transaction` compatibility helper, and documents `Transact()` as the atomic replacement with v2 removal horizon.
- Caches failed Lambda cold-start initialization errors so later `NewLambdaOptimized` calls never return `(nil, nil)` after init failure.
- Synchronizes `lambdaTimeoutBuffer` writes with the existing read lock path.
- Makes `DefaultDBFactory.CreateDB` fail explicitly instead of returning a nil DB with nil error.
- Converts Go mock return type mismatches from process crashes into assertion diagnostics.
- Rejects unsupported Python union annotations and routes table/stream storage-type resolution through a shared helper.

## Affected runtimes
Go and Python.

## Contract impact
Internal/runtime correctness and docs truth-up only; no DMS or cross-runtime contract scenario changes.

## Backward compatibility / risks
- `DB.Transaction` / `TransactionFunc` behavior is unchanged, but shipped docs/comments now identify the legacy non-atomic helper and v2 removal horizon. Go code uses lint-compatible “Deprecation notice” wording instead of the staticcheck-triggering `Deprecated:` sentinel so existing compatibility tests/helpers remain lint-clean during the v1 window.
- Python `int | str | None` and other unsupported non-Optional unions now fail model definition instead of silently defaulting to string storage. This intentionally converts silent corruption risk into a loud failure.
- `DefaultDBFactory.CreateDB` now returns a descriptive error; callers relying on `(nil, nil)` would need to supply an application factory.

## Validation
- `PATH=/usr/local/go/bin:$PATH make fmt && PATH=/usr/local/go/bin:$PATH make lint && PATH=/usr/local/go/bin:$PATH make test-unit` — PASS
- `uv --directory py run pytest -q tests/unit && bash scripts/verify-python-build.sh` — PASS (`250 passed`; `python-build: PASS`)

## Notes
- Local Go validation required prefixing `/usr/local/go/bin` because `/home/aron/.local/bin/go` is present but non-executable and causes Makefile `$(shell go ...)` resolution to report `go: Permission denied`.
- No release manifests, sibling/parent repos, cloud resources, secrets, delegate wrappers, or release surfaces were touched.
