### PR TITLE
feat(contract): strengthen harness foundations

### DIFF
--- a/contract-tests/runners/go/contract_test.go
+++ b/contract-tests/runners/go/contract_test.go
@@ -2,6 +2,7 @@ package contracttests
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,6 +15,19 @@ import (
 )
 
 func TestContract_P0(t *testing.T) {
+	t.Helper()
+	runContractScenarios(t, filepath.Join("contract-tests", "scenarios", "p0"))
+}
+
+func TestContract_Interop(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CONTRACT_RUN_INTEROP") != "1" {
+		t.Skip("set CONTRACT_RUN_INTEROP=1 to run cross-runtime interop scenarios")
+	}
+	runContractScenarios(t, filepath.Join("contract-tests", "scenarios", "interop"))
+}
+
+func runContractScenarios(t *testing.T, scenarioRelDir string) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -34,7 +48,7 @@ func TestContract_P0(t *testing.T) {
 	models, err := spec.LoadModelsDir(filepath.Join(root, "contract-tests", "dms", "v0.1", "models"))
 	require.NoError(t, err)
 
-	scenarioDir := filepath.Join(root, "contract-tests", "scenarios", "p0")
+	scenarioDir := filepath.Join(root, scenarioRelDir)
 	files, err := filepath.Glob(filepath.Join(scenarioDir, "*.yml"))
 	require.NoError(t, err)
 	require.NotEmpty(t, files)

--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -28,6 +28,10 @@ const (
 	ErrMissingPrimaryKey ErrorCode = "ErrMissingPrimaryKey"
 	ErrInvalidOperator   ErrorCode = "ErrInvalidOperator"
 
+	ErrEncryptionNotConfigured    ErrorCode = "ErrEncryptionNotConfigured"
+	ErrEncryptedFieldNotQueryable ErrorCode = "ErrEncryptedFieldNotQueryable"
+	ErrInvalidEncryptedEnvelope   ErrorCode = "ErrInvalidEncryptedEnvelope"
+
 	ErrImmutableModelMutation          ErrorCode = "ErrImmutableModelMutation"
 	ErrProtectedFieldMutation          ErrorCode = "ErrProtectedFieldMutation"
 	ErrRejectedDeployAuthorityEvidence ErrorCode = "ErrRejectedDeployAuthorityEvidence"
@@ -94,6 +98,12 @@ func MapError(err error) ErrorCode {
 		return ErrMissingPrimaryKey
 	case errors.Is(err, theorydbErrors.ErrInvalidOperator):
 		return ErrInvalidOperator
+	case errors.Is(err, theorydbErrors.ErrEncryptionNotConfigured):
+		return ErrEncryptionNotConfigured
+	case errors.Is(err, theorydbErrors.ErrEncryptedFieldNotQueryable):
+		return ErrEncryptedFieldNotQueryable
+	case errors.Is(err, theorydbErrors.ErrInvalidEncryptedEnvelope):
+		return ErrInvalidEncryptedEnvelope
 	case errors.Is(err, theorydbErrors.ErrImmutableModelMutation):
 		return ErrImmutableModelMutation
 	case errors.Is(err, theorydbErrors.ErrProtectedFieldMutation):

--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -40,8 +40,34 @@ type Driver interface {
 	Update(ctx context.Context, model string, item map[string]any, fields []string, protectedAttributes []string) error
 	Save(ctx context.Context, model string, item map[string]any) error
 	Delete(ctx context.Context, model string, key map[string]any) error
+	Query(ctx context.Context, model string, req ReadRequest) (ReadResult, error)
+	Scan(ctx context.Context, model string, req ReadRequest) (ReadResult, error)
 	TransitionAppendEvent(ctx context.Context, actual TransitionActual, event TransitionEvent) error
 	ValidateProvenance(ctx context.Context, model string, item map[string]any) error
+}
+
+type ReadRequest struct {
+	Index          string
+	Partition      *ReadCondition
+	Sort           *ReadCondition
+	Filter         []ReadCondition
+	SortDirection  string
+	Limit          int
+	Projection     []string
+	Cursor         string
+	ConsistentRead *bool
+}
+
+type ReadCondition struct {
+	Attribute string
+	Operator  string
+	Value     any
+	Values    []any
+}
+
+type ReadResult struct {
+	Items  []map[string]any
+	Cursor string
 }
 
 type TransitionActual struct {
@@ -90,6 +116,8 @@ func (d *TheorydbDriver) Capabilities() []string {
 		"lifecycle.timestamps",
 		"optimistic_lock.version",
 		"ttl.epoch_seconds",
+		"query.basic",
+		"scan.basic",
 		"release_state.write_policy",
 		"release_state.transactional_transition",
 		"release_state.provenance_confidence",
@@ -222,6 +250,105 @@ func (d *TheorydbDriver) Delete(ctx context.Context, model string, key map[strin
 	}
 }
 
+func (d *TheorydbDriver) Query(ctx context.Context, model string, req ReadRequest) (ReadResult, error) {
+	q, err := d.buildReadQuery(ctx, model, req)
+	if err != nil {
+		return ReadResult{}, err
+	}
+	if req.Partition == nil {
+		return ReadResult{}, fmt.Errorf("%w: query partition is required", theorydbErrors.ErrMissingPrimaryKey)
+	}
+	q = q.Where(req.Partition.Attribute, req.Partition.Operator, conditionValue(*req.Partition))
+	if req.Sort != nil {
+		q = q.Where(req.Sort.Attribute, req.Sort.Operator, conditionValue(*req.Sort))
+	}
+	return d.executeRead(model, q)
+}
+
+func (d *TheorydbDriver) Scan(ctx context.Context, model string, req ReadRequest) (ReadResult, error) {
+	q, err := d.buildReadQuery(ctx, model, req)
+	if err != nil {
+		return ReadResult{}, err
+	}
+	return d.executeRead(model, q)
+}
+
+func (d *TheorydbDriver) buildReadQuery(ctx context.Context, modelName string, req ReadRequest) (core.Query, error) {
+	instance, err := emptyModel(modelName)
+	if err != nil {
+		return nil, err
+	}
+	q := d.db.WithContext(ctx).Model(instance)
+	if req.Index != "" {
+		q = q.Index(req.Index)
+	}
+	for _, filter := range req.Filter {
+		q = q.Filter(filter.Attribute, filter.Operator, conditionValue(filter))
+	}
+	if req.SortDirection != "" {
+		sortAttr := ""
+		if req.Sort != nil {
+			sortAttr = req.Sort.Attribute
+		}
+		q = q.OrderBy(sortAttr, req.SortDirection)
+	}
+	if req.Limit > 0 {
+		q = q.Limit(req.Limit)
+	}
+	if len(req.Projection) > 0 {
+		q = q.Select(req.Projection...)
+	}
+	if req.Cursor != "" {
+		q = q.Cursor(req.Cursor)
+	}
+	if req.ConsistentRead != nil && *req.ConsistentRead {
+		q = q.ConsistentRead()
+	}
+	return q, nil
+}
+
+func (d *TheorydbDriver) executeRead(model string, q core.Query) (ReadResult, error) {
+	switch model {
+	case "User":
+		var out []User
+		page, err := q.AllPaginated(&out)
+		if err != nil {
+			return ReadResult{}, err
+		}
+		return ReadResult{Items: normalizeUsers(out), Cursor: page.NextCursor}, nil
+	case "Order":
+		var out []Order
+		page, err := q.AllPaginated(&out)
+		if err != nil {
+			return ReadResult{}, err
+		}
+		return ReadResult{Items: normalizeOrders(out), Cursor: page.NextCursor}, nil
+	case "ReleaseStateActual":
+		var out []ReleaseStateActual
+		page, err := q.AllPaginated(&out)
+		if err != nil {
+			return ReadResult{}, err
+		}
+		return ReadResult{Items: normalizeReleaseStateActuals(out), Cursor: page.NextCursor}, nil
+	case "ReleaseStateEvent":
+		var out []ReleaseStateEvent
+		page, err := q.AllPaginated(&out)
+		if err != nil {
+			return ReadResult{}, err
+		}
+		return ReadResult{Items: normalizeReleaseStateEvents(out), Cursor: page.NextCursor}, nil
+	default:
+		return ReadResult{}, fmt.Errorf("%w: unknown model %q", theorydbErrors.ErrInvalidModel, model)
+	}
+}
+
+func conditionValue(cond ReadCondition) any {
+	if len(cond.Values) > 0 {
+		return append([]any(nil), cond.Values...)
+	}
+	return cond.Value
+}
+
 func (d *TheorydbDriver) TransitionAppendEvent(ctx context.Context, actual TransitionActual, event TransitionEvent) error {
 	if actual.Model != "ReleaseStateActual" || event.Model != "ReleaseStateEvent" {
 		return fmt.Errorf("%w: unsupported transition models %s/%s", theorydbErrors.ErrInvalidModel, actual.Model, event.Model)
@@ -290,6 +417,21 @@ func modelFromMap(model string, item map[string]any) (any, error) {
 		return releaseStateActualFromMap(item)
 	case "ReleaseStateEvent":
 		return releaseStateEventFromMap(item)
+	default:
+		return nil, fmt.Errorf("%w: unknown model %q", theorydbErrors.ErrInvalidModel, model)
+	}
+}
+
+func emptyModel(model string) (any, error) {
+	switch model {
+	case "User":
+		return &User{}, nil
+	case "Order":
+		return &Order{}, nil
+	case "ReleaseStateActual":
+		return &ReleaseStateActual{}, nil
+	case "ReleaseStateEvent":
+		return &ReleaseStateEvent{}, nil
 	default:
 		return nil, fmt.Errorf("%w: unknown model %q", theorydbErrors.ErrInvalidModel, model)
 	}
@@ -623,6 +765,14 @@ func normalizeUser(u User) map[string]any {
 	return out
 }
 
+func normalizeUsers(items []User) []map[string]any {
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, normalizeUser(item))
+	}
+	return out
+}
+
 func normalizeReleaseStateActual(actual ReleaseStateActual) map[string]any {
 	return map[string]any{
 		"PK":                actual.PK,
@@ -635,6 +785,14 @@ func normalizeReleaseStateActual(actual ReleaseStateActual) map[string]any {
 		"updatedAt":         actual.UpdatedAt.Format(time.RFC3339Nano),
 		"version":           actual.Version,
 	}
+}
+
+func normalizeReleaseStateActuals(items []ReleaseStateActual) []map[string]any {
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, normalizeReleaseStateActual(item))
+	}
+	return out
 }
 
 func normalizeReleaseStateEvent(event ReleaseStateEvent) map[string]any {
@@ -650,6 +808,14 @@ func normalizeReleaseStateEvent(event ReleaseStateEvent) map[string]any {
 	}
 }
 
+func normalizeReleaseStateEvents(items []ReleaseStateEvent) []map[string]any {
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, normalizeReleaseStateEvent(item))
+	}
+	return out
+}
+
 func normalizeOrder(o Order) map[string]any {
 	out := map[string]any{
 		"PK":        o.PK,
@@ -660,6 +826,14 @@ func normalizeOrder(o Order) map[string]any {
 		"updatedAt": o.UpdatedAt.Format(time.RFC3339Nano),
 		"version":   o.Version,
 		"ttl":       o.TTL,
+	}
+	return out
+}
+
+func normalizeOrders(items []Order) []map[string]any {
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, normalizeOrder(item))
 	}
 	return out
 }

--- a/contract-tests/runners/go/internal/driver/driver_test.go
+++ b/contract-tests/runners/go/internal/driver/driver_test.go
@@ -1,0 +1,39 @@
+package driver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+func TestMapError_EncryptionCodes(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want ErrorCode
+	}{
+		{
+			name: "encryption not configured",
+			err:  fmt.Errorf("wrapped: %w", theorydbErrors.ErrEncryptionNotConfigured),
+			want: ErrEncryptionNotConfigured,
+		},
+		{
+			name: "encrypted field not queryable",
+			err:  fmt.Errorf("wrapped: %w", theorydbErrors.ErrEncryptedFieldNotQueryable),
+			want: ErrEncryptedFieldNotQueryable,
+		},
+		{
+			name: "invalid encrypted envelope",
+			err:  fmt.Errorf("wrapped: %w", theorydbErrors.ErrInvalidEncryptedEnvelope),
+			want: ErrInvalidEncryptedEnvelope,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, MapError(tt.err))
+		})
+	}
+}

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -135,6 +135,18 @@ func (r *Runner) runStep(t require.TestingT, ctx context.Context, s *scenario.Sc
 		r.assertStepResult(t, step.Expect, item, err, raw, model)
 		return
 
+	case "query":
+		require.NotNil(t, step.Query, "query request is required")
+		result, err := r.driver.Query(ctx, modelName, readRequestFromScenario(step.Query))
+		r.assertReadResult(t, step.Expect, result, err, model)
+		return
+
+	case "scan":
+		require.NotNil(t, step.Scan, "scan request is required")
+		result, err := r.driver.Scan(ctx, modelName, readRequestFromScenario(step.Scan))
+		r.assertReadResult(t, step.Expect, result, err, model)
+		return
+
 	case "transition_append_event":
 		require.NotNil(t, step.Actual, "transition_append_event actual is required")
 		require.NotNil(t, step.Event, "transition_append_event event is required")
@@ -157,6 +169,41 @@ func (r *Runner) runStep(t require.TestingT, ctx context.Context, s *scenario.Sc
 
 	default:
 		require.FailNow(t, fmt.Sprintf("unsupported op: %s", step.Op))
+	}
+}
+
+func readRequestFromScenario(req *scenario.ReadRequest) driver.ReadRequest {
+	if req == nil {
+		return driver.ReadRequest{}
+	}
+	out := driver.ReadRequest{
+		Index:          req.Index,
+		SortDirection:  req.SortDirection,
+		Limit:          req.Limit,
+		Projection:     append([]string(nil), req.Projection...),
+		Cursor:         req.Cursor,
+		ConsistentRead: req.ConsistentRead,
+	}
+	if req.Partition != nil {
+		partition := readConditionFromScenario(*req.Partition)
+		out.Partition = &partition
+	}
+	if req.Sort != nil {
+		sortCond := readConditionFromScenario(*req.Sort)
+		out.Sort = &sortCond
+	}
+	for _, filter := range req.Filter {
+		out.Filter = append(out.Filter, readConditionFromScenario(filter))
+	}
+	return out
+}
+
+func readConditionFromScenario(cond scenario.ReadCondition) driver.ReadCondition {
+	return driver.ReadCondition{
+		Attribute: cond.Attribute,
+		Operator:  cond.Operator,
+		Value:     cond.Value,
+		Values:    append([]any(nil), cond.Values...),
 	}
 }
 
@@ -224,6 +271,42 @@ func (r *Runner) assertStepResult(t require.TestingT, expect scenario.Expectatio
 	if len(expect.ItemFieldNotEqualsVar) > 0 {
 		for attr, varName := range expect.ItemFieldNotEqualsVar {
 			require.NotEqual(t, r.vars[varName], item[attr], "field %s should differ from var %s", attr, varName)
+		}
+	}
+}
+
+func (r *Runner) assertReadResult(t require.TestingT, expect scenario.Expectation, result driver.ReadResult, err error, model spec.Model) {
+	if expect.Error != "" {
+		require.Error(t, err)
+		require.Equal(t, driver.ErrorCode(expect.Error), driver.MapError(err))
+		return
+	}
+	if expect.Ok != nil {
+		if *expect.Ok {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+		}
+	}
+	if err != nil {
+		return
+	}
+
+	if expect.ItemCount != nil {
+		require.Len(t, result.Items, *expect.ItemCount)
+	}
+
+	if len(expect.ItemsContains) > 0 {
+		require.GreaterOrEqual(t, len(result.Items), len(expect.ItemsContains), "not enough result items")
+		for i, wantItem := range expect.ItemsContains {
+			haveItem := result.Items[i]
+			for attr, want := range wantItem {
+				have, ok := haveItem[attr]
+				require.True(t, ok, "missing attr %s in result item %d", attr, i)
+				attrDef := model.AttributeByName(attr)
+				require.NotNil(t, attrDef, "unknown attr %s in model %s", attr, model.Name)
+				assertValueMatches(t, *attrDef, want, have, nil)
+			}
 		}
 	}
 }

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -189,7 +190,7 @@ func (r *Runner) assertStepResult(t require.TestingT, expect scenario.Expectatio
 			require.True(t, ok, "missing attr %s in item", attr)
 			attrDef := model.AttributeByName(attr)
 			require.NotNil(t, attrDef, "unknown attr %s in model %s", attr, model.Name)
-			assertValueMatches(t, *attrDef, want, have)
+			assertValueMatches(t, *attrDef, want, have, raw[attr])
 		}
 	}
 
@@ -227,14 +228,20 @@ func (r *Runner) assertStepResult(t require.TestingT, expect scenario.Expectatio
 	}
 }
 
-func assertValueMatches(t require.TestingT, attr spec.Attribute, want any, have any) {
+func assertValueMatches(t require.TestingT, attr spec.Attribute, want any, have any, raw types.AttributeValue) {
 	switch attr.Type {
 	case "S":
 		require.Equal(t, fmt.Sprintf("%v", want), fmt.Sprintf("%v", have))
 	case "N":
-		wantN, err := asInt64(want)
+		wantN, err := canonicalDecimalString(want)
 		require.NoError(t, err)
-		haveN, err := asInt64(have)
+		if raw != nil {
+			rawN, ok := raw.(*types.AttributeValueMemberN)
+			require.True(t, ok, "expected raw N for %s, got %T", attr.Attribute, raw)
+			require.Equal(t, wantN, rawN.Value)
+			return
+		}
+		haveN, err := canonicalDecimalString(have)
 		require.NoError(t, err)
 		require.Equal(t, wantN, haveN)
 	case "SS":
@@ -248,21 +255,46 @@ func assertValueMatches(t require.TestingT, attr spec.Attribute, want any, have 
 	}
 }
 
-func asInt64(v any) (int64, error) {
+func canonicalDecimalString(v any) (string, error) {
 	if v == nil {
-		return 0, nil
+		return "0", nil
 	}
 	switch n := v.(type) {
 	case int:
-		return int64(n), nil
+		return strconv.FormatInt(int64(n), 10), nil
+	case int8:
+		return strconv.FormatInt(int64(n), 10), nil
+	case int16:
+		return strconv.FormatInt(int64(n), 10), nil
+	case int32:
+		return strconv.FormatInt(int64(n), 10), nil
 	case int64:
-		return n, nil
+		return strconv.FormatInt(n, 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(n), 10), nil
+	case uint8:
+		return strconv.FormatUint(uint64(n), 10), nil
+	case uint16:
+		return strconv.FormatUint(uint64(n), 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(n), 10), nil
+	case uint64:
+		return strconv.FormatUint(n, 10), nil
 	case float64:
-		return int64(n), nil
+		if math.IsInf(n, 0) || math.IsNaN(n) {
+			return "", fmt.Errorf("non-finite number %v", n)
+		}
+		return strconv.FormatFloat(n, 'f', -1, 64), nil
+	case float32:
+		f := float64(n)
+		if math.IsInf(f, 0) || math.IsNaN(f) {
+			return "", fmt.Errorf("non-finite number %v", n)
+		}
+		return strconv.FormatFloat(f, 'f', -1, 32), nil
 	case string:
-		return strconv.ParseInt(n, 10, 64)
+		return n, nil
 	default:
-		return 0, fmt.Errorf("expected number, got %T", v)
+		return "", fmt.Errorf("expected DynamoDB decimal string, got %T", v)
 	}
 }
 

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -241,6 +241,10 @@ func (r *Runner) assertStepResult(t require.TestingT, expect scenario.Expectatio
 		}
 	}
 
+	if len(expect.ItemEquals) > 0 {
+		assertItemEquals(t, expect.ItemEquals, item, raw, model)
+	}
+
 	if len(expect.ItemHasFields) > 0 {
 		for _, attr := range expect.ItemHasFields {
 			_, ok := item[attr]
@@ -309,11 +313,43 @@ func (r *Runner) assertReadResult(t require.TestingT, expect scenario.Expectatio
 			}
 		}
 	}
+	if expect.CursorEquals != nil {
+		require.Equal(t, *expect.CursorEquals, result.Cursor)
+	}
+}
+
+func assertItemEquals(t require.TestingT, want map[string]any, item map[string]any, raw map[string]types.AttributeValue, model spec.Model) {
+	if raw != nil {
+		require.Len(t, raw, len(want), "raw item should contain exactly the expected attributes")
+		for attr, wantValue := range want {
+			rawValue, ok := raw[attr]
+			require.True(t, ok, "missing raw attr %s", attr)
+			attrDef := model.AttributeByName(attr)
+			require.NotNil(t, attrDef, "unknown attr %s in model %s", attr, model.Name)
+			assertValueMatches(t, *attrDef, wantValue, item[attr], rawValue)
+		}
+		return
+	}
+
+	require.Len(t, item, len(want), "item should contain exactly the expected attributes")
+	for attr, wantValue := range want {
+		have, ok := item[attr]
+		require.True(t, ok, "missing attr %s", attr)
+		attrDef := model.AttributeByName(attr)
+		require.NotNil(t, attrDef, "unknown attr %s in model %s", attr, model.Name)
+		assertValueMatches(t, *attrDef, wantValue, have, nil)
+	}
 }
 
 func assertValueMatches(t require.TestingT, attr spec.Attribute, want any, have any, raw types.AttributeValue) {
 	switch attr.Type {
 	case "S":
+		if raw != nil {
+			rawS, ok := raw.(*types.AttributeValueMemberS)
+			require.True(t, ok, "expected raw S for %s, got %T", attr.Attribute, raw)
+			require.Equal(t, fmt.Sprintf("%v", want), rawS.Value)
+			return
+		}
 		require.Equal(t, fmt.Sprintf("%v", want), fmt.Sprintf("%v", have))
 	case "N":
 		wantN, err := canonicalDecimalString(want)
@@ -330,6 +366,14 @@ func assertValueMatches(t require.TestingT, attr spec.Attribute, want any, have 
 	case "SS":
 		wantSS, err := asStringSet(want)
 		require.NoError(t, err)
+		if raw != nil {
+			rawSS, ok := raw.(*types.AttributeValueMemberSS)
+			require.True(t, ok, "expected raw SS for %s, got %T", attr.Attribute, raw)
+			haveSS := append([]string(nil), rawSS.Value...)
+			sort.Strings(haveSS)
+			require.Equal(t, wantSS, haveSS)
+			return
+		}
 		haveSS, err := asStringSet(have)
 		require.NoError(t, err)
 		require.Equal(t, wantSS, haveSS)

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -327,8 +327,9 @@ func (r *Runner) getRawItem(ctx context.Context, tableName string, model spec.Mo
 	}
 
 	out, err := r.ddb.GetItem(ctx, &dynamodb.GetItemInput{
-		TableName: aws.String(tableName),
-		Key:       keyAV,
+		TableName:      aws.String(tableName),
+		Key:            keyAV,
+		ConsistentRead: aws.Bool(true),
 	})
 	if err != nil {
 		return nil, err

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -79,12 +80,28 @@ func (r *Runner) RunScenario(t require.TestingT, ctx context.Context, s *scenari
 
 	require.NotEmpty(t, tableName, "table name required")
 
-	require.NoError(t, r.recreateTable(ctx, tableName, model))
+	steps, recreate := stepsForRuntime(s, "go")
+	if recreate {
+		require.NoError(t, r.recreateTable(ctx, tableName, model))
+	}
 
-	for i := range s.Steps {
-		step := s.Steps[i]
+	for i := range steps {
+		step := steps[i]
 		r.runStep(t, ctx, s, models, tableName, step)
 	}
+}
+
+func stepsForRuntime(s *scenario.Scenario, runtimeName string) ([]scenario.Step, bool) {
+	if s.SeedRuntime == "" {
+		return s.Steps, true
+	}
+	if strings.EqualFold(s.SeedRuntime, runtimeName) {
+		steps := make([]scenario.Step, 0, len(s.SeedSteps)+len(s.ReadSteps))
+		steps = append(steps, s.SeedSteps...)
+		steps = append(steps, s.ReadSteps...)
+		return steps, true
+	}
+	return s.ReadSteps, false
 }
 
 func (r *Runner) runStep(t require.TestingT, ctx context.Context, s *scenario.Scenario, models map[string]spec.Model, tableName string, step scenario.Step) {

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -232,10 +232,21 @@ func stepModelName(s *scenario.Scenario, step scenario.Step) string {
 }
 
 func (r *Runner) assertStepResult(t require.TestingT, expect scenario.Expectation, item map[string]any, err error, raw map[string]types.AttributeValue, model spec.Model) {
+	hasItemAssertion := expectationHasItemAssertion(expect)
+	hasRawAssertion := expectationHasRawItemAssertion(expect)
+
 	if expect.Error != "" {
 		require.Error(t, err)
 		require.Equal(t, driver.ErrorCode(expect.Error), driver.MapError(err))
+		require.False(t, hasItemAssertion, "item assertions cannot be combined with error expectations")
 		return
+	}
+	if hasItemAssertion {
+		require.NoError(t, err, "expected successful operation for item assertions")
+		require.NotNil(t, item, "expected item for item assertions")
+	}
+	if hasRawAssertion {
+		require.NotNil(t, raw, "expected raw item for raw assertions")
 	}
 	if expect.Ok != nil {
 		if *expect.Ok {
@@ -297,10 +308,16 @@ func (r *Runner) assertStepResult(t require.TestingT, expect scenario.Expectatio
 }
 
 func (r *Runner) assertReadResult(t require.TestingT, expect scenario.Expectation, result driver.ReadResult, err error, model spec.Model) {
+	hasReadAssertion := expectationHasReadAssertion(expect)
+
 	if expect.Error != "" {
 		require.Error(t, err)
 		require.Equal(t, driver.ErrorCode(expect.Error), driver.MapError(err))
+		require.False(t, hasReadAssertion, "read assertions cannot be combined with error expectations")
 		return
+	}
+	if hasReadAssertion {
+		require.NoError(t, err, "expected successful read for read assertions")
 	}
 	if expect.Ok != nil {
 		if *expect.Ok {
@@ -333,6 +350,26 @@ func (r *Runner) assertReadResult(t require.TestingT, expect scenario.Expectatio
 	if expect.CursorEquals != nil {
 		require.Equal(t, *expect.CursorEquals, result.Cursor)
 	}
+}
+
+func expectationHasItemAssertion(expect scenario.Expectation) bool {
+	return len(expect.ItemContains) > 0 ||
+		len(expect.ItemEquals) > 0 ||
+		len(expect.ItemHasFields) > 0 ||
+		len(expect.ItemMissingFields) > 0 ||
+		len(expect.RawAttributeTypes) > 0 ||
+		len(expect.ItemFieldEqualsVar) > 0 ||
+		len(expect.ItemFieldNotEqualsVar) > 0
+}
+
+func expectationHasRawItemAssertion(expect scenario.Expectation) bool {
+	return len(expect.ItemMissingFields) > 0 || len(expect.RawAttributeTypes) > 0
+}
+
+func expectationHasReadAssertion(expect scenario.Expectation) bool {
+	return expect.ItemCount != nil ||
+		len(expect.ItemsContains) > 0 ||
+		expect.CursorEquals != nil
 }
 
 func assertItemEquals(t require.TestingT, want map[string]any, item map[string]any, raw map[string]types.AttributeValue, model spec.Model) {

--- a/contract-tests/runners/go/internal/runner/runner_test.go
+++ b/contract-tests/runners/go/internal/runner/runner_test.go
@@ -1,0 +1,103 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/driver"
+	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/scenario"
+	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/spec"
+)
+
+type requireCaptureT struct {
+	failed bool
+}
+
+func (t *requireCaptureT) Errorf(string, ...any) {
+	t.failed = true
+}
+
+func (t *requireCaptureT) FailNow() {
+	panic("require failed")
+}
+
+func (t *requireCaptureT) Helper() {}
+
+func requireFails(t *testing.T, fn func(requireT *requireCaptureT)) {
+	t.Helper()
+
+	capture := &requireCaptureT{}
+	defer func() {
+		if recovered := recover(); recovered != nil && fmt.Sprint(recovered) != "require failed" {
+			panic(recovered)
+		}
+		if !capture.failed {
+			t.Fatalf("expected assertion failure")
+		}
+	}()
+
+	fn(capture)
+}
+
+func TestAssertStepResult_FailsClosedWhenItemAssertionHasErrorWithoutOk(t *testing.T) {
+	r := &Runner{vars: map[string]any{}}
+	model := spec.Model{
+		Name: "User",
+		Attributes: []spec.Attribute{
+			{Attribute: "PK", Type: "S"},
+		},
+	}
+
+	requireFails(t, func(requireT *requireCaptureT) {
+		r.assertStepResult(
+			requireT,
+			scenario.Expectation{ItemEquals: map[string]any{"PK": "USER#1"}},
+			nil,
+			errors.New("missing item"),
+			nil,
+			model,
+		)
+	})
+}
+
+func TestAssertStepResult_FailsClosedWhenItemAssertionHasNoItem(t *testing.T) {
+	r := &Runner{vars: map[string]any{}}
+	model := spec.Model{
+		Name: "User",
+		Attributes: []spec.Attribute{
+			{Attribute: "PK", Type: "S"},
+		},
+	}
+
+	requireFails(t, func(requireT *requireCaptureT) {
+		r.assertStepResult(
+			requireT,
+			scenario.Expectation{ItemMissingFields: []string{"nickname"}},
+			nil,
+			nil,
+			nil,
+			model,
+		)
+	})
+}
+
+func TestAssertReadResult_FailsClosedWhenReadAssertionHasErrorWithoutOk(t *testing.T) {
+	r := &Runner{vars: map[string]any{}}
+	model := spec.Model{
+		Name: "User",
+		Attributes: []spec.Attribute{
+			{Attribute: "PK", Type: "S"},
+		},
+	}
+
+	requireFails(t, func(requireT *requireCaptureT) {
+		r.assertReadResult(
+			requireT,
+			scenario.Expectation{ItemsContains: []map[string]any{{"PK": "USER#1"}}},
+			driver.ReadResult{},
+			errors.New("query failed"),
+			model,
+		)
+	})
+}

--- a/contract-tests/runners/go/internal/scenario/scenario.go
+++ b/contract-tests/runners/go/internal/scenario/scenario.go
@@ -15,6 +15,9 @@ type Scenario struct {
 	Model                string   `yaml:"model"`
 	Table                Table    `yaml:"table"`
 	Steps                []Step   `yaml:"steps"`
+	SeedRuntime          string   `yaml:"seed_runtime"`
+	SeedSteps            []Step   `yaml:"seed_steps"`
+	ReadSteps            []Step   `yaml:"read_steps"`
 }
 
 type Table struct {
@@ -108,79 +111,105 @@ func LoadFile(path string) (*Scenario, error) {
 }
 
 func validateSteps(s *Scenario) error {
-	for i, step := range s.Steps {
-		if step.Op == "" {
-			return fmt.Errorf("step %d: op is required", i)
+	if s.SeedRuntime != "" {
+		if len(s.SeedSteps) == 0 {
+			return fmt.Errorf("seed_steps are required when seed_runtime is set")
 		}
-		switch step.Op {
-		case "sleep":
-			continue
-		case "create", "update", "save":
-			if len(step.Item) == 0 {
-				return fmt.Errorf("step %d %s: item is required", i, step.Op)
-			}
-		case "get", "delete":
-			if len(step.Key) == 0 {
-				return fmt.Errorf("step %d %s: key is required", i, step.Op)
-			}
-		case "query":
-			if step.Query == nil {
-				return fmt.Errorf("step %d query: query is required", i)
-			}
-			if step.Query.Partition == nil {
-				return fmt.Errorf("step %d query: query.partition is required", i)
-			}
-			if err := validateReadCondition(step.Query.Partition, fmt.Sprintf("step %d query.partition", i)); err != nil {
+		if len(s.ReadSteps) == 0 {
+			return fmt.Errorf("read_steps are required when seed_runtime is set")
+		}
+	}
+	if s.SeedRuntime == "" && len(s.Steps) == 0 {
+		return fmt.Errorf("scenario steps are required")
+	}
+
+	for label, steps := range map[string][]Step{
+		"steps":      s.Steps,
+		"seed_steps": s.SeedSteps,
+		"read_steps": s.ReadSteps,
+	} {
+		for i, step := range steps {
+			if err := validateStep(label, i, step); err != nil {
 				return err
 			}
-			if step.Query.Sort != nil {
-				if err := validateReadCondition(step.Query.Sort, fmt.Sprintf("step %d query.sort", i)); err != nil {
-					return err
-				}
-			}
-			for j := range step.Query.Filter {
-				if err := validateReadCondition(&step.Query.Filter[j], fmt.Sprintf("step %d query.filter[%d]", i, j)); err != nil {
-					return err
-				}
-			}
-		case "scan":
-			if step.Scan == nil {
-				return fmt.Errorf("step %d scan: scan is required", i)
-			}
-			for j := range step.Scan.Filter {
-				if err := validateReadCondition(&step.Scan.Filter[j], fmt.Sprintf("step %d scan.filter[%d]", i, j)); err != nil {
-					return err
-				}
-			}
-		case "transition_append_event":
-			if step.Actual == nil {
-				return fmt.Errorf("step %d transition_append_event: actual is required", i)
-			}
-			if step.Actual.Model == "" {
-				return fmt.Errorf("step %d transition_append_event: actual.model is required", i)
-			}
-			if len(step.Actual.Key) == 0 {
-				return fmt.Errorf("step %d transition_append_event: actual.key is required", i)
-			}
-			if len(step.Actual.Set) == 0 {
-				return fmt.Errorf("step %d transition_append_event: actual.set is required", i)
-			}
-			if step.Event == nil {
-				return fmt.Errorf("step %d transition_append_event: event is required", i)
-			}
-			if step.Event.Model == "" {
-				return fmt.Errorf("step %d transition_append_event: event.model is required", i)
-			}
-			if len(step.Event.Item) == 0 {
-				return fmt.Errorf("step %d transition_append_event: event.item is required", i)
-			}
-		case "validate_provenance":
-			if len(step.Item) == 0 {
-				return fmt.Errorf("step %d validate_provenance: item is required", i)
-			}
-		default:
-			return fmt.Errorf("step %d: unsupported op %q", i, step.Op)
 		}
+	}
+	return nil
+}
+
+func validateStep(label string, i int, step Step) error {
+	prefix := fmt.Sprintf("%s[%d]", label, i)
+	if step.Op == "" {
+		return fmt.Errorf("%s: op is required", prefix)
+	}
+	switch step.Op {
+	case "sleep":
+		return nil
+	case "create", "update", "save":
+		if len(step.Item) == 0 {
+			return fmt.Errorf("%s %s: item is required", prefix, step.Op)
+		}
+	case "get", "delete":
+		if len(step.Key) == 0 {
+			return fmt.Errorf("%s %s: key is required", prefix, step.Op)
+		}
+	case "query":
+		if step.Query == nil {
+			return fmt.Errorf("%s query: query is required", prefix)
+		}
+		if step.Query.Partition == nil {
+			return fmt.Errorf("%s query: query.partition is required", prefix)
+		}
+		if err := validateReadCondition(step.Query.Partition, fmt.Sprintf("%s query.partition", prefix)); err != nil {
+			return err
+		}
+		if step.Query.Sort != nil {
+			if err := validateReadCondition(step.Query.Sort, fmt.Sprintf("%s query.sort", prefix)); err != nil {
+				return err
+			}
+		}
+		for j := range step.Query.Filter {
+			if err := validateReadCondition(&step.Query.Filter[j], fmt.Sprintf("%s query.filter[%d]", prefix, j)); err != nil {
+				return err
+			}
+		}
+	case "scan":
+		if step.Scan == nil {
+			return fmt.Errorf("%s scan: scan is required", prefix)
+		}
+		for j := range step.Scan.Filter {
+			if err := validateReadCondition(&step.Scan.Filter[j], fmt.Sprintf("%s scan.filter[%d]", prefix, j)); err != nil {
+				return err
+			}
+		}
+	case "transition_append_event":
+		if step.Actual == nil {
+			return fmt.Errorf("%s transition_append_event: actual is required", prefix)
+		}
+		if step.Actual.Model == "" {
+			return fmt.Errorf("%s transition_append_event: actual.model is required", prefix)
+		}
+		if len(step.Actual.Key) == 0 {
+			return fmt.Errorf("%s transition_append_event: actual.key is required", prefix)
+		}
+		if len(step.Actual.Set) == 0 {
+			return fmt.Errorf("%s transition_append_event: actual.set is required", prefix)
+		}
+		if step.Event == nil {
+			return fmt.Errorf("%s transition_append_event: event is required", prefix)
+		}
+		if step.Event.Model == "" {
+			return fmt.Errorf("%s transition_append_event: event.model is required", prefix)
+		}
+		if len(step.Event.Item) == 0 {
+			return fmt.Errorf("%s transition_append_event: event.item is required", prefix)
+		}
+	case "validate_provenance":
+		if len(step.Item) == 0 {
+			return fmt.Errorf("%s validate_provenance: item is required", prefix)
+		}
+	default:
+		return fmt.Errorf("%s: unsupported op %q", prefix, step.Op)
 	}
 	return nil
 }

--- a/contract-tests/runners/go/internal/scenario/scenario.go
+++ b/contract-tests/runners/go/internal/scenario/scenario.go
@@ -3,6 +3,7 @@ package scenario
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -28,11 +29,32 @@ type Step struct {
 	ProtectedAttributes []string          `yaml:"protected_attributes"`
 	Item                map[string]any    `yaml:"item"`
 	Key                 map[string]any    `yaml:"key"`
+	Query               *ReadRequest      `yaml:"query"`
+	Scan                *ReadRequest      `yaml:"scan"`
 	Actual              *TransitionActual `yaml:"actual"`
 	Event               *TransitionEvent  `yaml:"event"`
 	Ms                  int               `yaml:"ms"`
 	Save                map[string]string `yaml:"save"`
 	Expect              Expectation       `yaml:"expect"`
+}
+
+type ReadRequest struct {
+	Index          string          `yaml:"index"`
+	Partition      *ReadCondition  `yaml:"partition"`
+	Sort           *ReadCondition  `yaml:"sort"`
+	Filter         []ReadCondition `yaml:"filter"`
+	SortDirection  string          `yaml:"sort_direction"`
+	Limit          int             `yaml:"limit"`
+	Projection     []string        `yaml:"projection"`
+	Cursor         string          `yaml:"cursor"`
+	ConsistentRead *bool           `yaml:"consistent_read"`
+}
+
+type ReadCondition struct {
+	Attribute string `yaml:"attribute"`
+	Operator  string `yaml:"operator"`
+	Value     any    `yaml:"value"`
+	Values    []any  `yaml:"values"`
 }
 
 type TransitionActual struct {
@@ -51,6 +73,8 @@ type Expectation struct {
 	Ok                    *bool             `yaml:"ok"`
 	Error                 string            `yaml:"error"`
 	ItemContains          map[string]any    `yaml:"item_contains"`
+	ItemsContains         []map[string]any  `yaml:"items_contains"`
+	ItemCount             *int              `yaml:"item_count"`
 	ItemHasFields         []string          `yaml:"item_has_fields"`
 	ItemMissingFields     []string          `yaml:"item_missing_fields"`
 	RawAttributeTypes     map[string]string `yaml:"raw_attribute_types"`
@@ -97,6 +121,35 @@ func validateSteps(s *Scenario) error {
 			if len(step.Key) == 0 {
 				return fmt.Errorf("step %d %s: key is required", i, step.Op)
 			}
+		case "query":
+			if step.Query == nil {
+				return fmt.Errorf("step %d query: query is required", i)
+			}
+			if step.Query.Partition == nil {
+				return fmt.Errorf("step %d query: query.partition is required", i)
+			}
+			if err := validateReadCondition(step.Query.Partition, fmt.Sprintf("step %d query.partition", i)); err != nil {
+				return err
+			}
+			if step.Query.Sort != nil {
+				if err := validateReadCondition(step.Query.Sort, fmt.Sprintf("step %d query.sort", i)); err != nil {
+					return err
+				}
+			}
+			for j := range step.Query.Filter {
+				if err := validateReadCondition(&step.Query.Filter[j], fmt.Sprintf("step %d query.filter[%d]", i, j)); err != nil {
+					return err
+				}
+			}
+		case "scan":
+			if step.Scan == nil {
+				return fmt.Errorf("step %d scan: scan is required", i)
+			}
+			for j := range step.Scan.Filter {
+				if err := validateReadCondition(&step.Scan.Filter[j], fmt.Sprintf("step %d scan.filter[%d]", i, j)); err != nil {
+					return err
+				}
+			}
 		case "transition_append_event":
 			if step.Actual == nil {
 				return fmt.Errorf("step %d transition_append_event: actual is required", i)
@@ -128,6 +181,31 @@ func validateSteps(s *Scenario) error {
 		}
 	}
 	return nil
+}
+
+func validateReadCondition(cond *ReadCondition, prefix string) error {
+	if cond == nil {
+		return fmt.Errorf("%s is required", prefix)
+	}
+	if cond.Attribute == "" {
+		return fmt.Errorf("%s.attribute is required", prefix)
+	}
+	if cond.Operator == "" {
+		return fmt.Errorf("%s.operator is required", prefix)
+	}
+	if cond.Value == nil && len(cond.Values) == 0 && !readOperatorAllowsNoValue(cond.Operator) {
+		return fmt.Errorf("%s.value or %s.values is required", prefix, prefix)
+	}
+	return nil
+}
+
+func readOperatorAllowsNoValue(operator string) bool {
+	switch strings.ToLower(operator) {
+	case "exists", "attribute_exists", "not_exists", "attribute_not_exists":
+		return true
+	default:
+		return false
+	}
 }
 
 func MissingCapabilities(required []string, supported []string) []string {

--- a/contract-tests/runners/go/internal/scenario/scenario.go
+++ b/contract-tests/runners/go/internal/scenario/scenario.go
@@ -73,8 +73,10 @@ type Expectation struct {
 	Ok                    *bool             `yaml:"ok"`
 	Error                 string            `yaml:"error"`
 	ItemContains          map[string]any    `yaml:"item_contains"`
+	ItemEquals            map[string]any    `yaml:"item_equals"`
 	ItemsContains         []map[string]any  `yaml:"items_contains"`
 	ItemCount             *int              `yaml:"item_count"`
+	CursorEquals          *string           `yaml:"cursor_equals"`
 	ItemHasFields         []string          `yaml:"item_has_fields"`
 	ItemMissingFields     []string          `yaml:"item_missing_fields"`
 	RawAttributeTypes     map[string]string `yaml:"raw_attribute_types"`

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -15,12 +15,15 @@ from botocore.exceptions import ClientError, EndpointConnectionError
 
 from theorydb_py import (
     ConditionFailedError,
+    FilterCondition,
+    FilterGroup,
     ImmutableModelMutationError,
     ModelDefinition,
     NotFoundError,
     Projection,
     ProtectedFieldMutationError,
     RejectedDeployAuthorityEvidenceError,
+    SortKeyCondition,
     Table,
     ValidationError,
     WritePolicy,
@@ -55,7 +58,7 @@ def _load_models() -> dict[str, dict[str, Any]]:
 def _load_scenarios() -> list[dict[str, Any]]:
     scenario_dir = _repo_root() / "contract-tests" / "scenarios" / "p0"
     scenarios = [_load_yaml(path) for path in sorted(scenario_dir.glob("*.yml"))]
-    assert len(scenarios) == 9
+    assert len(scenarios) >= 9
     return scenarios
 
 
@@ -190,6 +193,34 @@ class _TheorydbPyDriver:
     def delete(self, model: str, key: dict[str, Any]) -> None:
         self.tables[model].delete(key["PK"], key["SK"])
 
+    def query(self, model: str, request: dict[str, Any]) -> dict[str, Any]:
+        partition = request.get("partition")
+        if partition is None:
+            raise ValidationError("query partition is required")
+        page = self.tables[model].query(
+            _condition_value(partition),
+            sort=_sort_condition(request.get("sort")),
+            index_name=request.get("index"),
+            limit=request.get("limit"),
+            cursor=request.get("cursor"),
+            scan_forward=_scan_forward(request.get("sort_direction")),
+            consistent_read=bool(request.get("consistent_read", False)),
+            projection=request.get("projection"),
+            filter=_filter_expression(request.get("filter", [])),
+        )
+        return {"items": [_contract_item(item) for item in page.items], "cursor": page.next_cursor}
+
+    def scan(self, model: str, request: dict[str, Any]) -> dict[str, Any]:
+        page = self.tables[model].scan(
+            index_name=request.get("index"),
+            limit=request.get("limit"),
+            cursor=request.get("cursor"),
+            consistent_read=bool(request.get("consistent_read", False)),
+            projection=request.get("projection"),
+            filter=_filter_expression(request.get("filter", [])),
+        )
+        return {"items": [_contract_item(item) for item in page.items], "cursor": page.next_cursor}
+
     def transition_append_event(self, actual: dict[str, Any], event: dict[str, Any]) -> None:
         transition_release_state(
             self.tables[actual["model"]],
@@ -254,6 +285,8 @@ def _supported_capabilities() -> list[str]:
         "lifecycle.timestamps",
         "optimistic_lock.version",
         "ttl.epoch_seconds",
+        "query.basic",
+        "scan.basic",
         "release_state.write_policy",
         "release_state.transactional_transition",
         "release_state.provenance_confidence",
@@ -267,6 +300,84 @@ def _missing_capabilities(scenario: dict[str, Any], supported: list[str]) -> lis
         for capability in scenario.get("requires_capabilities", [])
         if capability not in supported_set
     ]
+
+
+def _condition_value(condition: dict[str, Any]) -> Any:
+    if "values" in condition:
+        return condition["values"]
+    return condition.get("value")
+
+
+def _condition_values(condition: dict[str, Any]) -> tuple[Any, ...]:
+    if "values" in condition:
+        return tuple(condition["values"])
+    return (condition.get("value"),)
+
+
+def _sort_condition(condition: dict[str, Any] | None) -> SortKeyCondition | None:
+    if condition is None:
+        return None
+    values = _condition_values(condition)
+    op = str(condition["operator"]).lower()
+    if op == "=":
+        return SortKeyCondition.eq(values[0])
+    if op == "<":
+        return SortKeyCondition.lt(values[0])
+    if op == "<=":
+        return SortKeyCondition.lte(values[0])
+    if op == ">":
+        return SortKeyCondition.gt(values[0])
+    if op == ">=":
+        return SortKeyCondition.gte(values[0])
+    if op == "between":
+        return SortKeyCondition.between(values[0], values[1])
+    if op == "begins_with":
+        return SortKeyCondition.begins_with(values[0])
+    raise ValidationError(f"unsupported sort operator: {condition['operator']}")
+
+
+def _filter_expression(conditions: list[dict[str, Any]]) -> Any:
+    filters = [_filter_condition(condition) for condition in conditions]
+    if not filters:
+        return None
+    if len(filters) == 1:
+        return filters[0]
+    return FilterGroup.and_(*filters)
+
+
+def _filter_condition(condition: dict[str, Any]) -> FilterCondition:
+    values = _condition_values(condition)
+    field = condition["attribute"]
+    op = str(condition["operator"]).lower()
+    if op == "=":
+        return FilterCondition.eq(field, values[0])
+    if op in {"!=", "<>"}:
+        return FilterCondition.ne(field, values[0])
+    if op == "<":
+        return FilterCondition.lt(field, values[0])
+    if op == "<=":
+        return FilterCondition.lte(field, values[0])
+    if op == ">":
+        return FilterCondition.gt(field, values[0])
+    if op == ">=":
+        return FilterCondition.gte(field, values[0])
+    if op == "between":
+        return FilterCondition.between(field, values[0], values[1])
+    if op == "begins_with":
+        return FilterCondition.begins_with(field, values[0])
+    if op == "contains":
+        return FilterCondition.contains(field, values[0])
+    if op == "in":
+        return FilterCondition.in_(field, list(values[0]))
+    if op in {"exists", "attribute_exists"}:
+        return FilterCondition.exists(field)
+    if op in {"not_exists", "attribute_not_exists"}:
+        return FilterCondition.not_exists(field)
+    raise ValidationError(f"unsupported filter operator: {condition['operator']}")
+
+
+def _scan_forward(sort_direction: str | None) -> bool:
+    return str(sort_direction or "ASC").upper() != "DESC"
 
 
 def _dynamodb_client() -> Any:
@@ -353,6 +464,16 @@ def _run_step(
         )
         return
 
+    if step["op"] == "query":
+        result, error = _capture_result(lambda: driver.query(model_name, step["query"]))
+        _assert_read_expectation(step.get("expect", {}), error=error, result=result, model=model)
+        return
+
+    if step["op"] == "scan":
+        result, error = _capture_result(lambda: driver.scan(model_name, step["scan"]))
+        _assert_read_expectation(step.get("expect", {}), error=error, result=result, model=model)
+        return
+
     if step["op"] == "transition_append_event":
         error = _capture_error(lambda: driver.transition_append_event(step["actual"], step["event"]))
         _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
@@ -437,6 +558,42 @@ def _assert_expectation(
         assert item is not None
         for attr, variable_name in expect["item_field_not_equals_var"].items():
             assert item[attr] != variables[variable_name]
+
+
+def _assert_read_expectation(
+    expect: dict[str, Any],
+    *,
+    error: Exception | None,
+    result: dict[str, Any],
+    model: dict[str, Any],
+) -> None:
+    if "error" in expect:
+        assert error is not None
+        assert _map_error(error) == expect["error"]
+        return
+
+    if "ok" in expect:
+        if expect["ok"]:
+            assert error is None
+        else:
+            assert error is not None
+    if error is not None:
+        return
+
+    items = result.get("items", [])
+
+    if "item_count" in expect:
+        assert len(items) == expect["item_count"]
+
+    if "items_contains" in expect:
+        assert len(items) >= len(expect["items_contains"])
+        for index, want_item in enumerate(expect["items_contains"]):
+            have_item = items[index]
+            for attr, want in want_item.items():
+                assert attr in have_item
+                attr_def = _attribute_by_name(model, attr)
+                assert attr_def is not None
+                _assert_value_matches(attr_def["type"], want, have_item[attr])
 
 
 def _map_error(error: Exception) -> str:

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -56,9 +56,15 @@ def _load_models() -> dict[str, dict[str, Any]]:
 
 
 def _load_scenarios() -> list[dict[str, Any]]:
-    scenario_dir = _repo_root() / "contract-tests" / "scenarios" / "p0"
-    scenarios = [_load_yaml(path) for path in sorted(scenario_dir.glob("*.yml"))]
+    scenarios = _load_scenarios_from("p0")
     assert len(scenarios) >= 9
+    return scenarios
+
+
+def _load_scenarios_from(name: str) -> list[dict[str, Any]]:
+    scenario_dir = _repo_root() / "contract-tests" / "scenarios" / name
+    scenarios = [_load_yaml(path) for path in sorted(scenario_dir.glob("*.yml"))]
+    assert scenarios
     return scenarios
 
 
@@ -278,6 +284,27 @@ def test_p0_contract_scenarios_execute_for_python(scenario: dict[str, Any]) -> N
     _run_scenario(client, driver, scenario, models)
 
 
+@pytest.mark.parametrize(
+    "scenario",
+    _load_scenarios_from("interop"),
+    ids=lambda scenario: str(scenario["name"]),
+)
+def test_cross_runtime_interop_scenarios_execute_for_python(scenario: dict[str, Any]) -> None:
+    if os.environ.get("CONTRACT_RUN_INTEROP") != "1":
+        pytest.skip("set CONTRACT_RUN_INTEROP=1 to run cross-runtime interop scenarios")
+
+    models = _load_models()
+    missing = _missing_capabilities(scenario, _supported_capabilities())
+    if missing:
+        pytest.skip(f"scenario requires unsupported capabilities: {', '.join(missing)}")
+
+    client = _dynamodb_client()
+    client.list_tables(Limit=1)
+
+    driver = _TheorydbPyDriver(client)
+    _run_scenario(client, driver, scenario, models)
+
+
 def _supported_capabilities() -> list[str]:
     return [
         "crud",
@@ -400,11 +427,26 @@ def _run_scenario(
 ) -> None:
     model = models[scenario["model"]]
     table_name = scenario.get("table", {}).get("name") or model["table"]["name"]
-    _recreate_table(client, table_name, model)
+    steps, recreate = _steps_for_runtime(scenario, "py")
+    if recreate:
+        _recreate_table(client, table_name, model)
     variables: dict[str, Any] = {}
 
-    for step in scenario["steps"]:
+    for step in steps:
         _run_step(client, driver, step, scenario, models, table_name, variables)
+
+
+def _steps_for_runtime(scenario: dict[str, Any], runtime_name: str) -> tuple[list[dict[str, Any]], bool]:
+    seed_runtime = scenario.get("seed_runtime")
+    if not seed_runtime:
+        return cast(list[dict[str, Any]], scenario["steps"]), True
+    if str(seed_runtime).lower() == runtime_name:
+        return (
+            cast(list[dict[str, Any]], scenario.get("seed_steps", []))
+            + cast(list[dict[str, Any]], scenario.get("read_steps", [])),
+            True,
+        )
+    return cast(list[dict[str, Any]], scenario.get("read_steps", [])), False
 
 
 def _run_step(

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -533,6 +533,10 @@ def _assert_expectation(
             raw_value = None if raw is None else raw.get(attr)
             _assert_value_matches(attr_def["type"], want, item[attr], raw_value)
 
+    if "item_equals" in expect:
+        assert item is not None
+        _assert_item_equals(expect["item_equals"], item, raw, model)
+
     if "item_has_fields" in expect:
         assert item is not None
         for attr in expect["item_has_fields"]:
@@ -595,6 +599,32 @@ def _assert_read_expectation(
                 assert attr_def is not None
                 _assert_value_matches(attr_def["type"], want, have_item[attr])
 
+    if "cursor_equals" in expect:
+        assert (result.get("cursor") or "") == expect["cursor_equals"]
+
+
+def _assert_item_equals(
+    want: dict[str, Any],
+    item: dict[str, Any],
+    raw: dict[str, Any] | None,
+    model: dict[str, Any],
+) -> None:
+    if raw is not None:
+        assert sorted(raw.keys()) == sorted(want.keys())
+        for attr, want_value in want.items():
+            assert attr in raw
+            attr_def = _attribute_by_name(model, attr)
+            assert attr_def is not None
+            _assert_value_matches(attr_def["type"], want_value, item.get(attr), raw[attr])
+        return
+
+    assert sorted(item.keys()) == sorted(want.keys())
+    for attr, want_value in want.items():
+        assert attr in item
+        attr_def = _attribute_by_name(model, attr)
+        assert attr_def is not None
+        _assert_value_matches(attr_def["type"], want_value, item[attr])
+
 
 def _map_error(error: Exception) -> str:
     if isinstance(error, NotFoundError):
@@ -641,6 +671,10 @@ def _normalize_contract_value(value: Any) -> Any:
 
 def _assert_value_matches(attr_type: str, want: Any, have: Any, raw: dict[str, Any] | None = None) -> None:
     if attr_type == "S":
+        if raw is not None:
+            assert "S" in raw
+            assert raw["S"] == str(want)
+            return
         assert str(have) == str(want)
         return
     if attr_type == "N":
@@ -651,6 +685,10 @@ def _assert_value_matches(attr_type: str, want: Any, have: Any, raw: dict[str, A
         assert _canonical_decimal_string(have) == _canonical_decimal_string(want)
         return
     if attr_type == "SS":
+        if raw is not None:
+            assert "SS" in raw
+            assert sorted(str(item) for item in raw["SS"]) == sorted(str(item) for item in want)
+            return
         assert sorted(str(item) for item in have) == sorted(str(item) for item in want)
         return
     assert have == want

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -553,10 +553,31 @@ def _assert_expectation(
     item: dict[str, Any] | None = None,
     raw: dict[str, Any] | None = None,
 ) -> None:
+    has_item_assertion = _expectation_has_any_key(
+        expect,
+        {
+            "item_contains",
+            "item_equals",
+            "item_has_fields",
+            "item_missing_fields",
+            "raw_attribute_types",
+            "item_field_equals_var",
+            "item_field_not_equals_var",
+        },
+    )
+    has_raw_assertion = _expectation_has_any_key(expect, {"item_missing_fields", "raw_attribute_types"})
+
     if "error" in expect:
         assert error is not None
         assert _map_error(error) == expect["error"]
+        assert not has_item_assertion, "item assertions cannot be combined with error expectations"
         return
+
+    if has_item_assertion:
+        assert error is None, "expected successful operation for item assertions"
+        assert item is not None, "expected item for item assertions"
+    if has_raw_assertion:
+        assert raw is not None, "expected raw item for raw assertions"
 
     if "ok" in expect:
         if expect["ok"]:
@@ -613,10 +634,17 @@ def _assert_read_expectation(
     result: dict[str, Any],
     model: dict[str, Any],
 ) -> None:
+    has_read_assertion = _expectation_has_any_key(expect, {"item_count", "items_contains", "cursor_equals"})
+
     if "error" in expect:
         assert error is not None
         assert _map_error(error) == expect["error"]
+        assert not has_read_assertion, "read assertions cannot be combined with error expectations"
         return
+
+    if has_read_assertion:
+        assert error is None, "expected successful read for read assertions"
+        assert result is not None, "expected read result for read assertions"
 
     if "ok" in expect:
         if expect["ok"]:
@@ -643,6 +671,42 @@ def _assert_read_expectation(
 
     if "cursor_equals" in expect:
         assert (result.get("cursor") or "") == expect["cursor_equals"]
+
+
+def _expectation_has_any_key(expect: dict[str, Any], keys: set[str]) -> bool:
+    return any(key in expect for key in keys)
+
+
+def test_assert_expectation_fails_closed_on_item_assertion_error_without_ok() -> None:
+    with pytest.raises(AssertionError, match="expected successful operation for item assertions"):
+        _assert_expectation(
+            {"item_equals": {"PK": "USER#fail-closed"}},
+            error=RuntimeError("missing seeded item"),
+            item=None,
+            raw=None,
+            model=_minimal_user_model(),
+            variables={},
+        )
+
+
+def test_assert_read_expectation_fails_closed_on_read_assertion_error_without_ok() -> None:
+    with pytest.raises(AssertionError, match="expected successful read for read assertions"):
+        _assert_read_expectation(
+            {"items_contains": [{"PK": "USER#fail-closed"}]},
+            error=RuntimeError("read failed"),
+            result={},
+            model=_minimal_user_model(),
+        )
+
+
+def _minimal_user_model() -> dict[str, Any]:
+    return {
+        "name": "User",
+        "attributes": [
+            {"attribute": "PK", "type": "S"},
+            {"attribute": "SK", "type": "S"},
+        ],
+    }
 
 
 def _assert_item_equals(

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -409,7 +409,8 @@ def _assert_expectation(
             assert attr in item
             attr_def = _attribute_by_name(model, attr)
             assert attr_def is not None
-            _assert_value_matches(attr_def["type"], want, item[attr])
+            raw_value = None if raw is None else raw.get(attr)
+            _assert_value_matches(attr_def["type"], want, item[attr], raw_value)
 
     if "item_has_fields" in expect:
         assert item is not None
@@ -481,17 +482,40 @@ def _normalize_contract_value(value: Any) -> Any:
     return value
 
 
-def _assert_value_matches(attr_type: str, want: Any, have: Any) -> None:
+def _assert_value_matches(attr_type: str, want: Any, have: Any, raw: dict[str, Any] | None = None) -> None:
     if attr_type == "S":
         assert str(have) == str(want)
         return
     if attr_type == "N":
-        assert Decimal(str(have)) == Decimal(str(want))
+        if raw is not None:
+            assert "N" in raw
+            assert raw["N"] == _canonical_decimal_string(want)
+            return
+        assert _canonical_decimal_string(have) == _canonical_decimal_string(want)
         return
     if attr_type == "SS":
         assert sorted(str(item) for item in have) == sorted(str(item) for item in want)
         return
     assert have == want
+
+
+def _canonical_decimal_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        raise AssertionError("DynamoDB N expectations must not be boolean")
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    if isinstance(value, float):
+        if not Decimal(str(value)).is_finite():
+            raise AssertionError("DynamoDB N expectations must be finite")
+        text = format(Decimal(str(value)), "f")
+        if "E" in text or "e" in text:
+            raise AssertionError("DynamoDB N expectations must use canonical decimal strings")
+        return text
+    raise AssertionError(f"expected DynamoDB canonical decimal string, got {type(value).__name__}")
 
 
 def _attribute_by_name(model: dict[str, Any], name: str) -> dict[str, Any] | None:

--- a/contract-tests/runners/ts/package.json
+++ b/contract-tests/runners/ts/package.json
@@ -12,6 +12,7 @@
     "test:update-builder": "tsx test/update-builder.contract.test.ts",
     "test:reserved-words": "tsx test/reserved-words.contract.test.ts",
     "test:contract:p0": "tsx test/contract.p0.test.ts",
+    "test:contract:interop": "tsx test/contract.interop.test.ts",
     "test:key-contract": "tsx test/key-contract.contract.test.ts"
   },
   "dependencies": {

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -6,6 +6,7 @@ import {
   transitionReleaseState,
   validateDeployAuthorityMetadata,
 } from "../../../../ts/src/release-state.js";
+import type { ReadCondition, ReadRequest } from "./types.js";
 
 export type ErrorCode =
   | "ErrItemNotFound"
@@ -39,6 +40,8 @@ export interface Driver {
   ): Promise<void>;
   save(model: string, item: Record<string, unknown>): Promise<void>;
   delete(model: string, key: Record<string, unknown>): Promise<void>;
+  query(model: string, req: ReadRequest): Promise<ReadResult>;
+  scan(model: string, req: ReadRequest): Promise<ReadResult>;
   transitionAppendEvent(
     actual: TransitionActual,
     event: TransitionEvent,
@@ -47,6 +50,11 @@ export interface Driver {
     model: string,
     item: Record<string, unknown>,
   ): Promise<void>;
+}
+
+export interface ReadResult {
+  items: Array<Record<string, unknown>>;
+  cursor?: string;
 }
 
 export interface TransitionActual {
@@ -75,6 +83,8 @@ export class TheorydbDriver implements Driver {
       "lifecycle.timestamps",
       "optimistic_lock.version",
       "ttl.epoch_seconds",
+      "query.basic",
+      "scan.basic",
       "release_state.write_policy",
       "release_state.transactional_transition",
       "release_state.provenance_confidence",
@@ -122,6 +132,49 @@ export class TheorydbDriver implements Driver {
     await this.client.delete(model, key);
   }
 
+  async query(model: string, req: ReadRequest): Promise<ReadResult> {
+    let builder = this.client.query(model);
+    if (req.index) builder = builder.usingIndex(req.index);
+    if (!req.partition) {
+      throw new TheorydbError(
+        "ErrMissingPrimaryKey",
+        "query partition is required",
+      );
+    }
+    builder = builder.partitionKey(conditionValue(req.partition));
+    if (req.sort) {
+      builder = builder.sortKey(
+        normalizeSortOperator(req.sort.operator),
+        ...conditionValues(req.sort),
+      );
+    }
+    builder = applyReadOptions(builder, req);
+    for (const filter of req.filter ?? []) {
+      builder = builder.filter(
+        filter.attribute,
+        filter.operator,
+        ...conditionValues(filter),
+      );
+    }
+    const page = await builder.page();
+    return { items: page.items, cursor: page.cursor };
+  }
+
+  async scan(model: string, req: ReadRequest): Promise<ReadResult> {
+    let builder = this.client.scan(model);
+    if (req.index) builder = builder.usingIndex(req.index);
+    builder = applyReadOptions(builder, req);
+    for (const filter of req.filter ?? []) {
+      builder = builder.filter(
+        filter.attribute,
+        filter.operator,
+        ...conditionValues(filter),
+      );
+    }
+    const page = await builder.page();
+    return { items: page.items, cursor: page.cursor };
+  }
+
   async transitionAppendEvent(
     actual: TransitionActual,
     event: TransitionEvent,
@@ -148,6 +201,62 @@ export class TheorydbDriver implements Driver {
     }
     validateDeployAuthorityMetadata(item);
   }
+}
+
+function applyReadOptions<
+  T extends {
+    consistentRead(enabled?: boolean): T;
+    limit(n: number): T;
+    projection(fields: string[]): T;
+    cursor(encoded: string): T;
+  },
+>(builder: T, req: ReadRequest): T {
+  let out = builder;
+  if (req.consistent_read) out = out.consistentRead(true);
+  if (req.limit !== undefined) out = out.limit(req.limit);
+  if (req.projection?.length) out = out.projection(req.projection);
+  if (req.cursor) out = out.cursor(req.cursor);
+  if ("sort" in out && req.sort_direction) {
+    out = (out as T & { sort(direction: "ASC" | "DESC"): T }).sort(
+      normalizeSortDirection(req.sort_direction),
+    );
+  }
+  return out;
+}
+
+function conditionValue(condition: ReadCondition): unknown {
+  return condition.values !== undefined ? condition.values : condition.value;
+}
+
+function conditionValues(condition: ReadCondition): unknown[] {
+  if (condition.values !== undefined) return condition.values;
+  if (condition.value === undefined) return [];
+  return [condition.value];
+}
+
+function normalizeSortOperator(
+  op: string,
+): "=" | "<" | "<=" | ">" | ">=" | "between" | "begins_with" {
+  const normalized = op.toLowerCase();
+  switch (normalized) {
+    case "=":
+    case "<":
+    case "<=":
+    case ">":
+    case ">=":
+    case "between":
+    case "begins_with":
+      return normalized;
+    default:
+      throw new TheorydbError(
+        "ErrInvalidOperator",
+        `unsupported sort operator: ${op}`,
+      );
+  }
+}
+
+function normalizeSortDirection(value: string): "ASC" | "DESC" {
+  return value.toUpperCase() === "DESC" ? "DESC" : "ASC";
 }
 
 function validateReleaseStateMetadataIfPresent(

--- a/contract-tests/runners/ts/src/load.ts
+++ b/contract-tests/runners/ts/src/load.ts
@@ -56,45 +56,71 @@ export async function loadScenariosDir(dir: string): Promise<Scenario[]> {
 }
 
 function validateScenario(scenario: Scenario, filePath: string): void {
-  if (!Array.isArray(scenario.steps) || scenario.steps.length === 0) {
+  if (scenario.seed_runtime) {
+    if (
+      !Array.isArray(scenario.seed_steps) ||
+      scenario.seed_steps.length === 0
+    ) {
+      throw new Error(`Scenario missing seed_steps: ${filePath}`);
+    }
+    if (
+      !Array.isArray(scenario.read_steps) ||
+      scenario.read_steps.length === 0
+    ) {
+      throw new Error(`Scenario missing read_steps: ${filePath}`);
+    }
+  } else if (!Array.isArray(scenario.steps) || scenario.steps.length === 0) {
     throw new Error(`Scenario missing steps: ${filePath}`);
   }
-  for (const [index, step] of scenario.steps.entries()) {
-    const prefix = `${filePath} step ${index} ${step.op}`;
-    switch (step.op) {
-      case "sleep":
-        break;
-      case "create":
-      case "update":
-      case "save":
-        requirePlainObject(step.item, `${prefix}: item is required`);
-        break;
-      case "get":
-      case "delete":
-        requirePlainObject(step.key, `${prefix}: key is required`);
-        break;
-      case "query":
-        requireReadRequest(step.query, `${prefix}: query`);
-        requireReadCondition(
-          step.query?.partition,
-          `${prefix}: query.partition`,
-        );
-        break;
-      case "scan":
-        requireReadRequest(step.scan, `${prefix}: scan`);
-        break;
-      case "transition_append_event":
-        requireTransitionActual(step.actual, `${prefix}: actual`);
-        requireTransitionEvent(step.event, `${prefix}: event`);
-        break;
-      case "validate_provenance":
-        requirePlainObject(step.item, `${prefix}: item is required`);
-        break;
-      default:
-        throw new Error(
-          `${filePath} step ${index}: unsupported op ${String(step.op)}`,
-        );
+
+  for (const [label, steps] of [
+    ["steps", scenario.steps ?? []],
+    ["seed_steps", scenario.seed_steps ?? []],
+    ["read_steps", scenario.read_steps ?? []],
+  ] as const) {
+    for (const [index, step] of steps.entries()) {
+      validateStep(filePath, label, index, step);
     }
+  }
+}
+
+function validateStep(
+  filePath: string,
+  label: string,
+  index: number,
+  step: Scenario["steps"][number],
+): void {
+  const prefix = `${filePath} ${label}[${index}] ${step.op}`;
+  switch (step.op) {
+    case "sleep":
+      break;
+    case "create":
+    case "update":
+    case "save":
+      requirePlainObject(step.item, `${prefix}: item is required`);
+      break;
+    case "get":
+    case "delete":
+      requirePlainObject(step.key, `${prefix}: key is required`);
+      break;
+    case "query":
+      requireReadRequest(step.query, `${prefix}: query`);
+      requireReadCondition(step.query?.partition, `${prefix}: query.partition`);
+      break;
+    case "scan":
+      requireReadRequest(step.scan, `${prefix}: scan`);
+      break;
+    case "transition_append_event":
+      requireTransitionActual(step.actual, `${prefix}: actual`);
+      requireTransitionEvent(step.event, `${prefix}: event`);
+      break;
+    case "validate_provenance":
+      requirePlainObject(step.item, `${prefix}: item is required`);
+      break;
+    default:
+      throw new Error(
+        `${filePath} ${label}[${index}]: unsupported op ${String(step.op)}`,
+      );
   }
 }
 

--- a/contract-tests/runners/ts/src/load.ts
+++ b/contract-tests/runners/ts/src/load.ts
@@ -73,6 +73,16 @@ function validateScenario(scenario: Scenario, filePath: string): void {
       case "delete":
         requirePlainObject(step.key, `${prefix}: key is required`);
         break;
+      case "query":
+        requireReadRequest(step.query, `${prefix}: query`);
+        requireReadCondition(
+          step.query?.partition,
+          `${prefix}: query.partition`,
+        );
+        break;
+      case "scan":
+        requireReadRequest(step.scan, `${prefix}: scan`);
+        break;
       case "transition_append_event":
         requireTransitionActual(step.actual, `${prefix}: actual`);
         requireTransitionEvent(step.event, `${prefix}: event`);
@@ -86,6 +96,59 @@ function validateScenario(scenario: Scenario, filePath: string): void {
         );
     }
   }
+}
+
+function requireReadRequest(value: unknown, prefix: string): void {
+  requirePlainObject(value, `${prefix} is required`);
+  const request = value as {
+    partition?: unknown;
+    sort?: unknown;
+    filter?: unknown;
+  };
+  if (request.sort !== undefined) {
+    requireReadCondition(request.sort, `${prefix}.sort`);
+  }
+  if (request.filter !== undefined) {
+    if (!Array.isArray(request.filter)) {
+      throw new Error(`${prefix}.filter must be an array`);
+    }
+    for (const [index, cond] of request.filter.entries()) {
+      requireReadCondition(cond, `${prefix}.filter[${index}]`);
+    }
+  }
+}
+
+function requireReadCondition(value: unknown, prefix: string): void {
+  requirePlainObject(value, `${prefix} is required`);
+  const condition = value as {
+    attribute?: unknown;
+    operator?: unknown;
+    value?: unknown;
+    values?: unknown;
+  };
+  if (typeof condition.attribute !== "string" || !condition.attribute) {
+    throw new Error(`${prefix}.attribute is required`);
+  }
+  if (typeof condition.operator !== "string" || !condition.operator) {
+    throw new Error(`${prefix}.operator is required`);
+  }
+  if (
+    condition.value === undefined &&
+    condition.values === undefined &&
+    !readOperatorAllowsNoValue(condition.operator)
+  ) {
+    throw new Error(`${prefix}.value or ${prefix}.values is required`);
+  }
+}
+
+function readOperatorAllowsNoValue(operator: unknown): boolean {
+  if (typeof operator !== "string") return false;
+  return [
+    "exists",
+    "attribute_exists",
+    "not_exists",
+    "attribute_not_exists",
+  ].includes(operator.toLowerCase());
 }
 
 function requireTransitionActual(value: unknown, prefix: string): void {

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -125,6 +125,28 @@ async function runStep(opts: {
     return;
   }
 
+  if (step.op === "query") {
+    assert.ok(step.query, "query request is required");
+    const res = await captureResult(() => driver.query(modelName, step.query!));
+    assertReadExpectation(step.expect, {
+      err: res.err,
+      result: res.value,
+      model,
+    });
+    return;
+  }
+
+  if (step.op === "scan") {
+    assert.ok(step.scan, "scan request is required");
+    const res = await captureResult(() => driver.scan(modelName, step.scan!));
+    assertReadExpectation(step.expect, {
+      err: res.err,
+      result: res.value,
+      model,
+    });
+    return;
+  }
+
   if (step.op === "transition_append_event") {
     assert.ok(step.actual, "transition_append_event actual is required");
     assert.ok(step.event, "transition_append_event event is required");
@@ -157,6 +179,52 @@ async function runStep(opts: {
   }
 
   throw new Error(`unsupported op: ${step.op}`);
+}
+
+function assertReadExpectation(
+  expect: Step["expect"] | undefined,
+  ctx: {
+    err?: unknown;
+    result?: { items: Array<Record<string, unknown>>; cursor?: string };
+    model: DmsModel;
+  },
+): void {
+  if (!expect) return;
+  const { err, result, model } = ctx;
+
+  if (expect.error) {
+    assert.ok(err, "expected error");
+    assert.equal(mapError(err), expect.error);
+    return;
+  }
+
+  if (expect.ok !== undefined) {
+    if (expect.ok) assert.equal(err, undefined);
+    else assert.ok(err, "expected failure");
+  }
+
+  if (err) return;
+  assert.ok(result, "expected read result");
+
+  if (expect.item_count !== undefined) {
+    assert.equal(result.items.length, expect.item_count);
+  }
+
+  if (expect.items_contains) {
+    assert.ok(
+      result.items.length >= expect.items_contains.length,
+      "not enough result items",
+    );
+    for (const [index, wantItem] of expect.items_contains.entries()) {
+      const haveItem = result.items[index]!;
+      for (const [attr, want] of Object.entries(wantItem)) {
+        assert.ok(attr in haveItem, `missing attr ${attr} in result ${index}`);
+        const attrDef = attributeByName(model, attr);
+        assert.ok(attrDef, `unknown attr ${attr}`);
+        assertValueMatches(attrDef.type, want, haveItem[attr]);
+      }
+    }
+  }
 }
 
 function modelByName(

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -225,6 +225,10 @@ function assertReadExpectation(
       }
     }
   }
+
+  if (expect.cursor_equals !== undefined) {
+    assert.equal(result.cursor ?? "", expect.cursor_equals);
+  }
 }
 
 function modelByName(
@@ -272,6 +276,10 @@ function assertExpectation(
     }
   }
 
+  if (expect.item_equals && item) {
+    assertItemEquals(expect.item_equals, item, raw, model);
+  }
+
   if (expect.item_has_fields && item) {
     for (const attr of expect.item_has_fields) {
       assert.ok(attr in item, `expected field ${attr}`);
@@ -308,6 +316,40 @@ function assertExpectation(
   }
 }
 
+function assertItemEquals(
+  want: Record<string, unknown>,
+  item: Record<string, unknown>,
+  raw: Record<string, AttributeValue> | undefined,
+  model: DmsModel,
+): void {
+  if (raw) {
+    assert.deepEqual(
+      Object.keys(raw).sort(),
+      Object.keys(want).sort(),
+      "raw item should contain exactly the expected attributes",
+    );
+    for (const [attr, wantValue] of Object.entries(want)) {
+      const rawValue = raw[attr];
+      assert.ok(rawValue, `missing raw attr ${attr}`);
+      const attrDef = attributeByName(model, attr);
+      assert.ok(attrDef, `unknown attr ${attr}`);
+      assertValueMatches(attrDef.type, wantValue, item[attr], rawValue);
+    }
+    return;
+  }
+
+  assert.deepEqual(
+    Object.keys(item).sort(),
+    Object.keys(want).sort(),
+    "item should contain exactly the expected attributes",
+  );
+  for (const [attr, wantValue] of Object.entries(want)) {
+    const attrDef = attributeByName(model, attr);
+    assert.ok(attrDef, `unknown attr ${attr}`);
+    assertValueMatches(attrDef.type, wantValue, item[attr]);
+  }
+}
+
 function attributeByName(
   model: DmsModel,
   name: string,
@@ -323,6 +365,11 @@ function assertValueMatches(
 ): void {
   switch (type) {
     case "S":
+      if (raw) {
+        assert.ok("S" in raw && raw.S !== undefined, "expected raw S value");
+        assert.equal(raw.S, String(want));
+        return;
+      }
       assert.equal(String(have), String(want));
       return;
     case "N":
@@ -335,7 +382,10 @@ function assertValueMatches(
       return;
     case "SS": {
       const wantArr = asStringArray(want);
-      const haveArr = asStringArray(have);
+      const haveArr =
+        raw && "SS" in raw && raw.SS !== undefined
+          ? raw.SS.slice()
+          : asStringArray(have);
       wantArr.sort();
       haveArr.sort();
       assert.deepEqual(haveArr, wantArr);

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -208,11 +208,30 @@ function assertReadExpectation(
 ): void {
   if (!expect) return;
   const { err, result, model } = ctx;
+  const hasReadAssertion = expectationHasAnyKey(expect, [
+    "item_count",
+    "items_contains",
+    "cursor_equals",
+  ]);
 
   if (expect.error) {
     assert.ok(err, "expected error");
     assert.equal(mapError(err), expect.error);
+    assert.equal(
+      hasReadAssertion,
+      false,
+      "read assertions cannot be combined with error expectations",
+    );
     return;
+  }
+
+  if (hasReadAssertion) {
+    assert.equal(
+      err,
+      undefined,
+      "expected successful read for read assertions",
+    );
+    assert.ok(result, "expected read result for read assertions");
   }
 
   if (expect.ok !== undefined) {
@@ -269,11 +288,41 @@ function assertExpectation(
 ): void {
   if (!expect) return;
   const { err, item, raw, model, vars } = ctx;
+  const hasItemAssertion = expectationHasAnyKey(expect, [
+    "item_contains",
+    "item_equals",
+    "item_has_fields",
+    "item_missing_fields",
+    "raw_attribute_types",
+    "item_field_equals_var",
+    "item_field_not_equals_var",
+  ]);
+  const hasRawAssertion = expectationHasAnyKey(expect, [
+    "item_missing_fields",
+    "raw_attribute_types",
+  ]);
 
   if (expect.error) {
     assert.ok(err, "expected error");
     assert.equal(mapError(err), expect.error);
+    assert.equal(
+      hasItemAssertion,
+      false,
+      "item assertions cannot be combined with error expectations",
+    );
     return;
+  }
+
+  if (hasItemAssertion) {
+    assert.equal(
+      err,
+      undefined,
+      "expected successful operation for item assertions",
+    );
+    assert.ok(item, "expected item for item assertions");
+  }
+  if (hasRawAssertion) {
+    assert.ok(raw, "expected raw item for raw assertions");
   }
 
   if (expect.ok !== undefined) {
@@ -331,6 +380,13 @@ function assertExpectation(
       assert.notEqual(item[attr], vars.get(varName));
     }
   }
+}
+
+function expectationHasAnyKey(
+  expect: NonNullable<Step["expect"]>,
+  keys: readonly (keyof NonNullable<Step["expect"]>)[],
+): boolean {
+  return keys.some((key) => Object.hasOwn(expect, key));
 }
 
 function assertItemEquals(

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -200,7 +200,7 @@ function assertExpectation(
       assert.ok(attr in item, `missing attr ${attr}`);
       const attrDef = attributeByName(model, attr);
       assert.ok(attrDef, `unknown attr ${attr}`);
-      assertValueMatches(attrDef.type, want, have);
+      assertValueMatches(attrDef.type, want, have, raw?.[attr]);
     }
   }
 
@@ -247,13 +247,23 @@ function attributeByName(
   return model.attributes.find((a) => a.attribute === name);
 }
 
-function assertValueMatches(type: string, want: unknown, have: unknown): void {
+function assertValueMatches(
+  type: string,
+  want: unknown,
+  have: unknown,
+  raw?: AttributeValue,
+): void {
   switch (type) {
     case "S":
       assert.equal(String(have), String(want));
       return;
     case "N":
-      assert.equal(Number(have), Number(want));
+      if (raw) {
+        assert.ok("N" in raw && raw.N !== undefined, "expected raw N value");
+        assert.equal(raw.N, canonicalDecimalString(want));
+        return;
+      }
+      assert.equal(canonicalDecimalString(have), canonicalDecimalString(want));
       return;
     case "SS": {
       const wantArr = asStringArray(want);
@@ -266,6 +276,29 @@ function assertValueMatches(type: string, want: unknown, have: unknown): void {
     default:
       assert.deepEqual(have, want);
   }
+}
+
+function canonicalDecimalString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "number") {
+    assert.ok(Number.isFinite(value), "DynamoDB N expectation must be finite");
+    if (Number.isInteger(value)) {
+      assert.ok(
+        Number.isSafeInteger(value),
+        "DynamoDB N integer expectations outside JS safe-integer range must be quoted decimal strings",
+      );
+    }
+    const text = String(value);
+    assert.ok(
+      !/[eE]/.test(text),
+      "DynamoDB N expectations using exponent notation must be quoted canonical decimal strings",
+    );
+    return text;
+  }
+  throw new Error(
+    `expected DynamoDB canonical decimal string, got ${typeof value}`,
+  );
 }
 
 function asStringArray(value: unknown): string[] {

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -37,13 +37,30 @@ export async function runScenario(opts: {
   const tableName = scenario.table?.name ?? model.table.name;
   assert.ok(tableName, "table name required");
 
-  await recreateTable(ddb, tableName, model);
+  const { steps, recreate } = stepsForRuntime(scenario, "ts");
+  if (recreate) {
+    await recreateTable(ddb, tableName, model);
+  }
 
   const vars = new Map<string, unknown>();
 
-  for (const step of scenario.steps) {
+  for (const step of steps) {
     await runStep({ ddb, driver, step, scenario, models, tableName, vars });
   }
+}
+
+function stepsForRuntime(
+  scenario: Scenario,
+  runtimeName: "go" | "ts" | "py",
+): { steps: Step[]; recreate: boolean } {
+  if (!scenario.seed_runtime) return { steps: scenario.steps, recreate: true };
+  if (scenario.seed_runtime.toLowerCase() === runtimeName) {
+    return {
+      steps: [...(scenario.seed_steps ?? []), ...(scenario.read_steps ?? [])],
+      recreate: true,
+    };
+  }
+  return { steps: scenario.read_steps ?? [], recreate: false };
 }
 
 async function runStep(opts: {

--- a/contract-tests/runners/ts/src/types.ts
+++ b/contract-tests/runners/ts/src/types.ts
@@ -112,8 +112,10 @@ export interface Expectation {
   ok?: boolean;
   error?: string;
   item_contains?: Record<string, unknown>;
+  item_equals?: Record<string, unknown>;
   items_contains?: Array<Record<string, unknown>>;
   item_count?: number;
+  cursor_equals?: string;
   item_has_fields?: string[];
   item_missing_fields?: string[];
   raw_attribute_types?: Record<string, string>;

--- a/contract-tests/runners/ts/src/types.ts
+++ b/contract-tests/runners/ts/src/types.ts
@@ -1,16 +1,7 @@
 export type DmsVersion = "0.1";
 
 export type ScalarType =
-  | "S"
-  | "N"
-  | "B"
-  | "BOOL"
-  | "NULL"
-  | "M"
-  | "L"
-  | "SS"
-  | "NS"
-  | "BS";
+  "S" | "N" | "B" | "BOOL" | "NULL" | "M" | "L" | "SS" | "NS" | "BS";
 
 export interface DmsDocument {
   dms_version: DmsVersion;
@@ -65,6 +56,8 @@ export interface Step {
     | "get"
     | "update"
     | "delete"
+    | "query"
+    | "scan"
     | "sleep"
     | "save"
     | "transition_append_event"
@@ -75,11 +68,32 @@ export interface Step {
   protected_attributes?: string[];
   item?: Record<string, unknown>;
   key?: Record<string, unknown>;
+  query?: ReadRequest;
+  scan?: ReadRequest;
   actual?: TransitionActual;
   event?: TransitionEvent;
   ms?: number;
   save?: Record<string, string>;
   expect?: Expectation;
+}
+
+export interface ReadRequest {
+  index?: string;
+  partition?: ReadCondition;
+  sort?: ReadCondition;
+  filter?: ReadCondition[];
+  sort_direction?: "ASC" | "DESC" | "asc" | "desc";
+  limit?: number;
+  projection?: string[];
+  cursor?: string;
+  consistent_read?: boolean;
+}
+
+export interface ReadCondition {
+  attribute: string;
+  operator: string;
+  value?: unknown;
+  values?: unknown[];
 }
 
 export interface TransitionActual {
@@ -98,6 +112,8 @@ export interface Expectation {
   ok?: boolean;
   error?: string;
   item_contains?: Record<string, unknown>;
+  items_contains?: Array<Record<string, unknown>>;
+  item_count?: number;
   item_has_fields?: string[];
   item_missing_fields?: string[];
   raw_attribute_types?: Record<string, string>;

--- a/contract-tests/runners/ts/src/types.ts
+++ b/contract-tests/runners/ts/src/types.ts
@@ -48,6 +48,9 @@ export interface Scenario {
   model: string;
   table?: { name?: string };
   steps: Step[];
+  seed_runtime?: "go" | "ts" | "py" | string;
+  seed_steps?: Step[];
+  read_steps?: Step[];
 }
 
 export interface Step {

--- a/contract-tests/runners/ts/test/contract.interop.test.ts
+++ b/contract-tests/runners/ts/test/contract.interop.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+
+import { loadModelsDir, loadScenariosDir } from "../src/load.js";
+import { TheorydbDriver } from "../src/driver.js";
+import { pingDynamo, runScenario } from "../src/runner.js";
+import { defineModel } from "../../../../ts/src/model.js";
+import type { Driver } from "../src/driver.js";
+import type { Scenario } from "../src/types.js";
+
+function contractRoot(): string {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, "..", "..", ".."); // runners/ts/test -> contract-tests
+}
+
+test("cross-runtime interop scenarios (ts read phase)", async (t) => {
+  if (process.env.CONTRACT_RUN_INTEROP !== "1") {
+    t.skip("set CONTRACT_RUN_INTEROP=1 to run cross-runtime interop scenarios");
+    return;
+  }
+
+  const root = contractRoot();
+  const models = await loadModelsDir(path.join(root, "dms", "v0.1", "models"));
+  const scenarios = await loadScenariosDir(
+    path.join(root, "scenarios", "interop"),
+  );
+  assert.ok(models.size > 0);
+  assert.ok(scenarios.length > 0);
+
+  const endpoint = process.env.DYNAMODB_ENDPOINT ?? "http://localhost:8000";
+  const ddb = new DynamoDBClient({
+    region: process.env.AWS_REGION ?? "us-east-1",
+    endpoint,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "dummy",
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "dummy",
+    },
+  });
+
+  await pingDynamo(ddb);
+
+  const compiled = Array.from(models.values()).map((m) => defineModel(m));
+  const driver = new TheorydbDriver(ddb, compiled);
+
+  for (const s of scenarios) {
+    await t.test(s.name, async (st) => {
+      const missing = missingCapabilities(s, driver);
+      if (missing.length > 0) {
+        st.skip(
+          `scenario requires unsupported capabilities: ${missing.join(", ")}`,
+        );
+        return;
+      }
+
+      await runScenario({ ddb, driver, scenario: s, models });
+    });
+  }
+});
+
+function missingCapabilities(scenario: Scenario, driver: Driver): string[] {
+  const supported = new Set(driver.capabilities());
+  return (scenario.requires_capabilities ?? []).filter(
+    (capability) => !supported.has(capability),
+  );
+}

--- a/contract-tests/runners/ts/test/fixtures.test.ts
+++ b/contract-tests/runners/ts/test/fixtures.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadModelsDir, loadScenariosDir } from "../src/load.js";
+import { runScenario } from "../src/runner.js";
 import { decodeCursor, encodeCursor } from "../../../../ts/src/cursor.js";
+import type { Driver } from "../src/driver.js";
+import type { DmsModel, Scenario, Step } from "../src/types.js";
 
 function contractRoot(): string {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -39,3 +42,110 @@ test("golden cursor decodes to expected JSON", async () => {
   const parsed = decodeCursor(cursor);
   assert.equal(encodeCursor(parsed), cursor);
 });
+
+test("interop item assertions fail closed on get errors without ok", async () => {
+  await assert.rejects(
+    () =>
+      runScenario({
+        ddb: {} as never,
+        driver: stubDriver({
+          get: async () => {
+            throw new Error("missing seeded item");
+          },
+        }),
+        scenario: scenarioWithReadStep({
+          op: "get",
+          key: { PK: "USER#fail-closed", SK: "PROFILE#fail-closed" },
+          expect: {
+            item_equals: {
+              PK: "USER#fail-closed",
+              SK: "PROFILE#fail-closed",
+            },
+          },
+        }),
+        models: new Map([[userModel.name, userModel]]),
+      }),
+    /expected successful operation for item assertions/,
+  );
+});
+
+test("interop read assertions fail closed on query errors without ok", async () => {
+  await assert.rejects(
+    () =>
+      runScenario({
+        ddb: {} as never,
+        driver: stubDriver({
+          query: async () => {
+            throw new Error("read failed");
+          },
+        }),
+        scenario: scenarioWithReadStep({
+          op: "query",
+          query: {
+            partition: {
+              attribute: "PK",
+              operator: "=",
+              value: "USER#fail-closed",
+            },
+          },
+          expect: {
+            items_contains: [{ PK: "USER#fail-closed" }],
+          },
+        }),
+        models: new Map([[userModel.name, userModel]]),
+      }),
+    /expected successful read for read assertions/,
+  );
+});
+
+const userModel: DmsModel = {
+  name: "User",
+  table: { name: "users_contract" },
+  keys: {
+    partition: { attribute: "PK", type: "S" },
+    sort: { attribute: "SK", type: "S" },
+  },
+  attributes: [
+    { attribute: "PK", type: "S", required: true, roles: ["pk"] },
+    { attribute: "SK", type: "S", required: true, roles: ["sk"] },
+  ],
+};
+
+function scenarioWithReadStep(step: Step): Scenario {
+  return {
+    name: "unit.interop.fail_closed_assertions",
+    dms_version: "0.1",
+    requires_capabilities: [],
+    model: userModel.name,
+    table: { name: userModel.table.name },
+    steps: [],
+    seed_runtime: "go",
+    seed_steps: [
+      {
+        op: "create",
+        item: { PK: "unused", SK: "unused" },
+        expect: { ok: true },
+      },
+    ],
+    read_steps: [step],
+  };
+}
+
+function stubDriver(overrides: Partial<Driver>): Driver {
+  const fail = async (): Promise<never> => {
+    throw new Error("unexpected stub driver call");
+  };
+  return {
+    capabilities: () => [],
+    create: fail,
+    get: fail,
+    update: fail,
+    save: fail,
+    delete: fail,
+    query: fail,
+    scan: fail,
+    transitionAppendEvent: fail,
+    validateProvenance: fail,
+    ...overrides,
+  };
+}

--- a/contract-tests/scenarios/interop/01-release-state-event-seeded-by-go.yml
+++ b/contract-tests/scenarios/interop/01-release-state-event-seeded-by-go.yml
@@ -1,0 +1,28 @@
+name: "interop.release_state_event.seeded_by_go"
+dms_version: "0.1"
+requires_capabilities: ["release_state.write_policy"]
+model: "ReleaseStateEvent"
+table:
+  name: "release_state_contract"
+seed_runtime: "go"
+seed_steps:
+  - op: create
+    if_not_exists: true
+    item:
+      PK: "INTEROP#release-state"
+      SK: "EVENT#2026-07-03T01:30:00Z"
+      releaseId: "rel_interop_go_seed"
+      eventType: "seeded"
+    expect:
+      ok: true
+read_steps:
+  - op: get
+    key:
+      PK: "INTEROP#release-state"
+      SK: "EVENT#2026-07-03T01:30:00Z"
+    expect:
+      item_equals:
+        PK: "INTEROP#release-state"
+        SK: "EVENT#2026-07-03T01:30:00Z"
+        releaseId: "rel_interop_go_seed"
+        eventType: "seeded"

--- a/contract-tests/scenarios/interop/01-release-state-event-seeded-by-go.yml
+++ b/contract-tests/scenarios/interop/01-release-state-event-seeded-by-go.yml
@@ -21,6 +21,7 @@ read_steps:
       PK: "INTEROP#release-state"
       SK: "EVENT#2026-07-03T01:30:00Z"
     expect:
+      ok: true
       item_equals:
         PK: "INTEROP#release-state"
         SK: "EVENT#2026-07-03T01:30:00Z"

--- a/contract-tests/scenarios/p0/08-release-state-transactional-transition.yml
+++ b/contract-tests/scenarios/p0/08-release-state-transactional-transition.yml
@@ -50,6 +50,8 @@ steps:
       PK: "RELEASE#service-a"
       SK: "EVENT#2026-04-24T19:05:00Z"
     expect:
-      item_contains:
+      item_equals:
+        PK: "RELEASE#service-a"
+        SK: "EVENT#2026-04-24T19:05:00Z"
         releaseId: "rel_002"
         eventType: "promoted"

--- a/contract-tests/scenarios/p0/10-query-scan-harness.yml
+++ b/contract-tests/scenarios/p0/10-query-scan-harness.yml
@@ -37,6 +37,20 @@ steps:
       partition: { attribute: "PK", operator: "=", value: "USER#QS" }
       sort: { attribute: "SK", operator: "begins_with", value: "PROFILE#" }
       sort_direction: "DESC"
+      limit: 1
+      projection: ["PK", "SK", "nickname"]
+    expect:
+      ok: true
+      item_count: 1
+      cursor_equals: "eyJsYXN0S2V5Ijp7IlBLIjp7IlMiOiJVU0VSI1FTIn0sIlNLIjp7IlMiOiJQUk9GSUxFIzAyIn19LCJzb3J0IjoiREVTQyJ9"
+      items_contains:
+        - { PK: "USER#QS", SK: "PROFILE#02", nickname: "two" }
+
+  - op: query
+    query:
+      partition: { attribute: "PK", operator: "=", value: "USER#QS" }
+      sort: { attribute: "SK", operator: "begins_with", value: "PROFILE#" }
+      sort_direction: "DESC"
       limit: 2
       projection: ["PK", "SK", "nickname"]
     expect:

--- a/contract-tests/scenarios/p0/10-query-scan-harness.yml
+++ b/contract-tests/scenarios/p0/10-query-scan-harness.yml
@@ -3,7 +3,7 @@ dms_version: "0.1"
 requires_capabilities: ["query.basic", "scan.basic"]
 model: "User"
 table:
-  name: "users_query_scan_contract"
+  name: "users_contract"
 steps:
   - op: create
     item:

--- a/contract-tests/scenarios/p0/10-query-scan-harness.yml
+++ b/contract-tests/scenarios/p0/10-query-scan-harness.yml
@@ -1,0 +1,67 @@
+name: "p0.harness.query_scan"
+dms_version: "0.1"
+requires_capabilities: ["query.basic", "scan.basic"]
+model: "User"
+table:
+  name: "users_query_scan_contract"
+steps:
+  - op: create
+    item:
+      PK: "USER#QS"
+      SK: "PROFILE#01"
+      emailHash: "query@example"
+      nickname: "one"
+    expect:
+      ok: true
+
+  - op: create
+    item:
+      PK: "USER#QS"
+      SK: "PROFILE#02"
+      emailHash: "query@example"
+      nickname: "two"
+    expect:
+      ok: true
+
+  - op: create
+    item:
+      PK: "USER#OTHER"
+      SK: "PROFILE#01"
+      emailHash: "other@example"
+      nickname: "other"
+    expect:
+      ok: true
+
+  - op: query
+    query:
+      partition: { attribute: "PK", operator: "=", value: "USER#QS" }
+      sort: { attribute: "SK", operator: "begins_with", value: "PROFILE#" }
+      sort_direction: "DESC"
+      limit: 2
+      projection: ["PK", "SK", "nickname"]
+    expect:
+      ok: true
+      item_count: 2
+      items_contains:
+        - { PK: "USER#QS", SK: "PROFILE#02", nickname: "two" }
+        - { PK: "USER#QS", SK: "PROFILE#01", nickname: "one" }
+
+  - op: query
+    query:
+      index: "gsi-email"
+      partition: { attribute: "emailHash", operator: "=", value: "query@example" }
+      limit: 2
+      projection: ["PK", "SK", "emailHash"]
+    expect:
+      ok: true
+      item_count: 2
+
+  - op: scan
+    scan:
+      filter:
+        - { attribute: "emailHash", operator: "=", value: "query@example" }
+      limit: 10
+      projection: ["PK", "SK", "emailHash"]
+    expect:
+      ok: true
+      item_count: 2

--- a/docs/development/planning/theorydb-contract-tests-suite-outline.md
+++ b/docs/development/planning/theorydb-contract-tests-suite-outline.md
@@ -212,6 +212,9 @@ Minimum assertions required for v0.1:
 - `cursor_equals: "<cursor>"` (byte-for-byte; for golden cursor tests)
 - `item_field_equals_var: { attr: "varName" }` (value equals previously saved var)
 - `item_field_not_equals_var: { attr: "varName" }` (value differs from previously saved var)
+- `item_count: <n>` (exact query/scan result count)
+- `items_contains: [{ attr: value }]` (ordered subset assertions for query/scan results; each value is checked using
+  the DMS attribute type)
 
 Value encoding in scenario files is “logical” (strings/numbers/bools/arrays/objects); the runner encodes based on DMS
 attribute `type`.
@@ -236,6 +239,39 @@ Comparison rules:
 - `query(modelName, request)` returning `{ items, cursor? }`
 - `scan(modelName, request)` returning `{ items, cursor? }`
 - cursor encode/decode must match `theorydb-spec-dms-v0.1` requirements
+
+The scenario harness advertises `query.basic` and `scan.basic` when a runner supports these read operations. Query and
+scan steps use this shape:
+
+```yaml
+- op: query
+  query:
+    index: "gsi-name"              # optional
+    partition: { attribute: "PK", operator: "=", value: "USER#1" }
+    sort: { attribute: "SK", operator: "begins_with", value: "PROFILE#" } # optional
+    sort_direction: "ASC"          # optional; ASC or DESC
+    limit: 10                      # optional
+    projection: ["PK", "SK"]       # optional
+    cursor: "<opaque-cursor>"      # optional
+    consistent_read: true          # optional; not valid for GSIs
+    filter:
+      - { attribute: "status", operator: "=", value: "active" }
+  expect:
+    item_count: 1
+    items_contains:
+      - { PK: "USER#1", SK: "PROFILE" }
+
+- op: scan
+  scan:
+    index: "gsi-name"              # optional
+    filter:
+      - { attribute: "status", operator: "=", value: "active" }
+    limit: 10
+    projection: ["PK", "SK"]
+```
+
+Supported basic operators are `=`, `<`, `<=`, `>`, `>=`, `between`, and `begins_with` for sort-key conditions, plus
+those and `!=`/`<>`, `contains`, `in`, `exists`/`attribute_exists`, and `not_exists`/`attribute_not_exists` for filters.
 
 ### P2 driver operations
 

--- a/docs/development/planning/theorydb-contract-tests-suite-outline.md
+++ b/docs/development/planning/theorydb-contract-tests-suite-outline.md
@@ -274,6 +274,28 @@ scan steps use this shape:
 Supported basic operators are `=`, `<`, `<=`, `>`, `>=`, `between`, and `begins_with` for sort-key conditions, plus
 those and `!=`/`<>`, `contains`, `in`, `exists`/`attribute_exists`, and `not_exists`/`attribute_not_exists` for filters.
 
+### Cross-runtime interop scenarios
+
+Interop scenarios live under `contract-tests/scenarios/interop/` and declare a seed/read manifest:
+
+```yaml
+seed_runtime: "go"
+seed_steps:
+  - op: create
+    item: { ... }
+read_steps:
+  - op: get
+    key: { ... }
+    expect:
+      item_equals: { ... }
+```
+
+The seed runtime recreates the table, runs `seed_steps`, then runs `read_steps` against the same DynamoDB Local instance.
+The non-seed runtimes do **not** recreate the table for that scenario; they run only `read_steps`, so they assert the
+physical items written by the seed runtime. The repository validation script runs the normal per-runtime P0 suites first,
+then runs the interop seed/read sequence in order (`go` seed/read, TypeScript read, Python read) with
+`CONTRACT_RUN_INTEROP=1`.
+
 ### P2 driver operations
 
 - `batchGet(modelName, keys)`

--- a/docs/development/planning/theorydb-contract-tests-suite-outline.md
+++ b/docs/development/planning/theorydb-contract-tests-suite-outline.md
@@ -32,6 +32,9 @@ Contract tests run scenarios against an implementation through a **Driver** inte
   - runs scenario steps through the driver,
   - asserts results (items, errors, cursor strings) using canonical encodings from the spec.
 
+Raw DynamoDB item assertions (`item_missing_fields`, `raw_attribute_types`, and exact raw item comparisons) MUST use
+strongly consistent reads in every runner. Eventual raw reads make the harness itself a source of parity drift.
+
 ## Proposed folder layout (contract repo)
 
 ```text

--- a/docs/development/planning/theorydb-contract-tests-suite-outline.md
+++ b/docs/development/planning/theorydb-contract-tests-suite-outline.md
@@ -205,11 +205,12 @@ Minimum assertions required for v0.1:
 - `ok: true`
 - `error: <ErrorCode>`
 - `item_contains: { attr: value }` (subset match)
-- `item_equals: { ... }` (exact match; optional in v0.1)
+- `item_equals: { ... }` (exact match; when a raw DynamoDB item is available, the raw attribute set must contain exactly
+  these attributes and no extras)
 - `item_has_fields: [attr]` (presence)
 - `item_missing_fields: [attr]` (absence in the *raw DynamoDB item*; critical for `omit_empty`)
 - `raw_attribute_types: { attr: "S"|"N"|"B"|... }` (type assertions against the raw DynamoDB item)
-- `cursor_equals: "<cursor>"` (byte-for-byte; for golden cursor tests)
+- `cursor_equals: "<cursor>"` (byte-for-byte read-result cursor equality; use `""` to assert no cursor)
 - `item_field_equals_var: { attr: "varName" }` (value equals previously saved var)
 - `item_field_not_equals_var: { attr: "varName" }` (value differs from previously saved var)
 - `item_count: <n>` (exact query/scan result count)

--- a/docs/development/planning/theorydb-contract-tests-suite-outline.md
+++ b/docs/development/planning/theorydb-contract-tests-suite-outline.md
@@ -217,6 +217,9 @@ Value encoding in scenario files is “logical” (strings/numbers/bools/arrays/
 attribute `type`.
 
 Comparison rules:
+- DynamoDB `N` values MUST be asserted as their canonical decimal strings. Runners compare the DynamoDB wire string
+  exactly and must not coerce through `int64`, JavaScript `number`, Python `float`, or any other lossy numeric type.
+  Quote non-integer values and integers outside JavaScript's safe-integer range in YAML.
 - DynamoDB set types (`SS`/`NS`/`BS`) MUST be compared **order-insensitively**.
 
 ## Driver interface (what each implementation must provide)

--- a/scripts/verify-contract-tests.sh
+++ b/scripts/verify-contract-tests.sh
@@ -42,4 +42,17 @@ if [[ -d "contract-tests/runners/py" ]]; then
   uv --directory py run pytest -q ../contract-tests/runners/py
 fi
 
+if [[ -d "contract-tests/scenarios/interop" ]]; then
+  echo "contract-tests: cross-runtime interop"
+  if [[ -f "contract-tests/runners/go/go.mod" ]]; then
+    (cd contract-tests/runners/go && CONTRACT_RUN_INTEROP=1 go test . -run TestContract_Interop -v)
+  fi
+  if [[ -f "contract-tests/runners/ts/package.json" ]]; then
+    CONTRACT_RUN_INTEROP=1 npm --prefix contract-tests/runners/ts run test:contract:interop
+  fi
+  if [[ -d "contract-tests/runners/py" ]]; then
+    CONTRACT_RUN_INTEROP=1 uv --directory py run pytest -q ../contract-tests/runners/py/test_contract_p0.py -k interop
+  fi
+fi
+
 echo "contract-tests: PASS"

--- a/scripts/verify-contract-tests.sh
+++ b/scripts/verify-contract-tests.sh
@@ -45,7 +45,7 @@ fi
 if [[ -d "contract-tests/scenarios/interop" ]]; then
   echo "contract-tests: cross-runtime interop"
   if [[ -f "contract-tests/runners/go/go.mod" ]]; then
-    (cd contract-tests/runners/go && CONTRACT_RUN_INTEROP=1 go test . -run TestContract_Interop -v)
+    (cd contract-tests/runners/go && CONTRACT_RUN_INTEROP=1 go test . -run TestContract_Interop -count=1 -v)
   fi
   if [[ -f "contract-tests/runners/ts/package.json" ]]; then
     CONTRACT_RUN_INTEROP=1 npm --prefix contract-tests/runners/ts run test:contract:interop


### PR DESCRIPTION
## Milestone
M5 — harness-foundations for TableTheory contract runners.

## Linear issues covered
- THE-2305 — Complete in this PR: raw-item assertions use consistent reads in the Go runner; TS/Py already did; suite outline documents the invariant.
- THE-2306 — Complete in this PR: runner numeric assertions compare DynamoDB `N` values as canonical decimal strings without lossy int/number coercion; suite outline documents quoted decimal expectations.
- THE-2309 — Complete in this PR: query/scan scenario ops, typed result assertions, capability keys `query.basic` and `scan.basic`, and proof fixture added across Go/TS/Py. Follow-up fixture alignment keeps the proof fixture on the model/DMS table because the current harness does not implement runtime table overrides.
- THE-2310 — Complete in this PR: `item_equals` and `cursor_equals` assertions implemented across Go/TS/Py; existing fixture upgraded to exact raw-item matching.
- THE-2318 — Complete in this PR: Go contract driver maps `ErrEncryptionNotConfigured`, `ErrEncryptedFieldNotQueryable`, and `ErrInvalidEncryptedEnvelope`.
- THE-2319 — Complete in this PR: `seed_runtime` / `seed_steps` / `read_steps` cross-runtime interop support added and wired into `make contract-tests`. Adversarial-review follow-up now makes interop read assertions fail closed across Go/TS/Py and runs the Go interop seed phase with `-count=1` so reruns cannot pass from Go's test cache.

## Affected runtimes
Go, TypeScript, and Python contract runners/harness only.

## Contract impact
Harness-foundation change. Adds scenario schema capabilities for query/scan, exact item/cursor assertions, and cross-runtime seed/read phases. Adds minimal proof fixtures only; does not implement M6 pin-the-core scenario content.

## Backward compatibility
Additive harness-only changes. Existing P0 fixtures continue to pass across all three runtimes.

## Validation
- Focused fail-closed regressions — PASS:
  - `go test ./internal/runner -run 'TestAssert.*FailsClosed' -count=1 -v`
  - `npm --prefix contract-tests/runners/ts run test:fixtures`
  - `uv --directory py run pytest -q ../contract-tests/runners/py/test_contract_p0.py -k 'fails_closed'`
- Go interop rerun/cache proof — PASS: ran `CONTRACT_RUN_INTEROP=1 go test . -run TestContract_Interop -count=1 -v` twice; both executions ran the seed/read test and did not report `(cached)`.
- `make contract-tests` — PASS (normal Go/TS/Py P0 suites plus cross-runtime interop phase)
- `git diff --check` — PASS
- `make rubric` — PASS (`Status: PASS (pass=36 fail=0 blocked=0)`)
- `make rubric-fast` — not run separately; full `make rubric` was run and passed.

## Signature verification
All eight new commits since base verify with good local git signatures for `aron23@gmail.com` (ED25519 key `SHA256:q7HPwpHpeTN3JDe9vzuMxby+Nc1n4trLrVNWUL7pzE8`).

## Cross-repo coordination
None expected for this milestone. THE-2319 may unblock later M6 work, but this PR does not implement those later scenarios.

## Risks / follow-ups
- Cross-runtime interop is wired through the contract validation script after normal P0 suites so the seed table is not destroyed before TS/Py read phases.
- Numeric decimal string support is in the harness assertion path; broader number-precision scenario content remains for the later scoped M6 item.
- Current runners do not support runtime table-name override from scenario `table.name`; fixtures that exercise driver writes should use the DMS/model table until explicit table override support is scoped.
