### PR TITLE
M8 error taxonomy

### DIFF
--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -28,6 +28,7 @@ type ErrorCode string
 const (
 	ErrItemNotFound      ErrorCode = "ErrItemNotFound"
 	ErrConditionFailed   ErrorCode = "ErrConditionFailed"
+	ErrVersionConflict   ErrorCode = "ErrVersionConflict"
 	ErrInvalidModel      ErrorCode = "ErrInvalidModel"
 	ErrMissingPrimaryKey ErrorCode = "ErrMissingPrimaryKey"
 	ErrInvalidOperator   ErrorCode = "ErrInvalidOperator"
@@ -91,31 +92,39 @@ type TransitionEvent struct {
 }
 
 func MapError(err error) ErrorCode {
+	codes := MapErrors(err)
+	if len(codes) == 0 {
+		return ""
+	}
+	return codes[0]
+}
+
+func MapErrors(err error) []ErrorCode {
 	switch {
 	case errors.Is(err, theorydbErrors.ErrItemNotFound):
-		return ErrItemNotFound
+		return []ErrorCode{ErrItemNotFound}
 	case errors.Is(err, theorydbErrors.ErrConditionFailed):
-		return ErrConditionFailed
+		return []ErrorCode{ErrConditionFailed}
 	case errors.Is(err, theorydbErrors.ErrInvalidModel):
-		return ErrInvalidModel
+		return []ErrorCode{ErrInvalidModel}
 	case errors.Is(err, theorydbErrors.ErrMissingPrimaryKey):
-		return ErrMissingPrimaryKey
+		return []ErrorCode{ErrMissingPrimaryKey}
 	case errors.Is(err, theorydbErrors.ErrInvalidOperator):
-		return ErrInvalidOperator
+		return []ErrorCode{ErrInvalidOperator}
 	case errors.Is(err, theorydbErrors.ErrEncryptionNotConfigured):
-		return ErrEncryptionNotConfigured
+		return []ErrorCode{ErrEncryptionNotConfigured}
 	case errors.Is(err, theorydbErrors.ErrEncryptedFieldNotQueryable):
-		return ErrEncryptedFieldNotQueryable
+		return []ErrorCode{ErrEncryptedFieldNotQueryable}
 	case errors.Is(err, theorydbErrors.ErrInvalidEncryptedEnvelope):
-		return ErrInvalidEncryptedEnvelope
+		return []ErrorCode{ErrInvalidEncryptedEnvelope}
 	case errors.Is(err, theorydbErrors.ErrImmutableModelMutation):
-		return ErrImmutableModelMutation
+		return []ErrorCode{ErrImmutableModelMutation}
 	case errors.Is(err, theorydbErrors.ErrProtectedFieldMutation):
-		return ErrProtectedFieldMutation
+		return []ErrorCode{ErrProtectedFieldMutation}
 	case errors.Is(err, theorydbErrors.ErrRejectedDeployAuthorityEvidence):
-		return ErrRejectedDeployAuthorityEvidence
+		return []ErrorCode{ErrRejectedDeployAuthorityEvidence}
 	default:
-		return ""
+		return nil
 	}
 }
 

--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -103,6 +103,8 @@ func MapErrors(err error) []ErrorCode {
 	switch {
 	case errors.Is(err, theorydbErrors.ErrItemNotFound):
 		return []ErrorCode{ErrItemNotFound}
+	case errors.Is(err, theorydbErrors.ErrVersionConflict):
+		return []ErrorCode{ErrConditionFailed, ErrVersionConflict}
 	case errors.Is(err, theorydbErrors.ErrConditionFailed):
 		return []ErrorCode{ErrConditionFailed}
 	case errors.Is(err, theorydbErrors.ErrInvalidModel):
@@ -139,6 +141,7 @@ func (d *TheorydbDriver) Capabilities() []string {
 		"omitempty",
 		"lifecycle.timestamps",
 		"optimistic_lock.version",
+		"error.version_conflict",
 		"ttl.epoch_seconds",
 		"number.precision.exact",
 		"type.matrix",

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -243,6 +243,12 @@ func (r *Runner) assertStepResult(t require.TestingT, expect scenario.Expectatio
 		require.False(t, hasItemAssertion, "item assertions cannot be combined with error expectations")
 		return
 	}
+	if len(expect.Errors) > 0 {
+		require.Error(t, err)
+		require.ElementsMatch(t, errorCodesFromExpectation(expect.Errors), driver.MapErrors(err))
+		require.False(t, hasItemAssertion, "item assertions cannot be combined with error expectations")
+		return
+	}
 	if hasItemAssertion {
 		require.NoError(t, err, "expected successful operation for item assertions")
 		require.NotNil(t, item, "expected item for item assertions")
@@ -328,6 +334,12 @@ func (r *Runner) assertReadResult(t require.TestingT, expect scenario.Expectatio
 	if expect.Error != "" {
 		require.Error(t, err)
 		require.Equal(t, driver.ErrorCode(expect.Error), driver.MapError(err))
+		require.False(t, hasReadAssertion, "read assertions cannot be combined with error expectations")
+		return
+	}
+	if len(expect.Errors) > 0 {
+		require.Error(t, err)
+		require.ElementsMatch(t, errorCodesFromExpectation(expect.Errors), driver.MapErrors(err))
 		require.False(t, hasReadAssertion, "read assertions cannot be combined with error expectations")
 		return
 	}
@@ -438,6 +450,14 @@ func expectationHasReadAssertion(expect scenario.Expectation) bool {
 		len(expect.ItemsContains) > 0 ||
 		len(expect.ItemsMissingFields) > 0 ||
 		expect.CursorEquals != nil
+}
+
+func errorCodesFromExpectation(values []string) []driver.ErrorCode {
+	out := make([]driver.ErrorCode, 0, len(values))
+	for _, value := range values {
+		out = append(out, driver.ErrorCode(value))
+	}
+	return out
 }
 
 func assertItemEquals(t require.TestingT, want map[string]any, item map[string]any, raw map[string]types.AttributeValue, model spec.Model) {

--- a/contract-tests/runners/go/internal/scenario/scenario.go
+++ b/contract-tests/runners/go/internal/scenario/scenario.go
@@ -81,6 +81,7 @@ type TransitionEvent struct {
 type Expectation struct {
 	Ok                    *bool             `yaml:"ok"`
 	Error                 string            `yaml:"error"`
+	Errors                []string          `yaml:"errors"`
 	ItemContains          map[string]any    `yaml:"item_contains"`
 	ItemEquals            map[string]any    `yaml:"item_equals"`
 	RawItemContains       map[string]any    `yaml:"raw_item_contains"`

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -768,6 +768,11 @@ def _assert_expectation(
         assert _map_error(error) == expect["error"]
         assert not has_item_assertion, "item assertions cannot be combined with error expectations"
         return
+    if "errors" in expect:
+        assert error is not None
+        assert sorted(_map_errors(error)) == sorted(expect["errors"])
+        assert not has_item_assertion, "item assertions cannot be combined with error expectations"
+        return
 
     if has_item_assertion:
         assert error is None, "expected successful operation for item assertions"
@@ -845,6 +850,11 @@ def _assert_read_expectation(
     if "error" in expect:
         assert error is not None
         assert _map_error(error) == expect["error"]
+        assert not has_read_assertion, "read assertions cannot be combined with error expectations"
+        return
+    if "errors" in expect:
+        assert error is not None
+        assert sorted(_map_errors(error)) == sorted(expect["errors"])
         assert not has_read_assertion, "read assertions cannot be combined with error expectations"
         return
 
@@ -963,27 +973,32 @@ def _assert_item_equals(
 
 
 def _map_error(error: Exception) -> str:
+    errors = _map_errors(error)
+    return errors[0] if errors else ""
+
+
+def _map_errors(error: Exception) -> list[str]:
     if isinstance(error, NotFoundError):
-        return "ErrItemNotFound"
+        return ["ErrItemNotFound"]
     if isinstance(error, EncryptionNotConfiguredError):
-        return "ErrEncryptionNotConfigured"
+        return ["ErrEncryptionNotConfigured"]
     if isinstance(error, ConditionFailedError):
-        return "ErrConditionFailed"
+        return ["ErrConditionFailed"]
     if isinstance(error, ImmutableModelMutationError):
-        return "ErrImmutableModelMutation"
+        return ["ErrImmutableModelMutation"]
     if isinstance(error, ProtectedFieldMutationError):
-        return "ErrProtectedFieldMutation"
+        return ["ErrProtectedFieldMutation"]
     if isinstance(error, RejectedDeployAuthorityEvidenceError):
-        return "ErrRejectedDeployAuthorityEvidence"
+        return ["ErrRejectedDeployAuthorityEvidence"]
     if isinstance(error, ValidationError):
         if (
             "consistent_read" in str(error)
             or "unsupported sort operator" in str(error)
             or "unsupported filter operator" in str(error)
         ):
-            return "ErrInvalidOperator"
-        return "ErrInvalidModel"
-    return ""
+            return ["ErrInvalidOperator"]
+        return ["ErrInvalidModel"]
+    return []
 
 
 def _expected_version(table: Table[Any], item: dict[str, Any]) -> int | None:

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -30,6 +30,7 @@ from theorydb_py import (
     SortKeyCondition,
     Table,
     ValidationError,
+    VersionConflictError,
     WritePolicy,
     gsi,
     theorydb_field,
@@ -488,6 +489,7 @@ def _supported_capabilities() -> list[str]:
         "omitempty",
         "lifecycle.timestamps",
         "optimistic_lock.version",
+        "error.version_conflict",
         "ttl.epoch_seconds",
         "number.precision.exact",
         "type.matrix",
@@ -982,6 +984,8 @@ def _map_errors(error: Exception) -> list[str]:
         return ["ErrItemNotFound"]
     if isinstance(error, EncryptionNotConfiguredError):
         return ["ErrEncryptionNotConfigured"]
+    if isinstance(error, VersionConflictError):
+        return ["ErrConditionFailed", "ErrVersionConflict"]
     if isinstance(error, ConditionFailedError):
         return ["ErrConditionFailed"]
     if isinstance(error, ImmutableModelMutationError):

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -95,6 +95,7 @@ export class TheorydbDriver implements Driver {
       "omitempty",
       "lifecycle.timestamps",
       "optimistic_lock.version",
+      "error.version_conflict",
       "ttl.epoch_seconds",
       ...(this.exactNumbers ? ["number.precision.exact"] : []),
       "type.matrix",

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -14,6 +14,7 @@ import type { EncryptionScenarioConfig } from "./types.js";
 export type ErrorCode =
   | "ErrItemNotFound"
   | "ErrConditionFailed"
+  | "ErrVersionConflict"
   | "ErrInvalidModel"
   | "ErrMissingPrimaryKey"
   | "ErrInvalidOperator"

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -225,6 +225,16 @@ function assertReadExpectation(
     );
     return;
   }
+  if (expect.errors?.length) {
+    assert.ok(err, "expected error");
+    assert.deepEqual(mapErrors(err).sort(), expect.errors.slice().sort());
+    assert.equal(
+      hasReadAssertion,
+      false,
+      "read assertions cannot be combined with error expectations",
+    );
+    return;
+  }
 
   if (hasReadAssertion) {
     assert.equal(
@@ -333,6 +343,16 @@ function assertExpectation(
   if (expect.error) {
     assert.ok(err, "expected error");
     assert.equal(mapError(err), expect.error);
+    assert.equal(
+      hasItemAssertion,
+      false,
+      "item assertions cannot be combined with error expectations",
+    );
+    return;
+  }
+  if (expect.errors?.length) {
+    assert.ok(err, "expected error");
+    assert.deepEqual(mapErrors(err).sort(), expect.errors.slice().sort());
     assert.equal(
       hasItemAssertion,
       false,
@@ -657,8 +677,19 @@ function asStringArray(value: unknown): string[] {
 }
 
 function mapError(err: unknown): ErrorCode | "" {
-  if (isTheorydbError(err)) return err.code;
-  return "";
+  const codes = mapErrors(err);
+  return codes[0] ?? "";
+}
+
+function mapErrors(err: unknown): ErrorCode[] {
+  if (isTheorydbError(err)) {
+    const maybeCodes = (err as { codes?: unknown }).codes;
+    if (Array.isArray(maybeCodes)) {
+      return maybeCodes.map((code) => String(code) as ErrorCode);
+    }
+    return [err.code];
+  }
+  return [];
 }
 
 function attributeValueTypeName(av: AttributeValue): string {

--- a/contract-tests/runners/ts/src/types.ts
+++ b/contract-tests/runners/ts/src/types.ts
@@ -130,6 +130,7 @@ export interface TransitionEvent {
 export interface Expectation {
   ok?: boolean;
   error?: string;
+  errors?: string[];
   item_contains?: Record<string, unknown>;
   item_equals?: Record<string, unknown>;
   raw_item_contains?: Record<string, unknown>;

--- a/contract-tests/scenarios/p0/14-version-conflict-error.yml
+++ b/contract-tests/scenarios/p0/14-version-conflict-error.yml
@@ -1,0 +1,55 @@
+name: "p0.error_taxonomy.version_conflict"
+dms_version: "0.1"
+requires_capabilities:
+  - "error.version_conflict"
+model: "User"
+table:
+  name: "users_contract"
+steps:
+  - op: create
+    item:
+      PK: "USER#46"
+      SK: "PROFILE"
+      nickname: "v0"
+    expect:
+      ok: true
+
+  - op: create
+    if_not_exists: true
+    item:
+      PK: "USER#46"
+      SK: "PROFILE"
+      nickname: "duplicate"
+    expect:
+      error: "ErrConditionFailed"
+
+  - op: update
+    fields: ["nickname"]
+    item:
+      PK: "USER#46"
+      SK: "PROFILE"
+      nickname: "v1"
+      version: 0
+    expect:
+      ok: true
+
+  - op: update
+    fields: ["nickname"]
+    item:
+      PK: "USER#46"
+      SK: "PROFILE"
+      nickname: "stale"
+      version: 0
+    expect:
+      errors:
+        - "ErrConditionFailed"
+        - "ErrVersionConflict"
+
+  - op: get
+    key:
+      PK: "USER#46"
+      SK: "PROFILE"
+    expect:
+      item_contains:
+        nickname: "v1"
+        version: 1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -438,12 +438,16 @@ TableTheory exports sentinel errors in `github.com/theory-cloud/tabletheory/pkg/
 
 ### Common Errors
 
-| Error Variable       | Description                                          |
-| -------------------- | ---------------------------------------------------- |
-| `ErrItemNotFound`    | Returned by `First()` when no item matches.          |
-| `ErrConditionFailed` | Returned when a conditional write/transaction fails. |
-| `ErrInvalidModel`    | Returned when a struct lacks `theorydb:"pk"` tags.   |
-| `ErrTableNotFound`   | Returned when the table does not exist in AWS.       |
+| Error Variable           | Description                                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `ErrItemNotFound`        | Returned by `First()` when no item matches.                                                      |
+| `ErrConditionFailed`     | Returned when a conditional write/transaction fails.                                             |
+| `ErrVersionConflict`     | Returned when an optimistic-lock version condition fails; still matches `ErrConditionFailed`.    |
+| `ErrThrottled`           | Returned when DynamoDB throttles or returns retryable capacity/service errors.                   |
+| `ErrTransactionConflict` | Returned for DynamoDB transaction conflicts; still matches `ErrTransactionFailed`.               |
+| `ErrInvalidModel`        | Returned when a struct lacks `theorydb:"pk"` tags.                                               |
+| `ErrTableNotFound`       | Returned when the table does not exist in AWS.                                                   |
+| `ErrInvalidTag`          | Returned for invalid `theorydb` tags; tag validation errors include the offending Go field name. |
 
 ### Custom Error Types
 

--- a/docs/struct-definition-guide.md
+++ b/docs/struct-definition-guide.md
@@ -27,6 +27,20 @@ type User struct {
 }
 ```
 
+## Table names
+
+If a model does not define `TableName() string`, TableTheory derives a table name with a simple pluralization rule:
+
+- names ending in `s` get `es`
+- names ending in `y` become `ies`
+- all other names get `s`
+
+Production models should steer table names explicitly instead of relying on pluralization:
+
+```go
+func (User) TableName() string { return "users_contract" }
+```
+
 ## Attribute naming
 
 By default, TableTheory uses your field name (or the configured naming convention) as the DynamoDB attribute name.
@@ -95,6 +109,9 @@ type Item struct {
 	Status string `theorydb:"lsi:status-index" json:"status"`
 }
 ```
+
+Legacy `index:lsi-*` / `index:lsi_*` prefix inference is still accepted for compatibility, but registration records a
+metadata warning. Prefer `theorydb:"lsi:<indexName>"` for new or edited models so the index type is explicit.
 
 ## Field-level encryption (`encrypted`)
 

--- a/internal/theorydb/query_executor.go
+++ b/internal/theorydb/query_executor.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -828,7 +829,7 @@ func (qe *queryExecutor) ExecutePutItem(input *core.CompiledQuery, item map[stri
 	_, err = client.PutItem(qe.ctxOrBackground(), putInput)
 	if err != nil {
 		if isConditionalCheckFailedException(err) {
-			return customerrors.ErrConditionFailed
+			return qe.conditionFailedError(input)
 		}
 		return fmt.Errorf("failed to put item: %w", err)
 	}
@@ -905,7 +906,7 @@ func (qe *queryExecutor) ExecuteUpdateItem(input *core.CompiledQuery, key map[st
 	_, err = client.UpdateItem(qe.ctxOrBackground(), updateInput)
 	if err != nil {
 		if isConditionalCheckFailedException(err) {
-			return customerrors.ErrConditionFailed
+			return qe.conditionFailedError(input)
 		}
 		return fmt.Errorf("failed to update item: %w", err)
 	}
@@ -940,7 +941,7 @@ func (qe *queryExecutor) ExecuteUpdateItemWithResult(input *core.CompiledQuery, 
 	output, err := client.UpdateItem(qe.ctxOrBackground(), updateInput)
 	if err != nil {
 		if isConditionalCheckFailedException(err) {
-			return nil, customerrors.ErrConditionFailed
+			return nil, qe.conditionFailedError(input)
 		}
 		return nil, fmt.Errorf("failed to update item: %w", err)
 	}
@@ -991,7 +992,7 @@ func (qe *queryExecutor) ExecuteDeleteItem(input *core.CompiledQuery, key map[st
 	_, err = client.DeleteItem(qe.ctxOrBackground(), deleteInput)
 	if err != nil {
 		if isConditionalCheckFailedException(err) {
-			return customerrors.ErrConditionFailed
+			return qe.conditionFailedError(input)
 		}
 		return fmt.Errorf("failed to delete item: %w", err)
 	}
@@ -1420,6 +1421,57 @@ func setIntLike(field reflect.Value, value int64) {
 func isConditionalCheckFailedException(err error) bool {
 	var ccfe *types.ConditionalCheckFailedException
 	return errors.As(err, &ccfe)
+}
+
+func (qe *queryExecutor) conditionFailedError(input *core.CompiledQuery) error {
+	versionAttr := ""
+	if qe != nil && qe.metadata != nil && qe.metadata.VersionField != nil {
+		versionAttr = qe.metadata.VersionField.DBName
+	}
+	if compiledConditionReferencesVersion(input, versionAttr) {
+		return customerrors.ErrVersionConflict
+	}
+	return customerrors.ErrConditionFailed
+}
+
+func compiledConditionReferencesVersion(input *core.CompiledQuery, versionAttr string) bool {
+	if input == nil || input.ConditionExpression == "" || versionAttr == "" {
+		return false
+	}
+
+	versionAttr = strings.ToLower(versionAttr)
+	for placeholder, attr := range input.ExpressionAttributeNames {
+		if strings.ToLower(attr) == versionAttr && strings.Contains(input.ConditionExpression, placeholder) {
+			return true
+		}
+	}
+
+	return containsExpressionToken(input.ConditionExpression, versionAttr)
+}
+
+func containsExpressionToken(expr string, token string) bool {
+	if token == "" {
+		return false
+	}
+	expr = strings.ToLower(expr)
+	token = strings.ToLower(token)
+	for {
+		idx := strings.Index(expr, token)
+		if idx < 0 {
+			return false
+		}
+		beforeOK := idx == 0 || !isExpressionIdentifierRune(rune(expr[idx-1]))
+		afterIdx := idx + len(token)
+		afterOK := afterIdx == len(expr) || !isExpressionIdentifierRune(rune(expr[afterIdx]))
+		if beforeOK && afterOK {
+			return true
+		}
+		expr = expr[afterIdx:]
+	}
+}
+
+func isExpressionIdentifierRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_'
 }
 
 func buildKeysAndAttributes(input *query.CompiledBatchGet) types.KeysAndAttributes {

--- a/internal/theorydb/query_executor_error_taxonomy_test.go
+++ b/internal/theorydb/query_executor_error_taxonomy_test.go
@@ -1,0 +1,47 @@
+package theorydb
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/model"
+)
+
+func TestQueryExecutorConditionFailedErrorDistinguishesVersionConflict(t *testing.T) {
+	qe := &queryExecutor{metadata: &model.Metadata{
+		VersionField: &model.FieldMetadata{DBName: "revision"},
+	}}
+
+	versionQuery := &core.CompiledQuery{
+		ConditionExpression: "#ver = :expected",
+		ExpressionAttributeNames: map[string]string{
+			"#ver": "revision",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":expected": &types.AttributeValueMemberN{Value: "1"},
+		},
+	}
+
+	err := qe.conditionFailedError(versionQuery)
+	require.True(t, errors.Is(err, theorydbErrors.ErrVersionConflict))
+	require.True(t, errors.Is(err, theorydbErrors.ErrConditionFailed))
+
+	statusQuery := &core.CompiledQuery{
+		ConditionExpression: "#status = :active",
+		ExpressionAttributeNames: map[string]string{
+			"#status": "status",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":active": &types.AttributeValueMemberS{Value: "active"},
+		},
+	}
+
+	err = qe.conditionFailedError(statusQuery)
+	require.True(t, errors.Is(err, theorydbErrors.ErrConditionFailed))
+	require.False(t, errors.Is(err, theorydbErrors.ErrVersionConflict))
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -23,6 +23,17 @@ var (
 	// ErrConditionFailed is returned when a condition check fails
 	ErrConditionFailed = errors.New("condition check failed")
 
+	// ErrVersionConflict is returned when an optimistic-lock version condition fails.
+	// It matches ErrConditionFailed via errors.Is for backward compatibility.
+	ErrVersionConflict = conditionSubtypeError("version conflict")
+
+	// ErrThrottled is returned when DynamoDB rejects an operation due to throttling.
+	ErrThrottled = errors.New("throttled")
+
+	// ErrTransactionConflict is returned when DynamoDB reports a transaction conflict.
+	// It matches ErrTransactionFailed via errors.Is for backward compatibility.
+	ErrTransactionConflict = transactionSubtypeError("transaction conflict")
+
 	// ErrIndexNotFound is returned when a specified index doesn't exist
 	ErrIndexNotFound = errors.New("index not found")
 
@@ -68,6 +79,26 @@ var (
 	// ErrRejectedDeployAuthorityEvidence is returned when provenance/confidence evidence is not deploy-authoritative.
 	ErrRejectedDeployAuthorityEvidence = errors.New("rejected deploy authority evidence")
 )
+
+type conditionSubtypeError string
+
+func (e conditionSubtypeError) Error() string {
+	return string(e)
+}
+
+func (e conditionSubtypeError) Is(target error) bool {
+	return target == ErrConditionFailed
+}
+
+type transactionSubtypeError string
+
+func (e transactionSubtypeError) Error() string {
+	return string(e)
+}
+
+func (e transactionSubtypeError) Is(target error) bool {
+	return target == ErrTransactionFailed
+}
 
 // EncryptedFieldError wraps failures related to theorydb:"encrypted" fields (encryption/decryption).
 // It is safe-by-default: the error string must never include decrypted plaintext.

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -42,6 +42,21 @@ func TestErrorTypes(t *testing.T) {
 			expected: "condition check failed",
 		},
 		{
+			name:     "ErrVersionConflict",
+			err:      ErrVersionConflict,
+			expected: "version conflict",
+		},
+		{
+			name:     "ErrThrottled",
+			err:      ErrThrottled,
+			expected: "throttled",
+		},
+		{
+			name:     "ErrTransactionConflict",
+			err:      ErrTransactionConflict,
+			expected: "transaction conflict",
+		},
+		{
 			name:     "ErrIndexNotFound",
 			err:      ErrIndexNotFound,
 			expected: "index not found",
@@ -109,6 +124,14 @@ func TestErrorTypes(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.err.Error())
 		})
 	}
+}
+
+func TestErrorTaxonomySubtypeCompatibility(t *testing.T) {
+	require.ErrorIs(t, ErrVersionConflict, ErrConditionFailed)
+	require.NotErrorIs(t, ErrConditionFailed, ErrVersionConflict)
+	require.ErrorIs(t, fmt.Errorf("wrapped: %w", ErrVersionConflict), ErrConditionFailed)
+	require.ErrorIs(t, ErrTransactionConflict, ErrTransactionFailed)
+	require.NotErrorIs(t, ErrTransactionFailed, ErrTransactionConflict)
 }
 
 // TestTheorydbError_Error tests the Error method of TheorydbError

--- a/pkg/model/registry.go
+++ b/pkg/model/registry.go
@@ -107,6 +107,7 @@ type Metadata struct {
 	UpdatedAtField   *FieldMetadata
 	TableName        string
 	Indexes          []IndexSchema
+	Warnings         []string
 	WritePolicy      WritePolicy
 	NamingConvention naming.Convention
 }
@@ -354,7 +355,7 @@ func parseField(field reflect.StructField, indexPath []int, metadata *Metadata, 
 
 	fieldMeta, err := parseFieldMetadata(field, indexPath, metadata.NamingConvention)
 	if err != nil {
-		return fmt.Errorf("field validation failed: %w", err)
+		return fmt.Errorf("field %s validation failed: %w", field.Name, err)
 	}
 	if fieldMeta == nil {
 		return nil
@@ -362,7 +363,11 @@ func parseField(field reflect.StructField, indexPath []int, metadata *Metadata, 
 
 	if fieldMeta.IsEncrypted {
 		if fieldMeta.IsPK || fieldMeta.IsSK || len(fieldMeta.IndexInfo) > 0 {
-			return fmt.Errorf("%w: encrypted fields cannot be used as primary or index keys", errors.ErrInvalidTag)
+			return fmt.Errorf(
+				"%w: field %s: encrypted fields cannot be used as primary or index keys",
+				errors.ErrInvalidTag,
+				fieldMeta.Name,
+			)
 		}
 	}
 
@@ -373,7 +378,19 @@ func parseField(field reflect.StructField, indexPath []int, metadata *Metadata, 
 	}
 
 	applySpecialFields(metadata, fieldMeta)
-	return applyFieldIndexes(fieldMeta, indexMap)
+	return applyFieldIndexes(metadata, fieldMeta, indexMap)
+}
+
+func (m *Metadata) addWarning(warning string) {
+	if m == nil || warning == "" {
+		return
+	}
+	for _, existing := range m.Warnings {
+		if existing == warning {
+			return
+		}
+	}
+	m.Warnings = append(m.Warnings, warning)
 }
 
 func isEmbeddedStruct(field reflect.StructField) bool {
@@ -424,8 +441,16 @@ func applySpecialFields(metadata *Metadata, fieldMeta *FieldMetadata) {
 	}
 }
 
-func applyFieldIndexes(fieldMeta *FieldMetadata, indexMap map[string]*IndexSchema) error {
+func applyFieldIndexes(metadata *Metadata, fieldMeta *FieldMetadata, indexMap map[string]*IndexSchema) error {
 	for indexName, role := range fieldMeta.IndexInfo {
+		if _, explicitLSI := fieldMeta.Tags["lsi:"+indexName]; !explicitLSI && determineIndexType(indexName) == LocalSecondaryIndex {
+			metadata.addWarning(fmt.Sprintf(
+				"field %s uses legacy LSI prefix inference for index %q; prefer theorydb:\"lsi:%s\"",
+				fieldMeta.Name,
+				indexName,
+				indexName,
+			))
+		}
 		index := getOrCreateIndexSchema(fieldMeta, indexName, indexMap)
 
 		if role.IsPK {

--- a/pkg/model/registry_test.go
+++ b/pkg/model/registry_test.go
@@ -424,6 +424,48 @@ func TestRegisterInvalidTagTypes(t *testing.T) {
 	}
 }
 
+func TestRegisterInvalidTagNamesOffendingField(t *testing.T) {
+	type TypoTagModel struct {
+		ID     string `theorydb:"pk"`
+		Status string `theorydb:"creted_at"`
+	}
+
+	registry := model.NewRegistry()
+	err := registry.Register(&TypoTagModel{})
+	require.ErrorIs(t, err, theorydbErrors.ErrInvalidTag)
+	require.Contains(t, err.Error(), "Status")
+	require.Contains(t, err.Error(), "unknown tag 'creted_at'")
+}
+
+func TestRegisterLSIPrefixWarning(t *testing.T) {
+	type LegacyLSIPrefixModel struct {
+		PK     string `theorydb:"pk"`
+		SK     string `theorydb:"sk"`
+		Status string `theorydb:"index:lsi-status,sk"`
+	}
+
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&LegacyLSIPrefixModel{}))
+
+	metadata, err := registry.GetMetadata(&LegacyLSIPrefixModel{})
+	require.NoError(t, err)
+	require.NotEmpty(t, metadata.Warnings)
+	require.Contains(t, metadata.Warnings[0], "Status")
+	require.Contains(t, metadata.Warnings[0], `theorydb:"lsi:lsi-status"`)
+
+	type ExplicitLSIModel struct {
+		PK     string `theorydb:"pk"`
+		SK     string `theorydb:"sk"`
+		Status string `theorydb:"lsi:lsi-status"`
+	}
+
+	registry = model.NewRegistry()
+	require.NoError(t, registry.Register(&ExplicitLSIModel{}))
+	metadata, err = registry.GetMetadata(&ExplicitLSIModel{})
+	require.NoError(t, err)
+	require.Empty(t, metadata.Warnings)
+}
+
 func TestGetMetadataByTable(t *testing.T) {
 	registry := model.NewRegistry()
 

--- a/pkg/query/batch_operations.go
+++ b/pkg/query/batch_operations.go
@@ -3,15 +3,18 @@ package query
 
 import (
 	"context"
+	stderrs "errors"
 	"fmt"
 	"reflect"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
 
 	"github.com/theory-cloud/tabletheory/internal/expr"
 	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 )
 
 // BatchUpdateOptions configures batch update operations
@@ -486,32 +489,23 @@ func isRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
-
-	// Check for common retryable DynamoDB errors
-	errStr := err.Error()
-	retryableErrors := []string{
-		"ProvisionedThroughputExceededException",
-		"ThrottlingException",
-		"InternalServerError",
-		"ServiceUnavailable",
-		"RequestLimitExceeded",
+	if stderrs.Is(err, theorydbErrors.ErrThrottled) {
+		return true
 	}
 
-	for _, retryable := range retryableErrors {
-		if contains(errStr, retryable) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// contains checks if a string contains a substring
-func contains(s, substr string) bool {
-	if substr == "" {
+	var apiErr smithy.APIError
+	if !stderrs.As(err, &apiErr) {
 		return false
 	}
-	return len(s) >= len(substr) && s != "" && (s == substr || contains(s[1:], substr) || (len(s) >= len(substr) && s[:len(substr)] == substr))
+
+	switch apiErr.ErrorCode() {
+	case "ProvisionedThroughputExceededException", "ProvisionedThroughputExceeded",
+		"ThrottlingException", "ThrottlingError", "RequestLimitExceeded",
+		"InternalServerError", "ServiceUnavailable":
+		return true
+	default:
+		return false
+	}
 }
 
 // BatchResult represents the result of a batch operation

--- a/pkg/query/batch_operations_test.go
+++ b/pkg/query/batch_operations_test.go
@@ -12,8 +12,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aws/smithy-go"
+
 	"github.com/theory-cloud/tabletheory/pkg/core"
 )
+
+func batchAPIError(code string) error {
+	return &smithy.GenericAPIError{Code: code, Message: "test"}
+}
 
 // Mock types for testing
 type TestItem struct {
@@ -485,7 +491,7 @@ func TestExecuteWithRetry(t *testing.T) {
 		fn := func() error {
 			callCount++
 			if callCount < 3 {
-				return errors.New("ProvisionedThroughputExceededException")
+				return batchAPIError("ProvisionedThroughputExceededException")
 			}
 			return nil
 		}
@@ -512,7 +518,7 @@ func TestExecuteWithRetry(t *testing.T) {
 		callCount := 0
 		fn := func() error {
 			callCount++
-			return errors.New("ThrottlingException")
+			return batchAPIError("ThrottlingException")
 		}
 
 		q := &Query{}
@@ -533,7 +539,7 @@ func TestExecuteWithRetry(t *testing.T) {
 		callCount := 0
 		fn := func() error {
 			callCount++
-			return errors.New("ValidationException")
+			return batchAPIError("ValidationException")
 		}
 
 		q := &Query{}
@@ -571,37 +577,37 @@ func TestIsRetryableError(t *testing.T) {
 	}{
 		{
 			name:      "ProvisionedThroughputExceededException",
-			err:       errors.New("ProvisionedThroughputExceededException: Request rate exceeded"),
+			err:       batchAPIError("ProvisionedThroughputExceededException"),
 			wantRetry: true,
 		},
 		{
 			name:      "ThrottlingException",
-			err:       errors.New("ThrottlingException: Rate exceeded"),
+			err:       batchAPIError("ThrottlingException"),
 			wantRetry: true,
 		},
 		{
 			name:      "InternalServerError",
-			err:       errors.New("InternalServerError: Something went wrong"),
+			err:       batchAPIError("InternalServerError"),
 			wantRetry: true,
 		},
 		{
 			name:      "ServiceUnavailable",
-			err:       errors.New("ServiceUnavailable: Service is down"),
+			err:       batchAPIError("ServiceUnavailable"),
 			wantRetry: true,
 		},
 		{
 			name:      "RequestLimitExceeded",
-			err:       errors.New("RequestLimitExceeded: Too many requests"),
+			err:       batchAPIError("RequestLimitExceeded"),
 			wantRetry: true,
 		},
 		{
 			name:      "ValidationException",
-			err:       errors.New("ValidationException: Invalid input"),
+			err:       batchAPIError("ValidationException"),
 			wantRetry: false,
 		},
 		{
 			name:      "ResourceNotFoundException",
-			err:       errors.New("ResourceNotFoundException: Table not found"),
+			err:       batchAPIError("ResourceNotFoundException"),
 			wantRetry: false,
 		},
 		{
@@ -615,77 +621,6 @@ func TestIsRetryableError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := isRetryableError(tt.err)
 			assert.Equal(t, tt.wantRetry, got)
-		})
-	}
-}
-
-func TestContains(t *testing.T) {
-	tests := []struct {
-		name   string
-		s      string
-		substr string
-		want   bool
-	}{
-		{
-			name:   "exact match",
-			s:      "hello",
-			substr: "hello",
-			want:   true,
-		},
-		{
-			name:   "substring at start",
-			s:      "hello world",
-			substr: "hello",
-			want:   true,
-		},
-		{
-			name:   "substring in middle",
-			s:      "hello world",
-			substr: "lo wo",
-			want:   true,
-		},
-		{
-			name:   "substring at end",
-			s:      "hello world",
-			substr: "world",
-			want:   true,
-		},
-		{
-			name:   "no match",
-			s:      "hello world",
-			substr: "xyz",
-			want:   false,
-		},
-		{
-			name:   "empty substring",
-			s:      "hello",
-			substr: "",
-			want:   false,
-		},
-		{
-			name:   "empty string",
-			s:      "",
-			substr: "hello",
-			want:   false,
-		},
-		{
-			name:   "both empty",
-			s:      "",
-			substr: "",
-			want:   false,
-		},
-		{
-			name:   "substring longer than string",
-			s:      "hi",
-			substr: "hello",
-			want:   false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := contains(tt.s, tt.substr)
-			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/query/cov6_executor_helpers_test.go
+++ b/pkg/query/cov6_executor_helpers_test.go
@@ -241,7 +241,8 @@ func TestUnmarshalItems_PointerSliceAndErrorBranches_COV6(t *testing.T) {
 
 func TestIsConditionalCheckFailed_COV6(t *testing.T) {
 	require.False(t, isConditionalCheckFailed(nil))
-	require.True(t, isConditionalCheckFailed(errors.New("prefix ConditionalCheckFailed suffix")))
+	require.True(t, isConditionalCheckFailed(&types.ConditionalCheckFailedException{}))
+	require.False(t, isConditionalCheckFailed(errors.New("prefix ConditionalCheckFailed suffix")))
 	require.False(t, isConditionalCheckFailed(errors.New("something else")))
 }
 

--- a/pkg/query/executor.go
+++ b/pkg/query/executor.go
@@ -460,7 +460,11 @@ func (e *MainExecutor) ExecuteUpdateItemWithResult(input *core.CompiledQuery, ke
 		return nil, fmt.Errorf("key cannot be empty")
 	}
 
-	req := newUpdateItemRequest(&input.TableName).(*updateItemRequest)
+	req := &updateItemRequest{
+		input: &dynamodb.UpdateItemInput{
+			TableName: &input.TableName,
+		},
+	}
 	req.setAttributes(key)
 	req.applyCompiledQuery(input)
 	if input.ReturnValues == "" {

--- a/pkg/query/executor.go
+++ b/pkg/query/executor.go
@@ -367,6 +367,39 @@ func (r *deleteItemRequest) execute(ctx context.Context, client DynamoDBAPI) err
 	return err
 }
 
+type updateItemRequest struct {
+	input *dynamodb.UpdateItemInput
+}
+
+func newUpdateItemRequest(tableName *string) conditionalWriteRequest {
+	return &updateItemRequest{
+		input: &dynamodb.UpdateItemInput{
+			TableName: tableName,
+		},
+	}
+}
+
+func (r *updateItemRequest) applyCompiledQuery(input *core.CompiledQuery) {
+	if input.UpdateExpression != "" {
+		r.input.UpdateExpression = aws.String(input.UpdateExpression)
+	}
+	applyCompiledQueryWriteConditions(input, &r.input.ConditionExpression, &r.input.ExpressionAttributeNames, &r.input.ExpressionAttributeValues)
+	if input.ReturnValues != "" {
+		r.input.ReturnValues = types.ReturnValue(input.ReturnValues)
+	} else {
+		r.input.ReturnValues = types.ReturnValueNone
+	}
+}
+
+func (r *updateItemRequest) setAttributes(attributes map[string]types.AttributeValue) {
+	r.input.Key = attributes
+}
+
+func (r *updateItemRequest) execute(ctx context.Context, client DynamoDBAPI) error {
+	_, err := client.UpdateItem(ctx, r.input)
+	return err
+}
+
 func (e *MainExecutor) executeConditionalWrite(
 	input *core.CompiledQuery,
 	attributes map[string]types.AttributeValue,
@@ -388,7 +421,7 @@ func (e *MainExecutor) executeConditionalWrite(
 	}
 
 	if isConditionalCheckFailed(err) {
-		return fmt.Errorf("%w: %v", customerrors.ErrConditionFailed, err)
+		return fmt.Errorf("%w: %v", conditionFailedErrorForCompiled(input, ""), err)
 	}
 	return fmt.Errorf("failed to %s item: %w", operation, err)
 }
@@ -415,16 +448,34 @@ func (e *MainExecutor) ExecutePutItem(input *core.CompiledQuery, item map[string
 
 // ExecuteUpdateItem implements UpdateItemExecutor.ExecuteUpdateItem
 func (e *MainExecutor) ExecuteUpdateItem(input *core.CompiledQuery, key map[string]types.AttributeValue) error {
-	// Use the UpdateExecutor from core package
-	updateExecutor := core.NewUpdateExecutor(e.client, e.ctx)
-	return updateExecutor.ExecuteUpdateItem(input, key)
+	return e.executeConditionalWriteRequest(input, key, "key", "update", newUpdateItemRequest)
 }
 
 // ExecuteUpdateItemWithResult implements UpdateItemWithResultExecutor.ExecuteUpdateItemWithResult
 func (e *MainExecutor) ExecuteUpdateItemWithResult(input *core.CompiledQuery, key map[string]types.AttributeValue) (*core.UpdateResult, error) {
-	// Use the UpdateExecutor from core package
-	updateExecutor := core.NewUpdateExecutor(e.client, e.ctx)
-	return updateExecutor.ExecuteUpdateItemWithResult(input, key)
+	if input == nil {
+		return nil, fmt.Errorf("compiled query cannot be nil")
+	}
+	if len(key) == 0 {
+		return nil, fmt.Errorf("key cannot be empty")
+	}
+
+	req := newUpdateItemRequest(&input.TableName).(*updateItemRequest)
+	req.setAttributes(key)
+	req.applyCompiledQuery(input)
+	if input.ReturnValues == "" {
+		req.input.ReturnValues = types.ReturnValueAllNew
+	}
+
+	output, err := e.client.UpdateItem(e.ctx, req.input)
+	if err != nil {
+		if isConditionalCheckFailed(err) {
+			return nil, fmt.Errorf("%w: %v", conditionFailedErrorForCompiled(input, ""), err)
+		}
+		return nil, fmt.Errorf("failed to update item: %w", err)
+	}
+
+	return &core.UpdateResult{Attributes: output.Attributes}, nil
 }
 
 // ExecuteDeleteItem implements DeleteItemExecutor.ExecuteDeleteItem
@@ -518,10 +569,65 @@ func isConditionalCheckFailed(err error) bool {
 		return false
 	}
 	var condErr *types.ConditionalCheckFailedException
-	if errors.As(err, &condErr) {
-		return true
+	return errors.As(err, &condErr)
+}
+
+func conditionFailedErrorForCompiled(input *core.CompiledQuery, versionAttr string) error {
+	if compiledConditionReferencesVersion(input, versionAttr) {
+		return customerrors.ErrVersionConflict
 	}
-	return strings.Contains(err.Error(), "ConditionalCheckFailed")
+	return customerrors.ErrConditionFailed
+}
+
+func compiledConditionReferencesVersion(input *core.CompiledQuery, versionAttr string) bool {
+	if input == nil || input.ConditionExpression == "" {
+		return false
+	}
+
+	candidates := map[string]struct{}{}
+	if versionAttr != "" {
+		candidates[strings.ToLower(versionAttr)] = struct{}{}
+	} else {
+		candidates["version"] = struct{}{}
+	}
+
+	for placeholder, attr := range input.ExpressionAttributeNames {
+		if _, ok := candidates[strings.ToLower(attr)]; ok && strings.Contains(input.ConditionExpression, placeholder) {
+			return true
+		}
+	}
+
+	for attr := range candidates {
+		if containsExpressionToken(input.ConditionExpression, attr) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsExpressionToken(expr string, token string) bool {
+	if token == "" {
+		return false
+	}
+	expr = strings.ToLower(expr)
+	token = strings.ToLower(token)
+	for {
+		idx := strings.Index(expr, token)
+		if idx < 0 {
+			return false
+		}
+		beforeOK := idx == 0 || !isExpressionIdentifierRune(rune(expr[idx-1]))
+		afterIdx := idx + len(token)
+		afterOK := afterIdx == len(expr) || !isExpressionIdentifierRune(rune(expr[afterIdx]))
+		if beforeOK && afterOK {
+			return true
+		}
+		expr = expr[afterIdx:]
+	}
+}
+
+func isExpressionIdentifierRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_'
 }
 
 // ExecuteScanWithPagination implements PaginatedQueryExecutor.ExecuteScanWithPagination

--- a/pkg/query/executor_test.go
+++ b/pkg/query/executor_test.go
@@ -204,6 +204,64 @@ func TestExecuteUpdateItem(t *testing.T) {
 		assert.Equal(t, "test-table", *capturedInput.TableName)
 		assert.Equal(t, key, capturedInput.Key)
 	})
+
+	t.Run("conditional version failure returns version conflict sentinel", func(t *testing.T) {
+		mockClient := &MockDynamoDBClient{
+			UpdateItemFunc: func(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+				return nil, &types.ConditionalCheckFailedException{Message: aws.String("version mismatch")}
+			},
+		}
+
+		executor := NewExecutor(mockClient, ctx)
+		input := &core.CompiledQuery{
+			TableName:           "test-table",
+			UpdateExpression:    "SET #name = :name",
+			ConditionExpression: "#ver = :expected",
+			ExpressionAttributeNames: map[string]string{
+				"#name": "name",
+				"#ver":  "version",
+			},
+			ExpressionAttributeValues: map[string]types.AttributeValue{
+				":name":     &types.AttributeValueMemberS{Value: "Updated Name"},
+				":expected": &types.AttributeValueMemberN{Value: "1"},
+			},
+		}
+		key := map[string]types.AttributeValue{"id": &types.AttributeValueMemberS{Value: "123"}}
+
+		err := executor.ExecuteUpdateItem(input, key)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, customerrors.ErrVersionConflict)
+		assert.ErrorIs(t, err, customerrors.ErrConditionFailed)
+	})
+
+	t.Run("conditional non-version failure remains condition failed", func(t *testing.T) {
+		mockClient := &MockDynamoDBClient{
+			UpdateItemFunc: func(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+				return nil, &types.ConditionalCheckFailedException{Message: aws.String("status mismatch")}
+			},
+		}
+
+		executor := NewExecutor(mockClient, ctx)
+		input := &core.CompiledQuery{
+			TableName:           "test-table",
+			UpdateExpression:    "SET #name = :name",
+			ConditionExpression: "#status = :active",
+			ExpressionAttributeNames: map[string]string{
+				"#name":   "name",
+				"#status": "status",
+			},
+			ExpressionAttributeValues: map[string]types.AttributeValue{
+				":name":   &types.AttributeValueMemberS{Value: "Updated Name"},
+				":active": &types.AttributeValueMemberS{Value: "active"},
+			},
+		}
+		key := map[string]types.AttributeValue{"id": &types.AttributeValueMemberS{Value: "123"}}
+
+		err := executor.ExecuteUpdateItem(input, key)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, customerrors.ErrConditionFailed)
+		assert.NotErrorIs(t, err, customerrors.ErrVersionConflict)
+	})
 }
 
 func TestExecuteDeleteItem(t *testing.T) {

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -3,6 +3,7 @@ package transaction
 
 import (
 	"context"
+	stderrs "errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
 
 	"github.com/theory-cloud/tabletheory/internal/encryption"
 	"github.com/theory-cloud/tabletheory/internal/reflectutil"
@@ -419,19 +421,67 @@ func (tx *Transaction) handleTransactionError(err error) error {
 		return nil
 	}
 
-	// Check for specific transaction errors
-	errStr := err.Error()
-	switch {
-	case contains(errStr, "ConditionalCheckFailed"):
+	var conditionalFailed *types.ConditionalCheckFailedException
+	if stderrs.As(err, &conditionalFailed) {
 		return errors.ErrConditionFailed
-	case contains(errStr, "TransactionCanceled"):
-		// Parse cancellation reasons
-		return fmt.Errorf("transaction canceled: %w", err)
-	case contains(errStr, "ValidationException"):
-		return fmt.Errorf("validation error: %w", err)
-	default:
-		return err
 	}
+
+	var canceled *types.TransactionCanceledException
+	if stderrs.As(err, &canceled) {
+		if transactionCanceledHasReason(canceled, "ConditionalCheckFailed") {
+			return errors.ErrConditionFailed
+		}
+		if transactionCanceledHasReason(canceled, "TransactionConflict") {
+			return errors.ErrTransactionConflict
+		}
+		if transactionCanceledHasReason(canceled,
+			"ProvisionedThroughputExceeded",
+			"ThrottlingError",
+			"InternalServerError",
+		) {
+			return fmt.Errorf("%w: transaction canceled: %v", errors.ErrThrottled, err)
+		}
+		return fmt.Errorf("transaction canceled: %w", err)
+	}
+
+	var apiErr smithy.APIError
+	if stderrs.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "ConditionalCheckFailedException", "ConditionalCheckFailed":
+			return errors.ErrConditionFailed
+		case "TransactionConflictException", "TransactionConflict":
+			return errors.ErrTransactionConflict
+		case "ProvisionedThroughputExceededException", "ProvisionedThroughputExceeded",
+			"ThrottlingException", "ThrottlingError", "RequestLimitExceeded",
+			"InternalServerError", "ServiceUnavailable":
+			return fmt.Errorf("%w: %v", errors.ErrThrottled, err)
+		case "TransactionCanceledException", "TransactionCanceled":
+			return fmt.Errorf("transaction canceled: %w", err)
+		case "ValidationException":
+			return fmt.Errorf("validation error: %w", err)
+		}
+	}
+
+	return err
+}
+
+func transactionCanceledHasReason(exc *types.TransactionCanceledException, codes ...string) bool {
+	if exc == nil {
+		return false
+	}
+	wanted := make(map[string]struct{}, len(codes))
+	for _, code := range codes {
+		wanted[code] = struct{}{}
+	}
+	for _, reason := range exc.CancellationReasons {
+		if reason.Code == nil {
+			continue
+		}
+		if _, ok := wanted[*reason.Code]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // marshalItem converts a model to DynamoDB attribute values
@@ -565,9 +615,4 @@ func (tx *Transaction) extractPrimaryKey(model any, metadata *model.Metadata) (m
 	}
 
 	return key, nil
-}
-
-// contains checks if a string contains a substring
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && (s[0:len(substr)] == substr || contains(s[1:], substr)))
 }

--- a/pkg/transaction/transaction_unit_test.go
+++ b/pkg/transaction/transaction_unit_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
 	"github.com/stretchr/testify/require"
 
 	theorydberrors "github.com/theory-cloud/tabletheory/pkg/errors"
@@ -143,17 +145,43 @@ func TestTransaction_handleTransactionError(t *testing.T) {
 
 	require.NoError(t, tx.handleTransactionError(nil))
 
-	err := tx.handleTransactionError(stderrs.New("prefix ConditionalCheckFailed suffix"))
+	err := tx.handleTransactionError(&types.ConditionalCheckFailedException{})
 	require.ErrorIs(t, err, theorydberrors.ErrConditionFailed)
 
-	err = tx.handleTransactionError(stderrs.New("prefix TransactionCanceled suffix"))
+	err = tx.handleTransactionError(&types.TransactionCanceledException{
+		CancellationReasons: []types.CancellationReason{{Code: aws.String("ConditionalCheckFailed")}},
+	})
+	require.ErrorIs(t, err, theorydberrors.ErrConditionFailed)
+
+	err = tx.handleTransactionError(&types.TransactionCanceledException{
+		CancellationReasons: []types.CancellationReason{{Code: aws.String("TransactionConflict")}},
+	})
+	require.ErrorIs(t, err, theorydberrors.ErrTransactionConflict)
+	require.ErrorIs(t, err, theorydberrors.ErrTransactionFailed)
+
+	err = tx.handleTransactionError(&types.TransactionCanceledException{
+		CancellationReasons: []types.CancellationReason{{Code: aws.String("ThrottlingError")}},
+	})
+	require.ErrorIs(t, err, theorydberrors.ErrThrottled)
+
+	err = tx.handleTransactionError(transactionAPIError("TransactionCanceledException"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "transaction canceled")
 
-	err = tx.handleTransactionError(stderrs.New("prefix ValidationException suffix"))
+	err = tx.handleTransactionError(transactionAPIError("ValidationException"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "validation error")
 
+	err = tx.handleTransactionError(transactionAPIError("ProvisionedThroughputExceededException"))
+	require.ErrorIs(t, err, theorydberrors.ErrThrottled)
+
+	plain := stderrs.New("prefix ConditionalCheckFailed suffix")
+	require.ErrorIs(t, tx.handleTransactionError(plain), plain)
+
 	other := stderrs.New("something else")
 	require.ErrorIs(t, tx.handleTransactionError(other), other)
+}
+
+func transactionAPIError(code string) error {
+	return &smithy.GenericAPIError{Code: code, Message: "test"}
 }

--- a/py/src/theorydb_py/__init__.py
+++ b/py/src/theorydb_py/__init__.py
@@ -19,6 +19,7 @@ from .errors import (
     TheorydbPyError,
     TransactionCanceledError,
     ValidationError,
+    VersionConflictError,
 )
 from .model import (
     AttributeConverter,
@@ -319,6 +320,7 @@ __all__ = [
     "TransactionCanceledError",
     "Table",
     "ValidationError",
+    "VersionConflictError",
     "WritePolicy",
     "__repo_version__",
     "__version__",

--- a/py/src/theorydb_py/aws_errors.py
+++ b/py/src/theorydb_py/aws_errors.py
@@ -8,14 +8,17 @@ from .errors import (
     NotFoundError,
     TransactionCanceledError,
     ValidationError,
+    VersionConflictError,
 )
 
 
-def map_client_error(err: ClientError) -> Exception:
+def map_client_error(err: ClientError, *, version_conflict: bool = False) -> Exception:
     code = str(err.response.get("Error", {}).get("Code", ""))
     message = str(err.response.get("Error", {}).get("Message", ""))
 
     if code == "ConditionalCheckFailedException":
+        if version_conflict:
+            return VersionConflictError(message)
         return ConditionFailedError(message)
     if code == "ValidationException":
         return ValidationError(message)

--- a/py/src/theorydb_py/errors.py
+++ b/py/src/theorydb_py/errors.py
@@ -9,6 +9,10 @@ class ConditionFailedError(TheorydbPyError):
     pass
 
 
+class VersionConflictError(ConditionFailedError):
+    pass
+
+
 class LeaseHeldError(ConditionFailedError):
     pass
 

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -905,7 +905,7 @@ class Table[T]:
         try:
             resp = self._client.update_item(**req)
         except ClientError as err:  # pragma: no cover
-            raise _map_client_error(err) from err
+            raise _map_client_error(err, version_conflict=expected_version is not None) from err
 
         attrs = resp.get("Attributes")
         if not attrs:

--- a/py/src/theorydb_py/update_builder.py
+++ b/py/src/theorydb_py/update_builder.py
@@ -23,6 +23,7 @@ class UpdateBuilder[T]:
         self._return_values: str = "NONE"
         self._updates: list[tuple[str, tuple[Any, ...]]] = []
         self._conditions: list[tuple[str, str, str, Any]] = []
+        self._has_version_condition = False
 
     def set(self, field: str, value: Any) -> UpdateBuilder[T]:
         self._updates.append(("SET", (field, value)))
@@ -96,6 +97,7 @@ class UpdateBuilder[T]:
                 version_field = "version"
         if version_field is None:
             raise ValidationError("model does not define a version field")
+        self._has_version_condition = True
         return self.condition(version_field, "=", current_version)
 
     def return_values(self, option: str) -> UpdateBuilder[T]:
@@ -111,7 +113,7 @@ class UpdateBuilder[T]:
         try:
             resp = self._table._client.update_item(**req)
         except ClientError as err:  # pragma: no cover
-            raise _map_client_error(err) from err
+            raise _map_client_error(err, version_conflict=self._has_version_condition) from err
 
         attrs = resp.get("Attributes")
         if not attrs:

--- a/py/tests/unit/test_table_unit_behaviors.py
+++ b/py/tests/unit/test_table_unit_behaviors.py
@@ -12,6 +12,7 @@ from theorydb_py import (
     SortKeyCondition,
     Table,
     ValidationError,
+    VersionConflictError,
     theorydb_field,
 )
 from theorydb_py.model import Projection, gsi
@@ -293,6 +294,10 @@ def test_error_mapping_helpers() -> None:
     err = ClientError({"Error": {"Code": "ConditionalCheckFailedException", "Message": "no"}}, "PutItem")
     mapped = _map_client_error(err)
     assert mapped.__class__.__name__ == "ConditionFailedError"
+
+    version_mapped = _map_client_error(err, version_conflict=True)
+    assert isinstance(version_mapped, VersionConflictError)
+    assert version_mapped.__class__.__name__ == "VersionConflictError"
 
     tx_err = ClientError(
         {"Error": {"Code": "TransactionCanceledException", "Message": "ConditionalCheckFailed"}},

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -363,7 +363,7 @@ export class TheorydbClient {
     try {
       await this.ddb.send(cmd, this.sendOptions);
     } catch (err) {
-      throw mapDynamoError(err);
+      throw mapDynamoError(err, { versionConflict: true });
     }
   }
 

--- a/ts/src/dynamo-error.ts
+++ b/ts/src/dynamo-error.ts
@@ -5,13 +5,18 @@ import {
 
 import { TheorydbError } from './errors.js';
 
-export function mapDynamoError(err: unknown): unknown {
+export interface DynamoErrorMappingOptions {
+  readonly versionConflict?: boolean;
+}
+
+export function mapDynamoError(
+  err: unknown,
+  options: DynamoErrorMappingOptions = {},
+): unknown {
   if (err instanceof TheorydbError) return err;
 
   if (err instanceof ConditionalCheckFailedException) {
-    return new TheorydbError('ErrConditionFailed', 'Condition failed', {
-      cause: err,
-    });
+    return conditionFailedError('Condition failed', err, options);
   }
 
   if (err instanceof TransactionCanceledException) {
@@ -23,9 +28,7 @@ export function mapDynamoError(err: unknown): unknown {
   if (typeof err === 'object' && err !== null && 'name' in err) {
     const name = (err as { name?: unknown }).name;
     if (name === 'ConditionalCheckFailedException') {
-      return new TheorydbError('ErrConditionFailed', 'Condition failed', {
-        cause: err,
-      });
+      return conditionFailedError('Condition failed', err, options);
     }
     if (name === 'TransactionCanceledException') {
       return new TheorydbError('ErrConditionFailed', 'Transaction canceled', {
@@ -35,4 +38,15 @@ export function mapDynamoError(err: unknown): unknown {
   }
 
   return err;
+}
+
+function conditionFailedError(
+  message: string,
+  cause: unknown,
+  options: DynamoErrorMappingOptions,
+): TheorydbError {
+  return new TheorydbError('ErrConditionFailed', message, {
+    cause,
+    ...(options.versionConflict ? { codes: ['ErrVersionConflict'] } : {}),
+  });
 }

--- a/ts/src/errors.ts
+++ b/ts/src/errors.ts
@@ -1,6 +1,7 @@
 export type ErrorCode =
   | 'ErrItemNotFound'
   | 'ErrConditionFailed'
+  | 'ErrVersionConflict'
   | 'ErrLeaseHeld'
   | 'ErrLeaseNotOwned'
   | 'ErrInvalidModel'
@@ -16,10 +17,16 @@ export type ErrorCode =
 
 export class TheorydbError extends Error {
   readonly code: ErrorCode;
+  readonly codes: readonly ErrorCode[];
 
-  constructor(code: ErrorCode, message: string, options?: { cause?: unknown }) {
+  constructor(
+    code: ErrorCode,
+    message: string,
+    options?: { cause?: unknown; codes?: readonly ErrorCode[] },
+  ) {
     super(message);
     this.code = code;
+    this.codes = uniqueCodes([code, ...(options?.codes ?? [])]);
     this.name = code;
     if (options?.cause !== undefined) {
       // Avoid depending on a specific TS libdom ErrorOptions typing.
@@ -30,4 +37,24 @@ export class TheorydbError extends Error {
 
 export function isTheorydbError(value: unknown): value is TheorydbError {
   return value instanceof TheorydbError;
+}
+
+export function theorydbErrorCodes(value: unknown): readonly ErrorCode[] {
+  if (!isTheorydbError(value)) return [];
+  return value.codes.length > 0 ? value.codes : [value.code];
+}
+
+export function hasTheorydbErrorCode(value: unknown, code: ErrorCode): boolean {
+  return theorydbErrorCodes(value).includes(code);
+}
+
+function uniqueCodes(codes: readonly ErrorCode[]): readonly ErrorCode[] {
+  const seen = new Set<ErrorCode>();
+  const out: ErrorCode[] = [];
+  for (const code of codes) {
+    if (seen.has(code)) continue;
+    seen.add(code);
+    out.push(code);
+  }
+  return out;
 }

--- a/ts/src/update-builder.ts
+++ b/ts/src/update-builder.ts
@@ -281,6 +281,7 @@ export class UpdateBuilder {
   private readonly updateOps: UpdateOp[] = [];
   private readonly conditionOps: ConditionOp[] = [];
   private returnValuesOpt: ReturnValuesOption = 'NONE';
+  private hasVersionCondition = false;
 
   constructor(
     private readonly ddb: DynamoDBClient,
@@ -370,6 +371,7 @@ export class UpdateBuilder {
         `Model ${this.model.name} does not define a version field`,
       );
     }
+    this.hasVersionCondition = true;
     return this.condition(versionAttr, '=', currentVersion);
   }
 
@@ -454,7 +456,9 @@ export class UpdateBuilder {
         : resp.Attributes;
       return unmarshalItem(this.model, attrs, this.unmarshalOptions);
     } catch (err) {
-      throw mapDynamoError(err);
+      throw mapDynamoError(err, {
+        versionConflict: this.hasVersionCondition,
+      });
     }
   }
 

--- a/ts/test/unit/client.test.ts
+++ b/ts/test/unit/client.test.ts
@@ -15,7 +15,7 @@ import {
 } from '@aws-sdk/client-dynamodb';
 
 import { TheorydbClient } from '../../src/client.js';
-import { TheorydbError } from '../../src/errors.js';
+import { hasTheorydbErrorCode, TheorydbError } from '../../src/errors.js';
 import { defineModel } from '../../src/model.js';
 import { createDeterministicEncryptionProvider } from '../../src/testkit/index.js';
 import type { TransactAction } from '../../src/transaction.js';
@@ -167,7 +167,34 @@ class StubDdb {
   );
   await assert.rejects(
     () => client.create('User', { PK: 'A', SK: 'B' }, { ifNotExists: true }),
-    (e) => e instanceof TheorydbError && e.code === 'ErrConditionFailed',
+    (e) =>
+      e instanceof TheorydbError &&
+      e.code === 'ErrConditionFailed' &&
+      !hasTheorydbErrorCode(e, 'ErrVersionConflict'),
+  );
+}
+
+{
+  const err = new ConditionalCheckFailedException({
+    $metadata: {},
+    message: 'stale',
+  });
+  const ddb = new StubDdb(() => {
+    throw err;
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+  await assert.rejects(
+    () =>
+      client.update('User', { PK: 'A', SK: 'B', nickname: 'x', version: 0 }, [
+        'nickname',
+      ]),
+    (e) =>
+      e instanceof TheorydbError &&
+      e.code === 'ErrConditionFailed' &&
+      hasTheorydbErrorCode(e, 'ErrConditionFailed') &&
+      hasTheorydbErrorCode(e, 'ErrVersionConflict'),
   );
 }
 

--- a/ts/test/unit/update-builder.test.ts
+++ b/ts/test/unit/update-builder.test.ts
@@ -7,7 +7,7 @@ import {
 
 import { TheorydbClient } from '../../src/client.js';
 import { encryptAttributeValue } from '../../src/encryption.js';
-import { TheorydbError } from '../../src/errors.js';
+import { hasTheorydbErrorCode, TheorydbError } from '../../src/errors.js';
 import { defineModel } from '../../src/model.js';
 import {
   createDeterministicEncryptionProvider,
@@ -821,7 +821,42 @@ import {
   const client = new TheorydbClient(mock.client).register(model);
   await assert.rejects(
     () => client.updateBuilder('T', { PK: 'A' }).set('name', 'x').execute(),
-    (e) => e instanceof TheorydbError && e.code === 'ErrConditionFailed',
+    (e) =>
+      e instanceof TheorydbError &&
+      e.code === 'ErrConditionFailed' &&
+      !hasTheorydbErrorCode(e, 'ErrVersionConflict'),
+  );
+}
+
+{
+  const mock = createMockDynamoDBClient();
+  mock.when(UpdateItemCommand, async () => {
+    throw { name: 'ConditionalCheckFailedException' };
+  });
+
+  const model = defineModel({
+    name: 'T',
+    table: { name: 't' },
+    keys: { partition: { attribute: 'PK', type: 'S' } },
+    attributes: [
+      { attribute: 'PK', type: 'S', roles: ['pk'] },
+      { attribute: 'name', type: 'S', optional: true },
+      { attribute: 'version', type: 'N', roles: ['version'] },
+    ],
+  });
+
+  const client = new TheorydbClient(mock.client).register(model);
+  await assert.rejects(
+    () =>
+      client
+        .updateBuilder('T', { PK: 'A' })
+        .set('name', 'x')
+        .conditionVersion(1)
+        .execute(),
+    (e) =>
+      e instanceof TheorydbError &&
+      e.code === 'ErrConditionFailed' &&
+      hasTheorydbErrorCode(e, 'ErrVersionConflict'),
   );
 }
 


### PR DESCRIPTION
## Summary

- Add capability-gated P0 contract coverage for distinct version-conflict error taxonomy.
- Implement additive version-conflict error distinctions in Go, TypeScript, and Python while preserving existing `ErrConditionFailed` matching.
- Replace Go AWS error-string classification with typed `errors.As`/API-error classification for query, batch, and transaction paths.
- Improve Go model tag diagnostics by naming the offending field, warning on legacy LSI prefix inference, and documenting table-name pluralization/explicit naming.

## Refs

Refs THE-2338
Refs THE-2339
Refs THE-2340
Refs THE-2341
Refs THE-2342
Refs THE-2343

## Validation

- [x] `make contract-tests`
- [x] `make test-unit`
- [x] `make rubric`
- [x] `cd ts && npm run check`
- [x] `uv --directory py run pytest -q tests/unit`
- [x] `git diff --check project/tabletheory-product-strengthening-2026-07..HEAD`

`bash scripts/verify-generated-ts-key-contract.sh` was not run separately because M8 did not modify key-contract/generated surfaces; `make contract-tests` still ran the generated TS key-contract drift/type/helper parity checks.
