### PR TITLE
fix(lambda): synchronize timeout buffer reads

### DIFF
--- a/internal/theorydb/lambda_cov6_test.go
+++ b/internal/theorydb/lambda_cov6_test.go
@@ -332,6 +332,89 @@ func TestLambdaDB_OptimizeForMemorySynchronizesTimeoutBufferWithLambdaTimeout_CO
 	wg.Wait()
 }
 
+func TestLambdaDB_OptimizeForMemorySynchronizesTimeoutBufferWithDBTimeout_COV6(t *testing.T) {
+	db := &DB{}
+	ldb := &LambdaDB{
+		ExtendedDB:     db,
+		db:             db,
+		modelCache:     &sync.Map{},
+		lambdaMemoryMB: 1024,
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+	t.Cleanup(cancel)
+
+	const workers = 8
+	const iterations = 100
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				ldb.OptimizeForMemory()
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				gotAny := db.WithLambdaTimeout(ctx)
+				got, ok := gotAny.(*DB)
+				if !ok || got == nil {
+					t.Errorf("WithLambdaTimeout returned %T", gotAny)
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}
+
+func TestLambdaDB_OptimizeForMemorySynchronizesTimeoutBufferWithQueryTimeoutCheck_COV6(t *testing.T) {
+	db := &DB{lambdaDeadline: time.Now().Add(30 * time.Second)}
+	ldb := &LambdaDB{
+		ExtendedDB:     db,
+		db:             db,
+		modelCache:     &sync.Map{},
+		lambdaMemoryMB: 1024,
+	}
+
+	const workers = 8
+	const iterations = 100
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				ldb.OptimizeForMemory()
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				if err := (&queryExecutor{db: db}).checkLambdaTimeout(); err != nil {
+					t.Errorf("checkLambdaTimeout returned unexpected error: %v", err)
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}
+
 func TestLambdaDB_WithLambdaTimeoutConfig_NonPositiveBufferUsesDefault_COV6(t *testing.T) {
 	db := &DB{}
 	ldb := &LambdaDB{ExtendedDB: db, db: db, modelCache: &sync.Map{}}

--- a/internal/theorydb/query_executor.go
+++ b/internal/theorydb/query_executor.go
@@ -48,16 +48,24 @@ func (qe *queryExecutor) ctxOrBackground() context.Context {
 }
 
 func (qe *queryExecutor) checkLambdaTimeout() error {
-	if qe == nil || qe.db == nil || qe.db.lambdaDeadline.IsZero() {
+	if qe == nil || qe.db == nil {
 		return nil
 	}
 
-	remaining := time.Until(qe.db.lambdaDeadline)
+	qe.db.mu.RLock()
+	deadline := qe.db.lambdaDeadline
+	buffer := qe.db.lambdaTimeoutBuffer
+	qe.db.mu.RUnlock()
+
+	if deadline.IsZero() {
+		return nil
+	}
+
+	remaining := time.Until(deadline)
 	if remaining <= 0 {
 		return fmt.Errorf("lambda timeout exceeded")
 	}
 
-	buffer := qe.db.lambdaTimeoutBuffer
 	if buffer == 0 {
 		buffer = 100 * time.Millisecond
 	}

--- a/internal/theorydb/theorydb.go
+++ b/internal/theorydb/theorydb.go
@@ -450,6 +450,9 @@ func (db *DB) WithLambdaTimeout(ctx context.Context) core.DB {
 		return db
 	}
 
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
 	// Leave a buffer for Lambda cleanup. Store the hard Lambda deadline and
 	// the effective buffer separately so query execution applies the stop
 	// window exactly once.
@@ -457,9 +460,6 @@ func (db *DB) WithLambdaTimeout(ctx context.Context) core.DB {
 	if buffer == 0 {
 		buffer = 500 * time.Millisecond // Default buffer
 	}
-
-	db.mu.RLock()
-	defer db.mu.RUnlock()
 
 	newDB := &DB{
 		session:             db.session,


### PR DESCRIPTION
## Summary
- Synchronize `DB.WithLambdaTimeout` reads of `lambdaTimeoutBuffer` under the DB mutex.
- Snapshot `checkLambdaTimeout` deadline/buffer state under the same mutex before evaluating timeout windows.
- Extend Lambda race coverage for `OptimizeForMemory` concurrent with plain `DB.WithLambdaTimeout` and query timeout checks.

## Linear
- THE-2514 — https://linear.app/theorycloud/issue/THE-2514/tt-fast-follow-close-remaining-lambdatimeoutbuffer-unlocked-reads

## Validation
- `PATH=/usr/local/go/bin:$PATH make fmt` — pass
- `PATH=/usr/local/go/bin:$PATH go test -race ./internal/theorydb -run 'Lambda|Timeout|OptimizeForMemory'` — pass (`ok github.com/theory-cloud/tabletheory/internal/theorydb 1.033s`)
- `PATH=/usr/local/go/bin:$PATH make lint` — pass (`0 issues.`)
- `PATH=/usr/local/go/bin:$PATH make test-unit` — pass

## Notes
- No public API changes.
- No docs-truth, release, cloud/account, or cross-repo changes.
- The two residual production reads live in `internal/theorydb/theorydb.go` and `internal/theorydb/query_executor.go`; tests are in `internal/theorydb/lambda_cov6_test.go`.