### PR TITLE
docs: truth up M2 published docs and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Unsure where to begin? Look for these labels:
 
 2. **Set Up Your Development Environment**
    ```bash
-   # Install Go 1.21 or later
+   # Install the Go toolchain pinned by go.mod (`go1.26.4`)
    # https://golang.org/doc/install
 
    # Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 # TableTheory Makefile
 
+SHELL := /bin/bash
+
 .PHONY: all build test test-unit unit-cover clean lint fmt fmt-check docker-up docker-down docker-clean integration benchmark stress test-all verify-coverage verify-go-modules verify-ci-toolchain verify-planning-docs sec rubric stage-theorycloud-tabletheory-subtree verify-theorycloud-tabletheory-subtree sync-theorycloud-tabletheory-subtree trigger-theorycloud-publish
 
 # Variables
 GOMOD := github.com/theory-cloud/tabletheory
 TOOLCHAIN := $(shell awk '/^toolchain / {print $$2}' go.mod | head -n 1)
 export GOTOOLCHAIN ?= $(TOOLCHAIN)
-GO_BIN_DIR := $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
+GO_ENV_GOBIN := $(shell go env GOBIN 2>/dev/null)
+GO_ENV_GOPATH := $(shell go env GOPATH 2>/dev/null)
+GO_BIN_DIR := $(if $(GO_ENV_GOBIN),$(GO_ENV_GOBIN),$(GO_ENV_GOPATH)/bin)
 GOLANGCI_LINT := $(GO_BIN_DIR)/golangci-lint
 UNIT_PACKAGES := $(shell go list ./... | grep -v /vendor/ | grep -v /node_modules/ | grep -v /examples/ | grep -v /tests/stress | grep -v /tests/integration)
 ALL_PACKAGES := $(shell go list ./... | grep -v /vendor/ | grep -v /node_modules/ | grep -v /examples/ | grep -v /tests/stress)

--- a/docs/_decisions.yaml
+++ b/docs/_decisions.yaml
@@ -7,7 +7,7 @@ decisions:
     decision_tree:
       - condition: "Your service/runtime is Go"
         choice: "Use the Go SDK (this repo root module)"
-        reason: "First-class Go API with generics, query builder, and Lambda optimizations"
+        reason: "First-class Go API with reflection-backed model validation, query builder, and Lambda optimizations"
       - condition: "Your service/runtime is Node.js/TypeScript"
         choice: "Use the TypeScript SDK (`ts/`)"
         reason: "First-class Node.js 24 support with strict testkit and cross-language cursor contracts"

--- a/docs/cdk/README.md
+++ b/docs/cdk/README.md
@@ -256,10 +256,9 @@ myFunction.addEnvironment('AWS_REGION', Stack.of(this).region);
 myFunction.addEnvironment('RATE_LIMIT_TABLE_NAME', rateLimitTable.tableName);
 myFunction.addEnvironment('IDEMPOTENCY_TABLE_NAME', idempotencyTable.tableName);
 
-// Optional TableTheory configuration
-myFunction.addEnvironment('DYNAMORM_DEBUG', 'false');
-myFunction.addEnvironment('DYNAMORM_RETRY_MAX_ATTEMPTS', '3');
-myFunction.addEnvironment('DYNAMORM_RETRY_BASE_DELAY', '100'); // milliseconds
+// TableTheory uses the standard AWS SDK/Lambda environment.
+// Configure TableTheory-specific retry or endpoint options in Go with
+// tabletheory.Config when constructing the DB.
 ```
 
 ### Lambda Handler Setup
@@ -269,29 +268,28 @@ package main
 
 import (
     "context"
-    "os"
+    "log"
+    "time"
     
     "github.com/aws/aws-lambda-go/lambda"
     "github.com/theory-cloud/tabletheory"
-    "github.com/theory-cloud/tabletheory/pkg/protection"
     "github.com/theory-cloud/limited"
 )
 
 var (
-    db *tabletheory.DB
+    db *tabletheory.LambdaDB
     rateLimiter *limited.Limiter
 )
 
 func init() {
-    // Initialize TableTheory with Lambda optimizations
-    db = tabletheory.New(
-        tabletheory.WithLambdaOptimizations(),
-        tabletheory.WithRetryPolicy(3, 100), // 3 retries, 100ms base delay
+    var err error
+    db, err = tabletheory.LambdaInit(
+        &RateLimitRecord{},
+        &IdempotencyRecord{},
     )
-    
-    // Register models
-    db.RegisterModel(&RateLimitRecord{})
-    db.RegisterModel(&IdempotencyRecord{})
+    if err != nil {
+        log.Fatalf("initialize TableTheory: %v", err)
+    }
     
     // Initialize Limited library with TableTheory backend
     rateLimiter = limited.New(
@@ -365,15 +363,15 @@ import (
     "fmt"
     "time"
     
-    "github.com/theory-cloud/tabletheory"
+    "github.com/theory-cloud/tabletheory/pkg/core"
     "github.com/theory-cloud/limited"
 )
 
 type TableTheoryBackend struct {
-    db *tabletheory.DB
+    db core.DB
 }
 
-func NewTableTheoryBackend(db *tabletheory.DB) *TableTheoryBackend {
+func NewTableTheoryBackend(db core.DB) *TableTheoryBackend {
     return &TableTheoryBackend{db: db}
 }
 
@@ -477,14 +475,14 @@ import (
     "fmt"
     "time"
     
-    "github.com/theory-cloud/tabletheory"
+    "github.com/theory-cloud/tabletheory/pkg/core"
 )
 
 type RateLimitService struct {
-    db *tabletheory.DB
+    db core.DB
 }
 
-func NewRateLimitService(db *tabletheory.DB) *RateLimitService {
+func NewRateLimitService(db core.DB) *RateLimitService {
     return &RateLimitService{db: db}
 }
 
@@ -549,14 +547,14 @@ import (
     "time"
     
     "github.com/google/uuid"
-    "github.com/theory-cloud/tabletheory"
+    "github.com/theory-cloud/tabletheory/pkg/core"
 )
 
 type IdempotencyService struct {
-    db *tabletheory.DB
+    db core.DB
 }
 
-func NewIdempotencyService(db *tabletheory.DB) *IdempotencyService {
+func NewIdempotencyService(db core.DB) *IdempotencyService {
     return &IdempotencyService{db: db}
 }
 
@@ -723,14 +721,17 @@ TableTheory is flexible with existing data:
 
 ### Performance Optimization
 
-1. **Use Lambda Optimizations**:
+1. **Initialize once during Lambda cold start**:
    ```go
-   db := tabletheory.New(tabletheory.WithLambdaOptimizations())
+   db, err := tabletheory.LambdaInit(&RateLimitRecord{}, &IdempotencyRecord{})
+   if err != nil {
+       return err
+   }
    ```
 
 2. **Batch Operations**: Use batch methods for multiple items
    ```go
-   db.Model(&RateLimitRecord{}).BatchCreate(ctx, records)
+   err := db.Model(&RateLimitRecord{}).BatchCreate(records)
    ```
 
 3. **Projection Optimization**: Only fetch needed attributes

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -235,7 +235,7 @@ TableTheory is designed to provide significant business value by improving devel
 ### Developer Efficiency & Team Velocity
 
 - **Reduced Boilerplate:** TableTheory eliminates approximately **80% of the boilerplate code** typically required for DynamoDB interactions with the raw AWS SDK. This frees developers to focus on business logic.
-- **Type Safety:** Compile-time type safety with Go generics prevents common runtime errors, leading to fewer bugs and faster development cycles.
+- **Model-aware validation:** Go struct types, `theorydb` tags, and runtime model validation keep marshaling predictable without claiming a generic or compile-time field-name API that does not exist yet.
 - **Intuitive API:** The fluent, chainable API makes code more readable and easier to maintain, reducing the learning curve for new team members.
 
 ### Performance & Reliability
@@ -255,7 +255,7 @@ TableTheory is designed to provide significant business value by improving devel
 TableTheory is ideal for:
 
 - **Serverless Backends:** Building highly scalable and performant APIs with AWS Lambda and API Gateway.
-- **Event-Driven Architectures:** Processing DynamoDB Streams with type-safe model transformations.
+- **Event-Driven Architectures:** Processing DynamoDB Streams with struct-based model transformations.
 - **High-Throughput Microservices:** Services requiring fast, efficient interactions with DynamoDB.
 - **Financial & Critical Systems:** Leveraging atomic transactions for data consistency.
 - **Real-time Data Processing:** Applications needing low-latency access to DynamoDB data.

--- a/docs/development/planning/tabletheory-improvement-program-scoped-need-2026-07.md
+++ b/docs/development/planning/tabletheory-improvement-program-scoped-need-2026-07.md
@@ -63,7 +63,7 @@ Parity fills decided in scope: native `count()` (Select=COUNT), `get_or_none`/op
 ## Success criteria (observable)
 
 1. All four correctness traps have failing-before/passing-after tests; `DB.Transaction` doc no longer claims atomicity; Lambda init returns the cached error on every post-failure invocation (unit-testable); `-race` clean on the Lambda paths.
-2. A TS consumer gets compile errors for a typo'd field name in `filter()`/`.set()` against a `defineModel` schema; a Go consumer can write `ModelOf[User](db).All()` with no `any` and no reflection error path; mypy flags a typo'd Python role constant.
+2. A TS consumer gets compile errors for a typo'd field name in `filter()`/`.set()` against a `defineModel` schema; a Go consumer can use a future `ModelOf[User]` handle bound to `db` with no `any` and no reflection error path; mypy flags a typo'd Python role constant.
 3. `contract-tests/scenarios/` contains query/GSI/projection/pagination scenarios executed by all three runners; a non-integer number and an `NS`/`BS`/`B`/`BOOL`/`NULL`/`L` round-trip are asserted cross-runtime; `item_equals` and `cursor_equals` exist and are used; the Python KEY-M1 evaluator passes the shared fixture file; an item encrypted by Go is decrypted by TS and Py in a scenario run.
 4. `tabletheory init` produces a directory that reaches a successful CRUD write against DynamoDB Local in one documented command per language; `tabletheory gen` emits Go/TS/Py models from a DMS file that pass the equivalence gates; the hand-written contract models are deleted in favor of generated ones.
 5. `pip install` works on Python 3.12; `require()` works on Node 20; `import tabletheory_py` works with a deprecation-free path and `import theorydb_py` warns.

--- a/docs/development/planning/tabletheory-product-improvement-assessment-2026-07.md
+++ b/docs/development/planning/tabletheory-product-improvement-assessment-2026-07.md
@@ -79,7 +79,7 @@ All three runtimes expose dynamically-typed surfaces in languages whose ecosyste
 - Stringly-typed operators: `Where(field, op string, value any)` with validity decided at execution by a runtime switch (`internal/expr/builder.go:583-691`). Exported typed operator constants (or `.WhereBeginsWith(...)`-style methods) move typos to compile time. `BETWEEN` requiring `value` as `[]any{lo, hi}` (`builder.go:626-635`) deserves a two-argument form.
 - Field references are Go field names as strings; a struct rename silently breaks queries.
 
-**Recommendation:** an additive generic layer — `tabletheory.ModelOf[T](db)` returning `Query[T]` with `First() (T, error)` / `All() ([]T, error)`, typed operator constants, concrete option types. Existing `any` API stays for compatibility.
+**Recommendation:** an additive generic layer — a `tabletheory.ModelOf` handle parameterized by `T` and bound to `db`, returning `Query[T]` with `First() (T, error)` / `All() ([]T, error)`, typed operator constants, concrete option types. Existing `any` API stays for compatibility.
 
 ### II.2 TypeScript: `defineModel` erases the type it just described
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ For the multi-language monorepo:
 
 **Required:**
 
-- Go 1.25 or higher
+- Go toolchain `go1.26.4` (the pinned toolchain in the root `go.mod`)
 - AWS Credentials configured (or IAM role in Lambda)
 - Basic understanding of DynamoDB (Primary Keys, Tables)
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -13,7 +13,7 @@ TheoryCloud TableTheory subtree. This page is the Go migration guide.
 
 **Problem:** Directly using the AWS SDK for Go v2 for DynamoDB operations often leads to verbose code, manual attribute marshaling, and lacks type safety. It also requires explicit context management for every call.
 
-**Solution:** Replace direct SDK calls with TableTheory's fluent, type-safe API. TableTheory handles marshaling/unmarshaling, context propagation, and error handling automatically.
+**Solution:** Replace direct SDK calls with TableTheory's fluent, model-aware API. TableTheory handles marshaling/unmarshaling, context propagation, and error handling automatically; field-name and operator mistakes are still validated by the runtime rather than by a Go generic compile-time layer.
 
 ### Example: Creating an Item
 

--- a/docs/runtimes/python.md
+++ b/docs/runtimes/python.md
@@ -59,17 +59,17 @@ For a complete working program, see [`py/docs/getting-started.md`](https://githu
 
 `theorydb_field(roles=[…], encrypted=…, omitempty=…)` maps one-to-one onto the canonical TableTheory contract:
 
-| Go tag                       | Python field arg                          |
-|------------------------------|-------------------------------------------|
-| `theorydb:"pk"`              | `theorydb_field(roles=["pk"])`            |
-| `theorydb:"sk"`              | `theorydb_field(roles=["sk"])`            |
-| `theorydb:"gsi1pk"`          | `theorydb_field(roles=["gsi1pk"])`        |
-| `theorydb:"encrypted"`       | `theorydb_field(encrypted=True)`          |
-| `theorydb:"version"`         | `theorydb_field(roles=["version"])`       |
-| `theorydb:"created_at"`      | `theorydb_field(roles=["created_at"])`    |
-| `theorydb:"updated_at"`      | `theorydb_field(roles=["updated_at"])`    |
-| `theorydb:"ttl"`             | `theorydb_field(roles=["ttl"])`           |
-| `theorydb:"omitempty"`       | `theorydb_field(omitempty=True)`         |
+| Go tag                  | Python field arg                       |
+| ----------------------- | -------------------------------------- |
+| `theorydb:"pk"`         | `theorydb_field(roles=["pk"])`         |
+| `theorydb:"sk"`         | `theorydb_field(roles=["sk"])`         |
+| `theorydb:"gsi1pk"`     | `theorydb_field(roles=["gsi1pk"])`     |
+| `theorydb:"encrypted"`  | `theorydb_field(encrypted=True)`       |
+| `theorydb:"version"`    | `theorydb_field(roles=["version"])`    |
+| `theorydb:"created_at"` | `theorydb_field(roles=["created_at"])` |
+| `theorydb:"updated_at"` | `theorydb_field(roles=["updated_at"])` |
+| `theorydb:"ttl"`        | `theorydb_field(roles=["ttl"])`        |
+| `theorydb:"omitempty"`  | `theorydb_field(omitempty=True)`       |
 
 ## CRUD methods
 
@@ -85,6 +85,14 @@ table.delete(pk, sk)
 # Composite updates use update_builder for set/remove/add chains.
 table.update_builder(pk, sk).set("body", "updated").execute()
 ```
+
+## Aggregation helper warning
+
+Python aggregation helpers (`sum_field`, `average_field`, `min_field`, `max_field`, `aggregate_field`, `count_distinct`,
+and `group_by`) are client-side conveniences over already materialized sequences. If those sequences come from
+`query_all`, `scan_all`, or `scan_all_segments`, the runtime has loaded every matching item into memory before computing
+the result. Use them only for bounded result sets. When the planned native `count()` API lands, use it instead for
+count-only access patterns.
 
 ## Workflows
 

--- a/docs/runtimes/typescript.md
+++ b/docs/runtimes/typescript.md
@@ -30,36 +30,36 @@ The single distribution path is deliberate — it makes version drift between la
 The TypeScript public surface is **explicit**: models are declared via `defineModel({ … })` (no decorators), and operations run through a `TheorydbClient` instance.
 
 ```typescript
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { TheorydbClient, defineModel } from '@theory-cloud/tabletheory-ts';
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { TheorydbClient, defineModel } from "@theory-cloud/tabletheory-ts";
 
 const Note = defineModel({
-  name: 'Note',
-  table: { name: 'notes_contract' },
+  name: "Note",
+  table: { name: "notes_contract" },
   keys: {
-    partition: { attribute: 'PK', type: 'S' },
-    sort:      { attribute: 'SK', type: 'S' },
+    partition: { attribute: "PK", type: "S" },
+    sort: { attribute: "SK", type: "S" },
   },
   attributes: [
-    { attribute: 'PK',        type: 'S', roles: ['pk'] },
-    { attribute: 'SK',        type: 'S', roles: ['sk'] },
-    { attribute: 'body',      type: 'S', optional: true, omit_empty: true },
-    { attribute: 'createdAt', type: 'S', roles: ['created_at'] },
-    { attribute: 'updatedAt', type: 'S', roles: ['updated_at'] },
-    { attribute: 'version',   type: 'N', roles: ['version'] },
+    { attribute: "PK", type: "S", roles: ["pk"] },
+    { attribute: "SK", type: "S", roles: ["sk"] },
+    { attribute: "body", type: "S", optional: true, omit_empty: true },
+    { attribute: "createdAt", type: "S", roles: ["created_at"] },
+    { attribute: "updatedAt", type: "S", roles: ["updated_at"] },
+    { attribute: "version", type: "N", roles: ["version"] },
   ],
 });
 
-const ddb = new DynamoDBClient({ region: 'us-east-1' });
-const db  = new TheorydbClient(ddb).register(Note);
+const ddb = new DynamoDBClient({ region: "us-east-1" });
+const db = new TheorydbClient(ddb).register(Note);
 
-await db.create('Note', {
-  PK:   'USER#42',
-  SK:   'NOTE#welcome',
-  body: 'Hello, Theory Cloud.',
+await db.create("Note", {
+  PK: "USER#42",
+  SK: "NOTE#welcome",
+  body: "Hello, Theory Cloud.",
 });
 
-const item = await db.get('Note', { PK: 'USER#42', SK: 'NOTE#welcome' });
+const item = await db.get("Note", { PK: "USER#42", SK: "NOTE#welcome" });
 ```
 
 For a complete working program (model + GSI + create + query + update + delete + cursor pagination), see [`ts/examples/local.ts`](https://github.com/theory-cloud/tabletheory/blob/main/ts/examples/local.ts).
@@ -68,17 +68,17 @@ For a complete working program (model + GSI + create + query + update + delete +
 
 Every `role` accepted by `defineModel` attributes maps one-to-one onto the canonical TableTheory contract:
 
-| Go tag                       | TypeScript role / option                    |
-|------------------------------|---------------------------------------------|
-| `theorydb:"pk"`              | `roles: ['pk']`                             |
-| `theorydb:"sk"`              | `roles: ['sk']`                             |
-| `theorydb:"gsi1pk"`          | `roles: ['gsi1pk']` + `indexes:`            |
-| `theorydb:"encrypted"`       | `encryption: { v: 1 }`                      |
-| `theorydb:"version"`         | `roles: ['version']`                        |
-| `theorydb:"created_at"`      | `roles: ['created_at']`                     |
-| `theorydb:"updated_at"`      | `roles: ['updated_at']`                     |
-| `theorydb:"ttl"`             | `roles: ['ttl']`                            |
-| `theorydb:"omitempty"`       | `omit_empty: true`                          |
+| Go tag                  | TypeScript role / option         |
+| ----------------------- | -------------------------------- |
+| `theorydb:"pk"`         | `roles: ['pk']`                  |
+| `theorydb:"sk"`         | `roles: ['sk']`                  |
+| `theorydb:"gsi1pk"`     | `roles: ['gsi1pk']` + `indexes:` |
+| `theorydb:"encrypted"`  | `encryption: { v: 1 }`           |
+| `theorydb:"version"`    | `roles: ['version']`             |
+| `theorydb:"created_at"` | `roles: ['created_at']`          |
+| `theorydb:"updated_at"` | `roles: ['updated_at']`          |
+| `theorydb:"ttl"`        | `roles: ['ttl']`                 |
+| `theorydb:"omitempty"`  | `omit_empty: true`               |
 
 Naming strategy is implied by how you declare each attribute's name — the explicit shape of `defineModel` means no separate "naming strategy" decoration is needed.
 
@@ -94,6 +94,13 @@ await db.delete('Note', key);
 
 const page = await db.query('Note').partitionKey('USER#42').limit(20).page();
 ```
+
+## Aggregation helper warning
+
+TypeScript aggregation helpers (`sum`, `average`, `min`, `max`, `aggregate`, `countDistinct`, and `groupBy`) are
+client-side conveniences over `all()`. They follow every page and materialize every matching item in memory before
+computing the result. Use them only for bounded result sets. When the planned native `count()` API lands, use it instead
+for count-only access patterns.
 
 ## Workflows
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -105,7 +105,7 @@ example-name/
 
 ### Prerequisites
 ```bash
-# Install Go 1.21+
+# Install the Go toolchain pinned by the root go.mod (`go1.26.4`)
 go version
 
 # Install Docker for DynamoDB Local
@@ -113,24 +113,24 @@ docker --version
 
 # Clone the repository
 git clone https://github.com/theory-cloud/tabletheory
-cd theorydb/examples
+cd tabletheory/examples
 ```
 
-### Quick Start Any Example
+### Quick Start Any Basic Example
 ```bash
-# Navigate to any example
-cd basic/todo
+# Navigate to a basic example
+cd basic/todo  # or basic/notes, basic/contacts
 
 # Start DynamoDB Local
 make docker-up
 
-# Run the application
+# Run the CLI application
 make run
 
-# Run tests
+# Run compile/unit checks for the example module
 make test
 
-# Clean up
+# Clean up local DynamoDB state
 make docker-down
 ```
 
@@ -237,15 +237,20 @@ func TestTodoService_CreateTodo(t *testing.T) {
 ### Lambda Patterns
 ```go
 // From lambda/ - Proper Lambda initialization
-var db *tabletheory.DB
+var db *tabletheory.LambdaDB
 
 func init() {
-    db = tabletheory.New(tabletheory.WithLambdaOptimizations())
+    var err error
+    db, err = tabletheory.NewLambdaOptimized()
+    if err != nil {
+        panic(err)
+    }
 }
 
 func handler(ctx context.Context, event events.APIGatewayProxyRequest) {
-    // Use pre-initialized connection
-    return handleRequest(db, event)
+    // Derive an invocation-scoped DB that respects the Lambda deadline.
+    lambdaDB := db.WithLambdaTimeout(ctx)
+    return handleRequest(lambdaDB, event)
 }
 ```
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -91,7 +91,7 @@ service.GetUserContacts("user123")                // Uses main table
 
 ### Prerequisites
 ```bash
-# Ensure you have Go 1.21+
+# Ensure you have the root-pinned Go toolchain (`go1.26.4`)
 go version
 
 # Ensure you have Docker for DynamoDB Local
@@ -106,13 +106,13 @@ cd basic/todo  # or notes/ or contacts/
 # Start DynamoDB Local
 make docker-up
 
-# Create tables and run the application
+# Run the CLI application; it creates its table on startup
 make run
 
 # Run comprehensive tests
 make test
 
-# Stop DynamoDB Local
+# Stop DynamoDB Local and discard in-memory state
 make docker-down
 ```
 

--- a/examples/basic/contacts/Makefile
+++ b/examples/basic/contacts/Makefile
@@ -1,0 +1,37 @@
+SHELL := /bin/bash
+ROOT_GOTOOLCHAIN := $(shell awk '/^toolchain /{print $$2; exit}' ../../../go.mod)
+GO_ENV := AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy AWS_REGION=us-east-1 DYNAMODB_ENDPOINT=http://localhost:8000 GOTOOLCHAIN=$(ROOT_GOTOOLCHAIN)
+COMPOSE ?= docker compose
+
+.PHONY: docker-up docker-down run test fmt lint coverage dev-setup dev setup tables-create tables-delete clean
+
+run:
+	$(GO_ENV) go run .
+
+test:
+	$(GO_ENV) go test ./...
+
+fmt:
+	gofmt -w .
+
+lint:
+	$(GO_ENV) go vet ./...
+
+coverage:
+	$(GO_ENV) go test ./... -coverprofile=coverage.out
+
+setup tables-create:
+	@echo "Tables are created by the example on startup."
+
+dev-setup: docker-up setup
+
+dev: run
+
+docker-up:
+	$(COMPOSE) up -d
+
+docker-down clean:
+	$(COMPOSE) down
+
+tables-delete:
+	@echo "DynamoDB Local is in-memory; use 'make docker-down' to discard local example state."

--- a/examples/basic/contacts/Makefile
+++ b/examples/basic/contacts/Makefile
@@ -28,7 +28,11 @@ dev-setup: docker-up setup
 dev: run
 
 docker-up:
-	$(COMPOSE) up -d
+	@if curl -sS --max-time 2 -o /dev/null http://localhost:8000; then \
+		echo "DynamoDB Local already available at http://localhost:8000"; \
+	else \
+		$(COMPOSE) up -d; \
+	fi
 
 docker-down clean:
 	$(COMPOSE) down

--- a/examples/basic/contacts/main.go
+++ b/examples/basic/contacts/main.go
@@ -22,28 +22,28 @@ import (
 // Contact represents a contact with composite keys for organization
 type Contact struct {
 	// Composite primary key: OrgID#ContactID
-	ID string `theorydb:"pk"`
+	ID string `theorydb:"pk" json:"id"`
 
 	// Organization ID (extracted from composite key)
-	OrgID string
+	OrgID string `json:"org_id"`
 
 	// Contact's unique ID
-	ContactID string
+	ContactID string `json:"contact_id"`
 
 	// GSI for searching by email across all orgs
-	Email string `theorydb:"index:gsi-email,pk;required"`
+	Email string `theorydb:"index:gsi-email,pk" json:"email"`
 
 	// GSI for searching by phone
-	Phone string `theorydb:"index:gsi-phone,pk"`
+	Phone string `theorydb:"index:gsi-phone,pk" json:"phone"`
 
 	// Contact details
-	FirstName string `theorydb:"required"`
-	LastName  string `theorydb:"required"`
-	Company   string
-	JobTitle  string
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Company   string `json:"company"`
+	JobTitle  string `json:"job_title"`
 
 	// GSI for full name search (LastName#FirstName)
-	FullName string `theorydb:"index:gsi-name,pk"`
+	FullName string `theorydb:"index:gsi-name,pk" json:"full_name"`
 
 	// Address information
 	Address struct {
@@ -55,17 +55,17 @@ type Contact struct {
 	}
 
 	// Contact metadata
-	Tags       []string `theorydb:"set"`
-	Notes      string
-	IsFavorite bool
+	Tags       []string `theorydb:"set" json:"tags"`
+	Notes      string   `json:"notes"`
+	IsFavorite bool     `json:"is_favorite"`
 
 	// Timestamps
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
-	LastContactedAt *time.Time
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	LastContactedAt *time.Time `json:"last_contacted_at,omitempty"`
 
 	// Custom fields as a map
-	CustomFields map[string]string
+	CustomFields map[string]string `json:"custom_fields,omitempty"`
 }
 
 // ContactsApp manages contact operations

--- a/examples/basic/notes/Makefile
+++ b/examples/basic/notes/Makefile
@@ -1,0 +1,37 @@
+SHELL := /bin/bash
+ROOT_GOTOOLCHAIN := $(shell awk '/^toolchain /{print $$2; exit}' ../../../go.mod)
+GO_ENV := AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy AWS_REGION=us-east-1 DYNAMODB_ENDPOINT=http://localhost:8000 GOTOOLCHAIN=$(ROOT_GOTOOLCHAIN)
+COMPOSE ?= docker compose
+
+.PHONY: docker-up docker-down run test fmt lint coverage dev-setup dev setup tables-create tables-delete clean
+
+run:
+	$(GO_ENV) go run .
+
+test:
+	$(GO_ENV) go test ./...
+
+fmt:
+	gofmt -w .
+
+lint:
+	$(GO_ENV) go vet ./...
+
+coverage:
+	$(GO_ENV) go test ./... -coverprofile=coverage.out
+
+setup tables-create:
+	@echo "Tables are created by the example on startup."
+
+dev-setup: docker-up setup
+
+dev: run
+
+docker-up:
+	$(COMPOSE) up -d
+
+docker-down clean:
+	$(COMPOSE) down
+
+tables-delete:
+	@echo "DynamoDB Local is in-memory; use 'make docker-down' to discard local example state."

--- a/examples/basic/notes/Makefile
+++ b/examples/basic/notes/Makefile
@@ -28,7 +28,11 @@ dev-setup: docker-up setup
 dev: run
 
 docker-up:
-	$(COMPOSE) up -d
+	@if curl -sS --max-time 2 -o /dev/null http://localhost:8000; then \
+		echo "DynamoDB Local already available at http://localhost:8000"; \
+	else \
+		$(COMPOSE) up -d; \
+	fi
 
 docker-down clean:
 	$(COMPOSE) down

--- a/examples/basic/notes/main.go
+++ b/examples/basic/notes/main.go
@@ -23,28 +23,28 @@ import (
 // This example adds indexes and more complex data types
 type Note struct {
 	// Primary key
-	ID string `theorydb:"pk"`
+	ID string `theorydb:"pk" json:"id"`
 
 	// Global Secondary Index for querying by user
-	UserID string `theorydb:"index:gsi-user,pk"`
+	UserID string `theorydb:"index:gsi-user,pk" json:"user_id"`
 
 	// Required fields
-	Title   string `theorydb:"required"`
-	Content string `theorydb:"required"`
+	Title   string `json:"title"`
+	Content string `json:"content"`
 
 	// Tags demonstrate working with sets
-	Tags []string `theorydb:"set"`
+	Tags []string `theorydb:"set" json:"tags"`
 
 	// Category for another index
-	Category string `theorydb:"index:gsi-category,pk"`
+	Category string `theorydb:"index:gsi-category,pk" json:"category"`
 
 	// Timestamps with index on CreatedAt for time-based queries
-	CreatedAt time.Time `theorydb:"index:gsi-user,sk"`
-	UpdatedAt time.Time
+	CreatedAt time.Time `theorydb:"index:gsi-user,sk" json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 
 	// Additional metadata
-	WordCount int
-	IsPinned  bool
+	WordCount int  `json:"word_count"`
+	IsPinned  bool `json:"is_pinned"`
 }
 
 // NotesApp manages note operations

--- a/examples/basic/todo/Makefile
+++ b/examples/basic/todo/Makefile
@@ -1,0 +1,37 @@
+SHELL := /bin/bash
+ROOT_GOTOOLCHAIN := $(shell awk '/^toolchain /{print $$2; exit}' ../../../go.mod)
+GO_ENV := AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy AWS_REGION=us-east-1 DYNAMODB_ENDPOINT=http://localhost:8000 GOTOOLCHAIN=$(ROOT_GOTOOLCHAIN)
+COMPOSE ?= docker compose
+
+.PHONY: docker-up docker-down run test fmt lint coverage dev-setup dev setup tables-create tables-delete clean
+
+run:
+	$(GO_ENV) go run .
+
+test:
+	$(GO_ENV) go test ./...
+
+fmt:
+	gofmt -w .
+
+lint:
+	$(GO_ENV) go vet ./...
+
+coverage:
+	$(GO_ENV) go test ./... -coverprofile=coverage.out
+
+setup tables-create:
+	@echo "Tables are created by the example on startup."
+
+dev-setup: docker-up setup
+
+dev: run
+
+docker-up:
+	$(COMPOSE) up -d
+
+docker-down clean:
+	$(COMPOSE) down
+
+tables-delete:
+	@echo "DynamoDB Local is in-memory; use 'make docker-down' to discard local example state."

--- a/examples/basic/todo/Makefile
+++ b/examples/basic/todo/Makefile
@@ -28,7 +28,11 @@ dev-setup: docker-up setup
 dev: run
 
 docker-up:
-	$(COMPOSE) up -d
+	@if curl -sS --max-time 2 -o /dev/null http://localhost:8000; then \
+		echo "DynamoDB Local already available at http://localhost:8000"; \
+	else \
+		$(COMPOSE) up -d; \
+	fi
 
 docker-down clean:
 	$(COMPOSE) down

--- a/examples/basic/todo/README.md
+++ b/examples/basic/todo/README.md
@@ -47,7 +47,7 @@ type Todo struct {
 
 ### Prerequisites
 ```bash
-# Ensure Go 1.21+
+# Ensure the root-pinned Go toolchain (`go1.26.4`)
 go version
 
 # Ensure Docker for DynamoDB Local
@@ -58,18 +58,13 @@ docker --version
 ```bash
 # Clone and navigate
 git clone https://github.com/theory-cloud/tabletheory
-cd theorydb/examples/basic/todo
+cd tabletheory/examples/basic/todo
 
 # Start DynamoDB Local
 make docker-up
 
-# Run the application
+# Run the interactive CLI application
 make run
-
-# In another terminal, test the API
-curl -X POST http://localhost:8080/todos \
-  -H "Content-Type: application/json" \
-  -d '{"title": "Learn TableTheory"}'
 
 # Run tests
 make test

--- a/examples/basic/todo/main.go
+++ b/examples/basic/todo/main.go
@@ -23,19 +23,19 @@ import (
 // This is the simplest possible TableTheory model
 type Todo struct {
 	// ID is our primary key - every DynamoDB item needs one
-	ID string `theorydb:"pk"`
+	ID string `theorydb:"pk" json:"id"`
 
-	// Title is required - we use the required tag to ensure it's not empty
-	Title string `theorydb:"required"`
+	// Title is validated in application code before writes.
+	Title string `json:"title"`
 
 	// Completed tracks whether the task is done
-	Completed bool
+	Completed bool `json:"completed"`
 
 	// CreatedAt helps us sort todos by creation time
-	CreatedAt time.Time
+	CreatedAt time.Time `json:"created_at"`
 
 	// UpdatedAt tracks when the todo was last modified
-	UpdatedAt time.Time
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // TodoApp manages our todo list operations
@@ -89,7 +89,7 @@ func (app *TodoApp) Create(title string) (*Todo, error) {
 	}
 
 	// Save to DynamoDB
-	// The Create method validates required fields and saves the item
+	// Application validation should run before saving required business fields.
 	if err := app.db.Model(todo).Create(); err != nil {
 		return nil, fmt.Errorf("failed to create todo: %v", err)
 	}

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -56,7 +56,7 @@ This example demonstrates how to build a modern blog platform using TableTheory 
 ## Quick Start
 
 ### Prerequisites
-- Go 1.21+
+- Go toolchain `go1.26.4`
 - AWS CLI configured
 - Docker (for local DynamoDB)
 

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -58,7 +58,7 @@ PK: org#123#resource#abc    SK: 2024-01-15T10:00:00Z
 ## Quick Start
 
 ### Prerequisites
-- Go 1.21+
+- Go toolchain `go1.26.4`
 - AWS CLI configured
 - Docker (for local DynamoDB)
 - Stripe account (for billing)

--- a/py/docs/api-reference.md
+++ b/py/docs/api-reference.md
@@ -15,6 +15,8 @@ from theorydb_py import (
     check_lambda_timeout,
     with_lambda_timeout,
 )
+from theorydb_py import TransactConditionCheck, TransactDelete, TransactPut, TransactUpdate
+from theorydb_py import UpdateAdd, UpdateSetIfNotExists
 from theorydb_py.mocks import FakeDynamoDBClient, FakeKmsClient
 ```
 
@@ -22,7 +24,7 @@ from theorydb_py.mocks import FakeDynamoDBClient, FakeKmsClient
 
 ### `theorydb_field(...)`
 
-Declares attribute metadata for dataclass fields (roles, omitempty, encryption, etc.).
+Declares attribute metadata for dataclass fields (roles, omitempty, encryption, defaults, converters, etc.).
 
 ### `ModelDefinition.from_dataclass(dataclass_type, table_name=...)`
 
@@ -30,20 +32,85 @@ Builds a model definition from a dataclass and a table name.
 
 ## Table
 
-### `Table(model, client, *, kms_key_arn=None, kms_client=None, rand_bytes=None, now=None)`
+### `Table(model, *, client=None, table_name=None, kms_key_arn=None, kms_client=None, rand_bytes=None, now=None)`
 
-Primary entrypoint for operations.
+Primary entrypoint for operations. `client` is a boto3-compatible DynamoDB client; when omitted, `Table` constructs one
+with `boto3.client("dynamodb")`. If any model attribute is encrypted, construction fails closed unless `kms_key_arn` is
+provided.
 
-Common operations:
-- `put(item, *, if_not_exists=False, condition_expression=None, ...)`
-- `get(pk, sk, *, consistent_read=False)`
-- `update(pk, sk, updates, *, expected_version=None, ...)`
-- `delete(pk, sk, *, condition_expression=None, ...)`
-- `query(pk, *, sort=None, limit=None, cursor=None)`
-- `batch_get(keys, *, consistent_read=False)`
-- `batch_write(puts=None, deletes=None)`
-- `transact_write(operations)`
-- `with_lambda_timeout(context, *, buffer_seconds=DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS)`
+### CRUD
+
+Actual signatures:
+
+- `put(item, *, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None) -> None`
+- `save(item, *, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None) -> None`
+- `get(pk, sk=None, *, consistent_read=False) -> T`
+- `update(pk, sk, updates, *, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, protected_attributes=(), expected_version=None) -> T`
+- `delete(pk, sk=None, *, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None) -> None`
+- `update_builder(pk, sk=None) -> UpdateBuilder[T]`
+
+Notes:
+
+- `put` does **not** accept an `if_not_exists` parameter. Use a `condition_expression` when a one-off condition is needed;
+  write-once/protected models add their create-if-absent condition automatically.
+- `save` is a mutable-model convenience wrapper around `put` and rejects write-once/protected overwrite paths.
+- `update` accepts a mapping of field names to values. Use `UpdateAdd(...)` or `UpdateSetIfNotExists(...)` inside the
+  mapping for DynamoDB `ADD` and `if_not_exists` update expressions.
+
+## Query and scan
+
+### `query(partition, *, sort=None, index_name=None, limit=None, cursor=None, scan_forward=True, consistent_read=False, projection=None, filter=None) -> Page[T]`
+
+All query parameters are listed above:
+
+- `partition`: required partition-key value
+- `sort`: optional `SortKeyCondition`
+- `index_name`: optional GSI/LSI name
+- `limit`: DynamoDB page limit; must be greater than zero when provided
+- `cursor`: opaque cursor returned as `Page.next_cursor`
+- `scan_forward`: `True` for ascending sort-key order, `False` for descending
+- `consistent_read`: defaults to `False`; rejected for GSIs
+- `projection`: optional list of projected attribute names
+- `filter`: optional `FilterExpression`
+
+### `query_all(...) -> list[T]`
+
+Accepts the same query parameters and follows cursors until exhaustion. It materializes every matching item into a Python
+list; prefer page-by-page `query` calls for large partitions.
+
+### `query_with_retry(..., max_retries=5, initial_delay_seconds=0.1, max_delay_seconds=5.0, backoff_factor=2.0, retry_on_empty=True, retry_on_error=True, verify=None, sleep=time.sleep) -> Page[T]`
+
+Retries query pages for eventually consistent reads or custom `verify` checks. Lambda timeout errors are not swallowed.
+
+### `scan(*, index_name=None, limit=None, cursor=None, consistent_read=False, projection=None, filter=None, segment=None, total_segments=None) -> Page[T]`
+
+Runs a DynamoDB Scan and returns a page with `items` and `next_cursor`.
+
+### `scan_all(...) -> list[T]`
+
+Accepts the same scan parameters and follows cursors until exhaustion. It materializes every scanned item into a Python
+list; prefer page-by-page `scan` calls for large tables.
+
+### `scan_all_segments(*, total_segments, index_name=None, limit=None, consistent_read=False, projection=None, filter=None, max_workers=None) -> list[T]`
+
+Runs a parallel scan across `total_segments` and materializes the combined result list.
+
+## Batch + transactions
+
+Actual signatures and defaults:
+
+- `batch_get(keys, *, consistent_read=False, projection=None, max_retries=5, sleep=time.sleep) -> list[T]`
+- `batch_write(*, puts=(), deletes=(), max_retries=5, sleep=time.sleep) -> None`
+- `transact_write(actions) -> None`
+
+`transact_write(actions)` accepts a sequence of dataclass actions:
+
+- `TransactPut(item, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None)`
+- `TransactUpdate(pk, sk, updates, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, protected_attributes=())`
+- `TransactDelete(pk, sk=None, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None)`
+- `TransactConditionCheck(pk, sk, condition_expression, expression_attribute_names=None, expression_attribute_values=None)`
+
+The Python runtime rejects an empty action list and more than 100 actions before submitting to DynamoDB.
 
 ## Lambda runtime helpers
 
@@ -89,7 +156,8 @@ def handler(event: dict, context: object) -> dict:
 
 ## Pagination
 
-Query returns a page object with `items` and `next_cursor` (opaque token). Pass `next_cursor` back into the next call.
+Query and scan methods return a page object with `items` and `next_cursor` (opaque token). Pass `next_cursor` back into
+the next call.
 
 ## Streams
 

--- a/py/docs/api-reference.md
+++ b/py/docs/api-reference.md
@@ -17,6 +17,7 @@ from theorydb_py import (
 )
 from theorydb_py import TransactConditionCheck, TransactDelete, TransactPut, TransactUpdate
 from theorydb_py import UpdateAdd, UpdateSetIfNotExists
+from theorydb_py import aggregate_field, average_field, count_distinct, group_by, max_field, min_field, sum_field
 from theorydb_py.mocks import FakeDynamoDBClient, FakeKmsClient
 ```
 
@@ -94,6 +95,22 @@ list; prefer page-by-page `scan` calls for large tables.
 ### `scan_all_segments(*, total_segments, index_name=None, limit=None, consistent_read=False, projection=None, filter=None, max_workers=None) -> list[T]`
 
 Runs a parallel scan across `total_segments` and materializes the combined result list.
+
+## Client-side aggregation helpers
+
+The Python package exports client-side helpers:
+
+- `sum_field(items, field)`
+- `average_field(items, field)`
+- `min_field(items, field)`
+- `max_field(items, field)`
+- `aggregate_field(items, field=None)`
+- `count_distinct(items, field)`
+- `group_by(items, field).count(alias).sum(field, alias).avg(field, alias).min(field, alias).max(field, alias).execute()`
+
+These helpers operate on an already materialized Python sequence. If the input came from `query_all`, `scan_all`, or
+`scan_all_segments`, every matching item is already resident in memory. Use only for bounded result sets. There is no
+native server-side `count()` in this release; when the planned native `count()` API lands, prefer it for count-only paths.
 
 ## Batch + transactions
 

--- a/py/docs/core-patterns.md
+++ b/py/docs/core-patterns.md
@@ -46,6 +46,13 @@ page2 = table.query("A", cursor=page1.next_cursor) if page1.next_cursor else Non
 table.batch_write(puts=[Note(pk="A", sk="2", value=1)], deletes=[("A", "1")])
 ```
 
+## Pattern: Aggregations are client-side
+
+`sum_field`, `average_field`, `min_field`, `max_field`, `aggregate_field`, `count_distinct`, and `group_by(...).execute()`
+operate on an already materialized Python sequence. If that sequence came from `query_all`, `scan_all`, or
+`scan_all_segments`, every matching item is already in memory. Use these helpers only for bounded result sets. When the
+planned native `count()` API lands, prefer it for count-only paths.
+
 ## Pattern: Streams unmarshalling
 
 ```python

--- a/py/docs/getting-started.md
+++ b/py/docs/getting-started.md
@@ -83,7 +83,7 @@ table.delete("NOTE#1", "v1")
 
 ## Next Steps
 
+- Use [API Reference](./api-reference.md) for exact signatures; for example, `put` uses condition-expression kwargs rather than `if_not_exists`, and `transact_write` takes an `actions` sequence.
 - Read [Core Patterns](./core-patterns.md) for cursor pagination, batch, transactions, streams, and encryption.
 - Use [Testing Guide](./testing-guide.md) for strict fakes and deterministic encryption tests.
-- Use [API Reference](./api-reference.md) when you need signature-level detail.
 

--- a/py/src/theorydb_py/aggregates.py
+++ b/py/src/theorydb_py/aggregates.py
@@ -1,3 +1,10 @@
+"""Client-side aggregation helpers over already materialized Python sequences.
+
+These helpers do not issue DynamoDB server-side aggregate requests. When used after
+``Table.query_all`` or ``Table.scan_all``, the full result set is already resident
+in memory; use them only for bounded result sets.
+"""
+
 from __future__ import annotations
 
 import math
@@ -42,6 +49,8 @@ class _HavingClause:
 
 
 class GroupByQuery[T]:
+    """Client-side group-by; stores the full source sequence and grouped items in memory."""
+
     def __init__(self, items: Sequence[T], group_by_field: str) -> None:
         self._items = list(items)
         self._group_by = group_by_field
@@ -49,30 +58,37 @@ class GroupByQuery[T]:
         self._having: list[_HavingClause] = []
 
     def count(self, alias: str) -> GroupByQuery[T]:
+        """Add a count aggregate computed in memory after the source sequence is materialized."""
         self._aggregates.append(_AggregateOp(function="COUNT", field="*", alias=alias))
         return self
 
     def sum(self, field: str, alias: str) -> GroupByQuery[T]:
+        """Add a sum aggregate computed in memory after the source sequence is materialized."""
         self._aggregates.append(_AggregateOp(function="SUM", field=field, alias=alias))
         return self
 
     def avg(self, field: str, alias: str) -> GroupByQuery[T]:
+        """Add an average aggregate computed in memory after the source sequence is materialized."""
         self._aggregates.append(_AggregateOp(function="AVG", field=field, alias=alias))
         return self
 
     def min(self, field: str, alias: str) -> GroupByQuery[T]:
+        """Add a minimum aggregate computed in memory after the source sequence is materialized."""
         self._aggregates.append(_AggregateOp(function="MIN", field=field, alias=alias))
         return self
 
     def max(self, field: str, alias: str) -> GroupByQuery[T]:
+        """Add a maximum aggregate computed in memory after the source sequence is materialized."""
         self._aggregates.append(_AggregateOp(function="MAX", field=field, alias=alias))
         return self
 
     def having(self, aggregate: str, operator: str, value: Any) -> GroupByQuery[T]:
+        """Add an in-memory having filter evaluated after groups and aggregates are materialized."""
         self._having.append(_HavingClause(aggregate=aggregate, operator=operator, value=value))
         return self
 
     def execute(self) -> list[GroupedResult[T]]:
+        """Materialize groups, grouped items, and aggregate values in memory."""
         groups: dict[str, GroupedResult[T]] = {}
 
         for item in self._items:
@@ -107,10 +123,12 @@ class GroupByQuery[T]:
 
 
 def group_by[T](items: Sequence[T], field: str) -> GroupByQuery[T]:
+    """Create a client-side group-by over an already materialized sequence."""
     return GroupByQuery(items, field)
 
 
 def sum_field[T](items: Sequence[T], field: str) -> float:
+    """Compute a client-side sum over an already materialized sequence."""
     total = 0.0
     for item in items:
         value = _extract_numeric_value(item, field)
@@ -121,6 +139,7 @@ def sum_field[T](items: Sequence[T], field: str) -> float:
 
 
 def average_field[T](items: Sequence[T], field: str) -> float:
+    """Compute a client-side average over an already materialized sequence."""
     if not items:
         return 0.0
 
@@ -139,14 +158,17 @@ def average_field[T](items: Sequence[T], field: str) -> float:
 
 
 def min_field[T](items: Sequence[T], field: str) -> Any:
+    """Compute a client-side minimum over an already materialized sequence."""
     return _extreme_value(items, field, direction=-1)
 
 
 def max_field[T](items: Sequence[T], field: str) -> Any:
+    """Compute a client-side maximum over an already materialized sequence."""
     return _extreme_value(items, field, direction=1)
 
 
 def aggregate_field[T](items: Sequence[T], field: str | None = None) -> AggregateResult:
+    """Compute a client-side aggregate over an already materialized sequence."""
     result = AggregateResult(count=len(items))
     if not field:
         return result
@@ -182,6 +204,7 @@ def aggregate_field[T](items: Sequence[T], field: str | None = None) -> Aggregat
 
 
 def count_distinct[T](items: Sequence[T], field: str) -> int:
+    """Compute a client-side distinct count over an already materialized sequence."""
     unique: set[str] = set()
     for item in items:
         value = _extract_field_value(item, field)

--- a/ts/README.md
+++ b/ts/README.md
@@ -6,14 +6,12 @@ This folder contains the TypeScript implementation of TableTheory in the multi-l
 
 **Official documentation:** [TypeScript SDK docs](./docs/README.md) and [repo docs index](../docs/README.md).
 
-Status: **Phase 1 complete (TS-0 → TS-7)**.
-
 Runtime: **Node.js 24** (AWS Lambda runtime).
 
 ## Goals
 
-- Provide a typed, testable DynamoDB access layer aligned with the Go implementation.
-- Prevent drift via shared fixtures + cursor compatibility.
+- Provide an explicit, testable DynamoDB access layer aligned with the Go and Python contracts.
+- Keep shipped behavior visible through shared fixtures, cursor compatibility, and strict unit tests.
 
 ## Quickstart (Local DynamoDB)
 
@@ -156,10 +154,10 @@ import {
 
 const provider: EncryptionProvider = {
   encrypt: async () => {
-    throw new Error('not implemented');
+    throw new Error('wire your KMS-backed encrypt implementation here');
   },
   decrypt: async () => {
-    throw new Error('not implemented');
+    throw new Error('wire your KMS-backed decrypt implementation here');
   },
 };
 const db = new TheorydbClient(ddb, { encryption: provider }).register(User);
@@ -196,8 +194,8 @@ to the attribute name.
 ## Parity Statement
 
 - Implemented parity tiers: `P0` (CRUD/lifecycle/omitempty/version/ttl), `P1` (query + cursor), `P2` (batch + tx)
-- Additional: streams image unmarshalling (`TS-5`), encrypted envelope semantics (`TS-6`)
-- Not yet implemented: filter expressions, full update builder, DMS codegen, full DynamoDB type surface
+- Additional shipped surface: filter expressions and nested filter groups, the `UpdateBuilder` DSL, streams image unmarshalling, encrypted envelope semantics, write policies, release-state helpers, Lambda timeout helpers, and strict testkit utilities
+- Type boundary: models are explicit runtime descriptors; `TheorydbClient` item payloads remain `Record<string, unknown>` rather than schema-inferred TypeScript item types
 
 ## Development
 

--- a/ts/docs/api-reference.md
+++ b/ts/docs/api-reference.md
@@ -198,6 +198,23 @@ and aggregation helpers as `QueryBuilder`, plus:
 - `parallelScan(segment: number, totalSegments: number): this`
 - `scanAllSegments(totalSegments: number, opts?: { concurrency?: number }): Promise<Array<Record<string, unknown>>>`
 
+## Client-side aggregation helpers
+
+`QueryBuilder` and `ScanBuilder` expose convenience helpers:
+
+- `sum(field)`
+- `average(field)`
+- `min(field)`
+- `max(field)`
+- `aggregate(...fields)`
+- `countDistinct(field)`
+- `groupBy(field).count(alias).sum(field, alias).avg(field, alias).min(field, alias).max(field, alias).execute()`
+
+These are **client-side** helpers. Each query/scan aggregation calls `all()` (or, for `groupBy`, calls `all()` when
+`execute()` runs), follows every page, and materializes every matching item in memory before computing the result. Use
+only for bounded result sets. There is no native server-side `count()` in this release; when the planned native `count()`
+API lands, prefer it for count-only paths.
+
 ## Batch + Transactions
 
 Actual signatures:

--- a/ts/docs/api-reference.md
+++ b/ts/docs/api-reference.md
@@ -9,28 +9,41 @@
 ```ts
 import {
   DEFAULT_LAMBDA_TIMEOUT_BUFFER_MS,
-  type LambdaContextLike,
   TheorydbClient,
   createLambdaDynamoDBClient,
   createLambdaTimeoutSignal,
   defineModel,
   withLambdaTimeout,
+  type BatchGetResult,
+  type BatchWriteResult,
+  type EncryptionProvider,
+  type LambdaContextLike,
+  type Model,
+  type Page,
+  type SendOptions,
+  type TransactAction,
+  type UpdateBuilder,
 } from '@theory-cloud/tabletheory-ts';
 import { createMockDynamoDBClient } from '@theory-cloud/tabletheory-ts/testkit';
 ```
 
 ## Model Definition
 
-### `defineModel(definition)`
+### `defineModel(definition: ModelSchema): Model`
 
 Defines a model with explicit attribute names and roles.
 
-**Core fields (conceptual):**
+**Core fields:**
 
 - `name`: model name used by the client registry
 - `table.name`: DynamoDB table name
 - `keys.partition` / `keys.sort`: key attribute names + DynamoDB scalar types
 - `attributes`: list of attribute definitions (`attribute`, `type`, `roles`, `optional`, `omit_empty`, `encrypted`, etc.)
+- `indexes`: optional GSI/LSI definitions with explicit key attributes
+- `write_policy`: optional write-once/protected-attribute policy
+
+`defineModel` returns a runtime model descriptor. It does not currently infer a schema-specific TypeScript item type for
+`TheorydbClient`; client item payloads are still `Record<string, unknown>`.
 
 See [Core Patterns](./core-patterns.md) for canonical model definitions.
 
@@ -40,26 +53,62 @@ See [Core Patterns](./core-patterns.md) for canonical model definitions.
 
 Creates a client bound to an AWS SDK v3 `DynamoDBClient`.
 
-Common options (conceptual):
+Options:
 
-- `now`: injected clock (testing hook)
-- `encryption`: encryption provider (required when models use encrypted attributes)
+```ts
+{
+  encryption?: EncryptionProvider;
+  now?: () => string;
+  sendOptions?: SendOptions;
+}
+```
 
-### `register(model)`
+- `encryption`: required when a registered model contains encrypted attributes
+- `now`: injected RFC3339-nano clock for deterministic tests
+- `sendOptions.abortSignal`: optional SDK send option, commonly provided by Lambda timeout helpers
 
-Registers a model definition and returns the client (builder-style).
+### `register(...models: Model[]): this`
+
+Registers one or more model definitions and returns the same client.
+
+### `withEncryption(provider: EncryptionProvider): this`
+
+Attaches or replaces the encryption provider on the same client.
+
+### `withSendOptions(sendOptions?: SendOptions): TheorydbClient`
+
+Returns a new client with the same DynamoDB client, models, clock, and encryption provider, plus the supplied send options.
+
+### `withDynamoDBClient(ddb): TheorydbClient`
+
+Returns a new client with the same models, clock, encryption provider, and send options, but a different AWS SDK v3
+`DynamoDBClient`.
 
 ### CRUD
 
-- `create(modelName, item, options?)`
-- `get(modelName, key, options?)`
-- `update(modelName, item, fields, options?)`
-- `delete(modelName, key, options?)`
+Actual signatures:
 
-Common write options (conceptual):
+- `create(modelName: string, item: Record<string, unknown>, opts?: { ifNotExists?: boolean }): Promise<void>`
+- `save(modelName: string, item: Record<string, unknown>): Promise<void>`
+- `get(modelName: string, key: Record<string, unknown>): Promise<Record<string, unknown>>`
+- `update(modelName: string, item: Record<string, unknown>, fields: string[], opts?: WritePolicyOptions): Promise<void>`
+- `delete(modelName: string, key: Record<string, unknown>): Promise<void>`
 
-- `ifNotExists` / `ifExists`
-- `conditionExpression`, `expressionAttributeNames`, `expressionAttributeValues`
+Notes:
+
+- `create(..., { ifNotExists: true })` adds an `attribute_not_exists(pk)` condition. Write-once/protected models also
+  require create-if-absent automatically.
+- `get` performs a consistent read and raises `ErrItemNotFound` when DynamoDB returns no item.
+- `update` requires the model to define a `version` role and requires the current version value in `item[versionAttr]`.
+  It increments the version using DynamoDB `ADD` and condition-checks the expected version.
+- CRUD `update` does not accept raw condition-expression options. Use `updateBuilder(...)` or transaction update actions
+  when you need expression-level conditions.
+
+### `updateBuilder(modelName: string, key: Record<string, unknown>): UpdateBuilder`
+
+Creates the shipped update-builder DSL for direct DynamoDB updates. The builder supports `set`, `setIfNotExists`, `add`,
+`increment`, `decrement`, `remove`, set `delete`, list append/prepend/index operations, condition chaining, version
+conditions, `returnValues`, `build`, and `execute`.
 
 ## Lambda runtime helpers
 
@@ -101,11 +150,36 @@ export async function handler(event: unknown, ctx: LambdaContextLike) {
 }
 ```
 
-## Query
+## Query and scan builders
 
-### `query(modelName)`
+### `query(modelName: string): QueryBuilder`
 
-Creates a query builder.
+Creates a DynamoDB Query builder.
+
+Key, cursor, and page methods:
+
+- `usingIndex(name: string): this`
+- `partitionKey(value: unknown): this`
+- `sortKey(op: '=' | '<' | '<=' | '>' | '>=' | 'between' | 'begins_with', ...values: unknown[]): this`
+- `sort(direction: 'ASC' | 'DESC'): this`
+- `consistentRead(enabled = true): this` (rejected for GSIs)
+- `limit(n: number): this`
+- `projection(fields: string[]): this`
+- `cursor(encoded: string): this`
+- `page(): Promise<Page>`
+- `all(): Promise<Array<Record<string, unknown>>>`
+- `pageWithRetry(options?): Promise<Page>`
+- `describe(): BuilderShape`
+
+Filter expressions are implemented:
+
+- `filter(field: string, op: string, ...values: unknown[]): this`
+- `orFilter(field: string, op: string, ...values: unknown[]): this`
+- `filterGroup(fn: (b: FilterGroupBuilder) => void): this`
+- `orFilterGroup(fn: (b: FilterGroupBuilder) => void): this`
+
+Supported filter operators include `=`, `!=`/`<>`, `<`, `<=`, `>`, `>=`, `BETWEEN`, `IN`, `BEGINS_WITH`, `CONTAINS`,
+`ATTRIBUTE_EXISTS`, and `ATTRIBUTE_NOT_EXISTS`. Encrypted attributes cannot be filtered.
 
 Typical chain:
 
@@ -116,15 +190,35 @@ const next = page.cursor
   : null;
 ```
 
+### `scan(modelName: string): ScanBuilder`
+
+Creates a DynamoDB Scan builder. `ScanBuilder` supports the same filter, cursor, limit, projection, `page`, `all`, retry,
+and aggregation helpers as `QueryBuilder`, plus:
+
+- `parallelScan(segment: number, totalSegments: number): this`
+- `scanAllSegments(totalSegments: number, opts?: { concurrency?: number }): Promise<Array<Record<string, unknown>>>`
+
 ## Batch + Transactions
 
-- `batchGet(modelName, keys, options?)`
-- `batchWrite(modelName, { puts, deletes }, options?)`
-- `transactWrite(ops, options?)`
+Actual signatures:
 
-For models with encrypted attributes, transaction `update` actions must use
-`updateFn`. Raw `updateExpression` transaction updates are rejected because they
-would bypass `UpdateBuilder` encryption and validation.
+- `batchGet(modelName: string, keys: Array<Record<string, unknown>>, opts?: RetryOptions & { consistentRead?: boolean }): Promise<BatchGetResult>`
+- `batchWrite(modelName: string, request: { puts?: Array<Record<string, unknown>>; deletes?: Array<Record<string, unknown>> }, opts?: RetryOptions): Promise<BatchWriteResult>`
+- `transactWrite(actions: TransactAction[]): Promise<void>`
+
+`batchGet` defaults to `consistentRead: true`, `maxAttempts: 5`, and `baseDelayMs: 25`. `batchWrite` defaults to
+`maxAttempts: 5` and `baseDelayMs: 25`.
+
+`TransactAction` is a discriminated union of:
+
+- `{ kind: 'put', model, item, ifNotExists? }`
+- `{ kind: 'update', model, key, updateExpression, conditionExpression?, expressionAttributeNames?, expressionAttributeValues? }`
+- `{ kind: 'update', model, key, updateFn }`
+- `{ kind: 'delete', model, key, conditionExpression?, expressionAttributeNames?, expressionAttributeValues? }`
+- `{ kind: 'condition', model, key, conditionExpression, expressionAttributeNames?, expressionAttributeValues? }`
+
+For models with encrypted attributes, transaction `update` actions must use `updateFn`. Raw `updateExpression`
+transaction updates are rejected because they would bypass `UpdateBuilder` encryption and validation.
 
 ## Streams
 

--- a/ts/docs/core-patterns.md
+++ b/ts/docs/core-patterns.md
@@ -56,6 +56,13 @@ const page2 = page1.cursor
   : { items: [] };
 ```
 
+## Pattern: Aggregations are client-side
+
+`db.query(...).sum(...)`, `average(...)`, `min(...)`, `max(...)`, `aggregate(...)`, `countDistinct(...)`, and
+`groupBy(...).execute()` are convenience helpers over `all()`: they follow every page and materialize every matching item
+in memory before computing the result. Use them only for bounded result sets. When the planned native `count()` API lands,
+prefer it for count-only paths.
+
 ## Pattern: Batch + Transactions
 
 ```ts

--- a/ts/docs/getting-started.md
+++ b/ts/docs/getting-started.md
@@ -82,11 +82,12 @@ await db.create(
   { ifNotExists: true },
 );
 const item = await db.get('Note', { PK: 'NOTE#1', SK: 'v1' });
+console.log(item.value);
 await db.delete('Note', { PK: 'NOTE#1', SK: 'v1' });
 ```
 
 ## Next Steps
 
+- Use [API Reference](./api-reference.md) for exact signatures; for example, `db.update` requires a `version` role and the current version value, while `db.get` has no options parameter.
 - Read [Core Patterns](./core-patterns.md) for cursor pagination, batch, transactions, streams, and encryption.
 - Use [Testing Guide](./testing-guide.md) for strict mocks and deterministic encryption tests.
-- Use [API Reference](./api-reference.md) when you need signature-level detail.

--- a/ts/src/aggregates.ts
+++ b/ts/src/aggregates.ts
@@ -1,3 +1,4 @@
+/** Result of an in-memory client-side aggregation over an already materialized item array. */
 export interface AggregateResult {
   min?: unknown;
   max?: unknown;
@@ -6,6 +7,7 @@ export interface AggregateResult {
   average: number;
 }
 
+/** Group produced by `GroupByQuery.execute()` after all source items have been materialized in memory. */
 export interface GroupedResult<T = Record<string, unknown>> {
   key: unknown;
   count: number;
@@ -27,6 +29,10 @@ interface HavingClause {
   value: unknown;
 }
 
+/**
+ * Client-side group-by helper. `execute()` loads the full source item set into memory,
+ * then keeps grouped items and aggregates in memory; use only for bounded result sets.
+ */
 export class GroupByQuery<T extends Record<string, unknown>> {
   private readonly aggregates: AggregateOp[] = [];
   private readonly havingClauses: HavingClause[] = [];
@@ -36,36 +42,43 @@ export class GroupByQuery<T extends Record<string, unknown>> {
     private readonly groupByField: string,
   ) {}
 
+  /** Adds a count aggregate computed in memory after the full source set is materialized. */
   count(alias: string): this {
     this.aggregates.push({ function: 'COUNT', field: '*', alias });
     return this;
   }
 
+  /** Adds a sum aggregate computed in memory after the full source set is materialized. */
   sum(field: string, alias: string): this {
     this.aggregates.push({ function: 'SUM', field, alias });
     return this;
   }
 
+  /** Adds an average aggregate computed in memory after the full source set is materialized. */
   avg(field: string, alias: string): this {
     this.aggregates.push({ function: 'AVG', field, alias });
     return this;
   }
 
+  /** Adds a minimum aggregate computed in memory after the full source set is materialized. */
   min(field: string, alias: string): this {
     this.aggregates.push({ function: 'MIN', field, alias });
     return this;
   }
 
+  /** Adds a maximum aggregate computed in memory after the full source set is materialized. */
   max(field: string, alias: string): this {
     this.aggregates.push({ function: 'MAX', field, alias });
     return this;
   }
 
+  /** Adds an in-memory having filter evaluated after groups and aggregates are materialized. */
   having(aggregate: string, operator: string, value: unknown): this {
     this.havingClauses.push({ aggregate, operator, value });
     return this;
   }
 
+  /** Materializes the full source set, groups it in memory, computes aggregates, and returns all groups. */
   async execute(): Promise<Array<GroupedResult<T>>> {
     const items = await this.items();
     const groups = new Map<string, GroupedResult<T>>();
@@ -103,6 +116,7 @@ export class GroupByQuery<T extends Record<string, unknown>> {
   }
 }
 
+/** Client-side sum over an already materialized item array; use only for bounded result sets. */
 export function sumField<T extends Record<string, unknown>>(
   items: T[],
   field: string,
@@ -116,6 +130,7 @@ export function sumField<T extends Record<string, unknown>>(
   return sum;
 }
 
+/** Client-side average over an already materialized item array; use only for bounded result sets. */
 export function averageField<T extends Record<string, unknown>>(
   items: T[],
   field: string,
@@ -134,6 +149,7 @@ export function averageField<T extends Record<string, unknown>>(
   return sum / count;
 }
 
+/** Client-side minimum over an already materialized item array; use only for bounded result sets. */
 export function minField<T extends Record<string, unknown>>(
   items: T[],
   field: string,
@@ -141,6 +157,7 @@ export function minField<T extends Record<string, unknown>>(
   return extremeValue(items, field, -1);
 }
 
+/** Client-side maximum over an already materialized item array; use only for bounded result sets. */
 export function maxField<T extends Record<string, unknown>>(
   items: T[],
   field: string,
@@ -148,6 +165,7 @@ export function maxField<T extends Record<string, unknown>>(
   return extremeValue(items, field, 1);
 }
 
+/** Client-side aggregate over an already materialized item array; use only for bounded result sets. */
 export function aggregateField<T extends Record<string, unknown>>(
   items: T[],
   field?: string,
@@ -189,6 +207,7 @@ export function aggregateField<T extends Record<string, unknown>>(
   return result;
 }
 
+/** Client-side distinct count over an already materialized item array; use only for bounded result sets. */
 export function countDistinct<T extends Record<string, unknown>>(
   items: T[],
   field: string,

--- a/ts/src/query.ts
+++ b/ts/src/query.ts
@@ -561,30 +561,58 @@ export class QueryBuilder {
     }
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before summing.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async sum(field: string): Promise<number> {
     return sumField(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before averaging.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async average(field: string): Promise<number> {
     return averageField(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before selecting the minimum.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async min(field: string): Promise<unknown> {
     return minField(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before selecting the maximum.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async max(field: string): Promise<unknown> {
     return maxField(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before computing the aggregate.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async aggregate(...fields: string[]): Promise<AggregateResult> {
     return aggregateField(await this.all(), fields[0]);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before counting distinct values.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async countDistinct(field: string): Promise<number> {
     return countDistinct(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: the returned group query calls `all()` during `execute()` and keeps groups in memory.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   groupBy(field: string): GroupByQuery<Record<string, unknown>> {
     return new GroupByQuery(() => this.all(), field);
   }
@@ -947,30 +975,58 @@ export class ScanBuilder {
     }
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before summing.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async sum(field: string): Promise<number> {
     return sumField(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before averaging.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async average(field: string): Promise<number> {
     return averageField(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before selecting the minimum.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async min(field: string): Promise<unknown> {
     return minField(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before selecting the maximum.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async max(field: string): Promise<unknown> {
     return maxField(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before computing the aggregate.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async aggregate(...fields: string[]): Promise<AggregateResult> {
     return aggregateField(await this.all(), fields[0]);
   }
 
+  /**
+   * Client-side aggregation: calls `all()` and materializes every matching item before counting distinct values.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   async countDistinct(field: string): Promise<number> {
     return countDistinct(await this.all(), field);
   }
 
+  /**
+   * Client-side aggregation: the returned group query calls `all()` during `execute()` and keeps groups in memory.
+   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   */
   groupBy(field: string): GroupByQuery<Record<string, unknown>> {
     return new GroupByQuery(() => this.all(), field);
   }


### PR DESCRIPTION
## Summary
- Correct published docs that over-claimed Go generics/type-safety and repaired the two authorized planning-doc DOC-4 broken links.
- Truth-up TypeScript and Python API docs against the shipped public surfaces.
- Repair basic example quick-start docs, Makefiles, and runnable example models without adding runtime features.
- Label TypeScript/Python aggregation helpers as client-side full-result-set operations with memory warnings.

## Linear
- Closes THE-2257
- Closes THE-2258
- Closes THE-2259
- Closes THE-2260
- Closes THE-2261

## Contract / runtime impact
- Docs, doc comments, examples, and Makefile operator-surface changes only.
- No DMS change, no contract scenario change, no new runtime feature.
- Example-code repair removes unsupported `theorydb:"required"` claims from basic apps and keeps required-business-field validation as application responsibility.

## Validation
- [x] `make test-unit`
- [x] `cd ts && npm run check`
- [x] `uv --directory py run pytest -q tests/unit`
- [x] `bash scripts/verify-python-build.sh`
- [x] Basic example quick-start proof: for `todo`, `notes`, and `contacts`, ran `make docker-up`, `printf 'quit\\n' | timeout 30s make run`, and `make test` against an already-running DynamoDB Local at `http://localhost:8000`.
- [x] `make rubric` — PASS (36 pass, 0 fail, 0 blocked)

## Notes
- Corrected Python validation path is `uv --directory py run pytest -q tests/unit`; `cd py && python -m unittest` is not the repo's Python unit gate.
- `make test-unit` initially exposed a Makefile shell/tool discovery issue in this environment (`go: Permission denied`); fixed with a Makefile-only validation repair before rerunning exact `make test-unit` successfully.
