### PR TITLE
feat(query): add native count and optional get

### DIFF
--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -150,6 +150,7 @@ func (d *TheorydbDriver) Capabilities() []string {
 		"type.matrix",
 		"query.basic",
 		"scan.basic",
+		"count.native",
 		"release_state.write_policy",
 		"release_state.transactional_transition",
 		"release_state.provenance_confidence",
@@ -477,11 +478,34 @@ func conditionValue(cond ReadCondition) any {
 }
 
 func (d *TheorydbDriver) CountQuery(ctx context.Context, model string, req ReadRequest) (ReadResult, error) {
-	return ReadResult{}, fmt.Errorf("%w: native count is not advertised", theorydbErrors.ErrInvalidOperator)
+	q, err := d.buildReadQuery(ctx, model, req)
+	if err != nil {
+		return ReadResult{}, err
+	}
+	if req.Partition == nil {
+		return ReadResult{}, fmt.Errorf("%w: query partition is required", theorydbErrors.ErrMissingPrimaryKey)
+	}
+	q = q.Where(req.Partition.Attribute, req.Partition.Operator, conditionValue(*req.Partition))
+	if req.Sort != nil {
+		q = q.Where(req.Sort.Attribute, req.Sort.Operator, conditionValue(*req.Sort))
+	}
+	return countResult(q)
 }
 
 func (d *TheorydbDriver) CountScan(ctx context.Context, model string, req ReadRequest) (ReadResult, error) {
-	return ReadResult{}, fmt.Errorf("%w: native count is not advertised", theorydbErrors.ErrInvalidOperator)
+	q, err := d.buildReadQuery(ctx, model, req)
+	if err != nil {
+		return ReadResult{}, err
+	}
+	return countResult(q)
+}
+
+func countResult(q core.Query) (ReadResult, error) {
+	count, err := q.Count()
+	if err != nil {
+		return ReadResult{}, err
+	}
+	return ReadResult{Items: []map[string]any{}, Count: &count}, nil
 }
 
 func (d *TheorydbDriver) TransitionAppendEvent(ctx context.Context, actual TransitionActual, event TransitionEvent) error {

--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -51,6 +51,8 @@ type Driver interface {
 	Delete(ctx context.Context, model string, key map[string]any) error
 	Query(ctx context.Context, model string, req ReadRequest) (ReadResult, error)
 	Scan(ctx context.Context, model string, req ReadRequest) (ReadResult, error)
+	CountQuery(ctx context.Context, model string, req ReadRequest) (ReadResult, error)
+	CountScan(ctx context.Context, model string, req ReadRequest) (ReadResult, error)
 	TransitionAppendEvent(ctx context.Context, actual TransitionActual, event TransitionEvent) error
 	ValidateProvenance(ctx context.Context, model string, item map[string]any) error
 }
@@ -77,6 +79,7 @@ type ReadCondition struct {
 type ReadResult struct {
 	Items  []map[string]any
 	Cursor string
+	Count  *int64
 }
 
 type TransitionActual struct {
@@ -471,6 +474,14 @@ func conditionValue(cond ReadCondition) any {
 		return append([]any(nil), cond.Values...)
 	}
 	return cond.Value
+}
+
+func (d *TheorydbDriver) CountQuery(ctx context.Context, model string, req ReadRequest) (ReadResult, error) {
+	return ReadResult{}, fmt.Errorf("%w: native count is not advertised", theorydbErrors.ErrInvalidOperator)
+}
+
+func (d *TheorydbDriver) CountScan(ctx context.Context, model string, req ReadRequest) (ReadResult, error) {
+	return ReadResult{}, fmt.Errorf("%w: native count is not advertised", theorydbErrors.ErrInvalidOperator)
 }
 
 func (d *TheorydbDriver) TransitionAppendEvent(ctx context.Context, actual TransitionActual, event TransitionEvent) error {

--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -46,6 +46,7 @@ type Driver interface {
 	Capabilities() []string
 	Create(ctx context.Context, model string, item map[string]any, ifNotExists bool) error
 	Get(ctx context.Context, model string, key map[string]any) (map[string]any, error)
+	GetOptional(ctx context.Context, model string, key map[string]any) (map[string]any, bool, error)
 	Update(ctx context.Context, model string, item map[string]any, fields []string, protectedAttributes []string) error
 	Save(ctx context.Context, model string, item map[string]any) error
 	Delete(ctx context.Context, model string, key map[string]any) error
@@ -298,6 +299,10 @@ func (d *TheorydbDriver) Get(ctx context.Context, model string, key map[string]a
 	default:
 		return nil, fmt.Errorf("%w: unknown model %q", theorydbErrors.ErrInvalidModel, model)
 	}
+}
+
+func (d *TheorydbDriver) GetOptional(ctx context.Context, model string, key map[string]any) (map[string]any, bool, error) {
+	return nil, false, fmt.Errorf("%w: optional get is not advertised", theorydbErrors.ErrInvalidOperator)
 }
 
 func (d *TheorydbDriver) Update(ctx context.Context, model string, item map[string]any, fields []string, protectedAttributes []string) error {

--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -152,6 +152,7 @@ func (d *TheorydbDriver) Capabilities() []string {
 		"query.basic",
 		"scan.basic",
 		"count.native",
+		"get.optional",
 		"release_state.write_policy",
 		"release_state.transactional_transition",
 		"release_state.provenance_confidence",
@@ -302,7 +303,14 @@ func (d *TheorydbDriver) Get(ctx context.Context, model string, key map[string]a
 }
 
 func (d *TheorydbDriver) GetOptional(ctx context.Context, model string, key map[string]any) (map[string]any, bool, error) {
-	return nil, false, fmt.Errorf("%w: optional get is not advertised", theorydbErrors.ErrInvalidOperator)
+	item, err := d.Get(ctx, model, key)
+	if err == nil {
+		return item, true, nil
+	}
+	if errors.Is(err, theorydbErrors.ErrItemNotFound) {
+		return nil, false, nil
+	}
+	return nil, false, err
 }
 
 func (d *TheorydbDriver) Update(ctx context.Context, model string, item map[string]any, fields []string, protectedAttributes []string) error {

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -477,7 +477,6 @@ func semanticallyMissingReadField(value any, ok bool) bool {
 func expectationHasItemAssertion(expect scenario.Expectation) bool {
 	return len(expect.ItemContains) > 0 ||
 		len(expect.ItemEquals) > 0 ||
-		expect.ItemAbsent != nil ||
 		len(expect.ItemHasFields) > 0 ||
 		len(expect.ItemMissingFields) > 0 ||
 		len(expect.RawAttributeTypes) > 0 ||

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -154,6 +154,26 @@ func (r *Runner) runStep(t require.TestingT, ctx context.Context, s *scenario.Sc
 		r.assertStepResult(t, step.Expect, item, err, raw, model)
 		return
 
+	case "get_optional":
+		item, found, err := r.driver.GetOptional(ctx, modelName, step.Key)
+		var raw map[string]types.AttributeValue
+		if err == nil && found {
+			var rawErr error
+			raw, rawErr = r.getRawItem(ctx, tableName, model, step.Key)
+			if rawErr != nil {
+				err = rawErr
+			}
+		}
+
+		if err == nil && found && len(step.Save) > 0 {
+			for varName, attrName := range step.Save {
+				r.vars[varName] = item[attrName]
+			}
+		}
+
+		r.assertStepResult(t, step.Expect, item, err, raw, model)
+		return
+
 	case "query":
 		require.NotNil(t, step.Query, "query request is required")
 		result, err := r.driver.Query(ctx, modelName, readRequestFromScenario(step.Query))
@@ -279,6 +299,13 @@ func (r *Runner) assertStepResult(t require.TestingT, expect scenario.Expectatio
 	}
 	if err != nil {
 		return
+	}
+	if expect.ItemAbsent != nil {
+		if *expect.ItemAbsent {
+			require.Nil(t, item, "expected absent item")
+		} else {
+			require.NotNil(t, item, "expected present item")
+		}
 	}
 
 	if len(expect.ItemContains) > 0 {
@@ -450,6 +477,7 @@ func semanticallyMissingReadField(value any, ok bool) bool {
 func expectationHasItemAssertion(expect scenario.Expectation) bool {
 	return len(expect.ItemContains) > 0 ||
 		len(expect.ItemEquals) > 0 ||
+		expect.ItemAbsent != nil ||
 		len(expect.ItemHasFields) > 0 ||
 		len(expect.ItemMissingFields) > 0 ||
 		len(expect.RawAttributeTypes) > 0 ||

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -166,6 +166,19 @@ func (r *Runner) runStep(t require.TestingT, ctx context.Context, s *scenario.Sc
 		r.assertReadResult(t, step.Expect, result, err, model)
 		return
 
+	case "count":
+		require.NotNil(t, step.Count, "count request is required")
+		var result driver.ReadResult
+		var err error
+		if step.Count.Query != nil {
+			result, err = r.driver.CountQuery(ctx, modelName, readRequestFromScenario(step.Count.Query))
+		} else {
+			require.NotNil(t, step.Count.Scan, "count.scan request is required")
+			result, err = r.driver.CountScan(ctx, modelName, readRequestFromScenario(step.Count.Scan))
+		}
+		r.assertReadResult(t, step.Expect, result, err, model)
+		return
+
 	case "transition_append_event":
 		require.NotNil(t, step.Actual, "transition_append_event actual is required")
 		require.NotNil(t, step.Event, "transition_append_event event is required")
@@ -361,6 +374,11 @@ func (r *Runner) assertReadResult(t require.TestingT, expect scenario.Expectatio
 		require.Len(t, result.Items, *expect.ItemCount)
 	}
 
+	if expect.Count != nil {
+		require.NotNil(t, result.Count, "expected count result")
+		require.Equal(t, int64(*expect.Count), *result.Count)
+	}
+
 	if len(expect.ItemsContains) > 0 {
 		require.GreaterOrEqual(t, len(result.Items), len(expect.ItemsContains), "not enough result items")
 		for i, wantItem := range expect.ItemsContains {
@@ -447,6 +465,7 @@ func expectationHasRawItemAssertion(expect scenario.Expectation) bool {
 
 func expectationHasReadAssertion(expect scenario.Expectation) bool {
 	return expect.ItemCount != nil ||
+		expect.Count != nil ||
 		len(expect.ItemsContains) > 0 ||
 		len(expect.ItemsMissingFields) > 0 ||
 		expect.CursorEquals != nil

--- a/contract-tests/runners/go/internal/scenario/scenario.go
+++ b/contract-tests/runners/go/internal/scenario/scenario.go
@@ -95,6 +95,7 @@ type Expectation struct {
 	ItemsMissingFields    []string          `yaml:"items_missing_fields"`
 	ItemCount             *int              `yaml:"item_count"`
 	Count                 *int              `yaml:"count"`
+	ItemAbsent            *bool             `yaml:"item_absent"`
 	CursorEquals          *string           `yaml:"cursor_equals"`
 	ItemHasFields         []string          `yaml:"item_has_fields"`
 	ItemMissingFields     []string          `yaml:"item_missing_fields"`
@@ -165,7 +166,7 @@ func validateStep(label string, i int, step Step) error {
 		if len(step.Item) == 0 {
 			return fmt.Errorf("%s %s: item is required", prefix, step.Op)
 		}
-	case "get", "delete":
+	case "get", "get_optional", "delete":
 		if len(step.Key) == 0 {
 			return fmt.Errorf("%s %s: key is required", prefix, step.Op)
 		}

--- a/contract-tests/runners/go/internal/scenario/scenario.go
+++ b/contract-tests/runners/go/internal/scenario/scenario.go
@@ -40,11 +40,17 @@ type Step struct {
 	Key                 map[string]any    `yaml:"key"`
 	Query               *ReadRequest      `yaml:"query"`
 	Scan                *ReadRequest      `yaml:"scan"`
+	Count               *CountRequest     `yaml:"count"`
 	Actual              *TransitionActual `yaml:"actual"`
 	Event               *TransitionEvent  `yaml:"event"`
 	Ms                  int               `yaml:"ms"`
 	Save                map[string]string `yaml:"save"`
 	Expect              Expectation       `yaml:"expect"`
+}
+
+type CountRequest struct {
+	Query *ReadRequest `yaml:"query"`
+	Scan  *ReadRequest `yaml:"scan"`
 }
 
 type ReadRequest struct {
@@ -88,6 +94,7 @@ type Expectation struct {
 	ItemsContains         []map[string]any  `yaml:"items_contains"`
 	ItemsMissingFields    []string          `yaml:"items_missing_fields"`
 	ItemCount             *int              `yaml:"item_count"`
+	Count                 *int              `yaml:"count"`
 	CursorEquals          *string           `yaml:"cursor_equals"`
 	ItemHasFields         []string          `yaml:"item_has_fields"`
 	ItemMissingFields     []string          `yaml:"item_missing_fields"`
@@ -163,34 +170,22 @@ func validateStep(label string, i int, step Step) error {
 			return fmt.Errorf("%s %s: key is required", prefix, step.Op)
 		}
 	case "query":
-		if step.Query == nil {
-			return fmt.Errorf("%s query: query is required", prefix)
-		}
-		if step.Query.Partition == nil {
-			return fmt.Errorf("%s query: query.partition is required", prefix)
-		}
-		if err := validateReadCondition(step.Query.Partition, fmt.Sprintf("%s query.partition", prefix)); err != nil {
-			return err
-		}
-		if step.Query.Sort != nil {
-			if err := validateReadCondition(step.Query.Sort, fmt.Sprintf("%s query.sort", prefix)); err != nil {
-				return err
-			}
-		}
-		for j := range step.Query.Filter {
-			if err := validateReadCondition(&step.Query.Filter[j], fmt.Sprintf("%s query.filter[%d]", prefix, j)); err != nil {
-				return err
-			}
-		}
+		return validateQueryReadRequest(step.Query, fmt.Sprintf("%s query", prefix))
 	case "scan":
-		if step.Scan == nil {
-			return fmt.Errorf("%s scan: scan is required", prefix)
+		return validateScanReadRequest(step.Scan, fmt.Sprintf("%s scan", prefix))
+	case "count":
+		if step.Count == nil {
+			return fmt.Errorf("%s count: count is required", prefix)
 		}
-		for j := range step.Scan.Filter {
-			if err := validateReadCondition(&step.Scan.Filter[j], fmt.Sprintf("%s scan.filter[%d]", prefix, j)); err != nil {
-				return err
-			}
+		hasQuery := step.Count.Query != nil
+		hasScan := step.Count.Scan != nil
+		if hasQuery == hasScan {
+			return fmt.Errorf("%s count: exactly one of count.query or count.scan is required", prefix)
 		}
+		if hasQuery {
+			return validateQueryReadRequest(step.Count.Query, fmt.Sprintf("%s count.query", prefix))
+		}
+		return validateScanReadRequest(step.Count.Scan, fmt.Sprintf("%s count.scan", prefix))
 	case "transition_append_event":
 		if step.Actual == nil {
 			return fmt.Errorf("%s transition_append_event: actual is required", prefix)
@@ -219,6 +214,41 @@ func validateStep(label string, i int, step Step) error {
 		}
 	default:
 		return fmt.Errorf("%s: unsupported op %q", prefix, step.Op)
+	}
+	return nil
+}
+
+func validateQueryReadRequest(req *ReadRequest, prefix string) error {
+	if req == nil {
+		return fmt.Errorf("%s: query is required", prefix)
+	}
+	if req.Partition == nil {
+		return fmt.Errorf("%s: query.partition is required", prefix)
+	}
+	if err := validateReadCondition(req.Partition, fmt.Sprintf("%s.partition", prefix)); err != nil {
+		return err
+	}
+	if req.Sort != nil {
+		if err := validateReadCondition(req.Sort, fmt.Sprintf("%s.sort", prefix)); err != nil {
+			return err
+		}
+	}
+	for j := range req.Filter {
+		if err := validateReadCondition(&req.Filter[j], fmt.Sprintf("%s.filter[%d]", prefix, j)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateScanReadRequest(req *ReadRequest, prefix string) error {
+	if req == nil {
+		return fmt.Errorf("%s: scan is required", prefix)
+	}
+	for j := range req.Filter {
+		if err := validateReadCondition(&req.Filter[j], fmt.Sprintf("%s.filter[%d]", prefix, j)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -305,8 +305,11 @@ class _TheorydbPyDriver:
         return _contract_item(table.get(_pk_value(key), _sk_value(key), consistent_read=True))
 
     def get_optional(self, model: str, key: dict[str, Any]) -> dict[str, Any] | None:
-        del model, key
-        raise ValidationError("optional get is not advertised")
+        table = self._table(model)
+        item = table.get_or_none(_pk_value(key), _sk_value(key), consistent_read=True)
+        if item is None:
+            return None
+        return _contract_item(item)
 
     def update(
         self,
@@ -528,6 +531,7 @@ def _supported_capabilities() -> list[str]:
         "query.basic",
         "scan.basic",
         "count.native",
+        "get.optional",
         "release_state.write_policy",
         "release_state.transactional_transition",
         "release_state.provenance_confidence",

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -358,6 +358,14 @@ class _TheorydbPyDriver:
         )
         return {"items": [_contract_item(item) for item in page.items], "cursor": page.next_cursor}
 
+    def count_query(self, model: str, request: dict[str, Any]) -> dict[str, Any]:
+        del model, request
+        raise ValidationError("native count is not advertised")
+
+    def count_scan(self, model: str, request: dict[str, Any]) -> dict[str, Any]:
+        del model, request
+        raise ValidationError("native count is not advertised")
+
     def transition_append_event(self, actual: dict[str, Any], event: dict[str, Any]) -> None:
         transition_release_state(
             self._table(actual["model"]),
@@ -711,6 +719,15 @@ def _run_step(
         _assert_read_expectation(step.get("expect", {}), error=error, result=result, model=model)
         return
 
+    if step["op"] == "count":
+        count_request = step["count"]
+        if "query" in count_request:
+            result, error = _capture_result(lambda: driver.count_query(model_name, count_request["query"]))
+        else:
+            result, error = _capture_result(lambda: driver.count_scan(model_name, count_request["scan"]))
+        _assert_read_expectation(step.get("expect", {}), error=error, result=result, model=model)
+        return
+
     if step["op"] == "transition_append_event":
         error = _capture_error(lambda: driver.transition_append_event(step["actual"], step["event"]))
         _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
@@ -846,7 +863,7 @@ def _assert_read_expectation(
     model: dict[str, Any],
 ) -> None:
     has_read_assertion = _expectation_has_any_key(
-        expect, {"item_count", "items_contains", "items_missing_fields", "cursor_equals"}
+        expect, {"item_count", "count", "items_contains", "items_missing_fields", "cursor_equals"}
     )
 
     if "error" in expect:
@@ -876,6 +893,9 @@ def _assert_read_expectation(
 
     if "item_count" in expect:
         assert len(items) == expect["item_count"]
+
+    if "count" in expect:
+        assert result.get("count") == expect["count"]
 
     if "items_contains" in expect:
         assert len(items) >= len(expect["items_contains"])

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -359,12 +359,32 @@ class _TheorydbPyDriver:
         return {"items": [_contract_item(item) for item in page.items], "cursor": page.next_cursor}
 
     def count_query(self, model: str, request: dict[str, Any]) -> dict[str, Any]:
-        del model, request
-        raise ValidationError("native count is not advertised")
+        partition = request.get("partition")
+        if partition is None:
+            raise ValidationError("query partition is required")
+        count = self._table(model).query_count(
+            _condition_value(partition),
+            sort=_sort_condition(request.get("sort")),
+            index_name=request.get("index"),
+            limit=request.get("limit"),
+            cursor=request.get("cursor"),
+            scan_forward=_scan_forward(request.get("sort_direction")),
+            consistent_read=bool(request.get("consistent_read", False)),
+            projection=request.get("projection"),
+            filter=_filter_expression(request.get("filter", [])),
+        )
+        return {"items": [], "count": count}
 
     def count_scan(self, model: str, request: dict[str, Any]) -> dict[str, Any]:
-        del model, request
-        raise ValidationError("native count is not advertised")
+        count = self._table(model).scan_count(
+            index_name=request.get("index"),
+            limit=request.get("limit"),
+            cursor=request.get("cursor"),
+            consistent_read=bool(request.get("consistent_read", False)),
+            projection=request.get("projection"),
+            filter=_filter_expression(request.get("filter", [])),
+        )
+        return {"items": [], "count": count}
 
     def transition_append_event(self, actual: dict[str, Any], event: dict[str, Any]) -> None:
         transition_release_state(
@@ -503,6 +523,7 @@ def _supported_capabilities() -> list[str]:
         "type.matrix",
         "query.basic",
         "scan.basic",
+        "count.native",
         "release_state.write_policy",
         "release_state.transactional_transition",
         "release_state.provenance_confidence",

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -810,7 +810,6 @@ def _assert_expectation(
         {
             "item_contains",
             "item_equals",
-            "item_absent",
             "item_has_fields",
             "item_missing_fields",
             "raw_attribute_types",

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -304,6 +304,10 @@ class _TheorydbPyDriver:
         table = self._table(model)
         return _contract_item(table.get(_pk_value(key), _sk_value(key), consistent_read=True))
 
+    def get_optional(self, model: str, key: dict[str, Any]) -> dict[str, Any] | None:
+        del model, key
+        raise ValidationError("optional get is not advertised")
+
     def update(
         self,
         model: str,
@@ -730,6 +734,21 @@ def _run_step(
         )
         return
 
+    if step["op"] == "get_optional":
+        item, error = _capture_result(lambda: driver.get_optional(model_name, step["key"]))
+        raw = (
+            None
+            if error is not None or item is None
+            else _get_raw_item(client, table_name, model, step["key"])
+        )
+        if error is None and item is not None:
+            for variable_name, attr in step.get("save", {}).items():
+                variables[variable_name] = item[attr]
+        _assert_expectation(
+            step.get("expect", {}), error=error, item=item, raw=raw, model=model, variables=variables
+        )
+        return
+
     if step["op"] == "query":
         result, error = _capture_result(lambda: driver.query(model_name, step["query"]))
         _assert_read_expectation(step.get("expect", {}), error=error, result=result, model=model)
@@ -791,6 +810,7 @@ def _assert_expectation(
         {
             "item_contains",
             "item_equals",
+            "item_absent",
             "item_has_fields",
             "item_missing_fields",
             "raw_attribute_types",
@@ -827,6 +847,12 @@ def _assert_expectation(
             assert error is not None
     if error is not None:
         return
+
+    if "item_absent" in expect:
+        if expect["item_absent"]:
+            assert item is None
+        else:
+            assert item is not None
 
     if "item_contains" in expect:
         assert item is not None

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -46,6 +46,8 @@ export interface Driver {
   delete(model: string, key: Record<string, unknown>): Promise<void>;
   query(model: string, req: ReadRequest): Promise<ReadResult>;
   scan(model: string, req: ReadRequest): Promise<ReadResult>;
+  countQuery(model: string, req: ReadRequest): Promise<ReadResult>;
+  countScan(model: string, req: ReadRequest): Promise<ReadResult>;
   transitionAppendEvent(
     actual: TransitionActual,
     event: TransitionEvent,
@@ -59,6 +61,7 @@ export interface Driver {
 export interface ReadResult {
   items: Array<Record<string, unknown>>;
   cursor?: string;
+  count?: number;
 }
 
 export interface TransitionActual {
@@ -193,6 +196,24 @@ export class TheorydbDriver implements Driver {
     }
     const page = await builder.page();
     return { items: page.items, cursor: page.cursor };
+  }
+
+  async countQuery(model: string, req: ReadRequest): Promise<ReadResult> {
+    void model;
+    void req;
+    throw new TheorydbError(
+      "ErrInvalidOperator",
+      "native count is not advertised",
+    );
+  }
+
+  async countScan(model: string, req: ReadRequest): Promise<ReadResult> {
+    void model;
+    void req;
+    throw new TheorydbError(
+      "ErrInvalidOperator",
+      "native count is not advertised",
+    );
   }
 
   async transitionAppendEvent(

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -109,6 +109,7 @@ export class TheorydbDriver implements Driver {
       "query.basic",
       "scan.basic",
       "count.native",
+      "get.optional",
       "release_state.write_policy",
       "release_state.transactional_transition",
       "release_state.provenance_confidence",
@@ -139,12 +140,7 @@ export class TheorydbDriver implements Driver {
     model: string,
     key: Record<string, unknown>,
   ): Promise<Record<string, unknown> | undefined> {
-    void model;
-    void key;
-    throw new TheorydbError(
-      "ErrInvalidOperator",
-      "optional get is not advertised",
-    );
+    return (await this.client.getOrNull(model, key)) ?? undefined;
   }
 
   async update(

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -104,6 +104,7 @@ export class TheorydbDriver implements Driver {
       "type.matrix",
       "query.basic",
       "scan.basic",
+      "count.native",
       "release_state.write_policy",
       "release_state.transactional_transition",
       "release_state.provenance_confidence",
@@ -199,21 +200,44 @@ export class TheorydbDriver implements Driver {
   }
 
   async countQuery(model: string, req: ReadRequest): Promise<ReadResult> {
-    void model;
-    void req;
-    throw new TheorydbError(
-      "ErrInvalidOperator",
-      "native count is not advertised",
-    );
+    let builder = this.client.query(model);
+    if (req.index) builder = builder.usingIndex(req.index);
+    if (!req.partition) {
+      throw new TheorydbError(
+        "ErrMissingPrimaryKey",
+        "query partition is required",
+      );
+    }
+    builder = builder.partitionKey(conditionValue(req.partition));
+    if (req.sort) {
+      builder = builder.sortKey(
+        normalizeSortOperator(req.sort.operator),
+        ...conditionValues(req.sort),
+      );
+    }
+    builder = applyReadOptions(builder, req);
+    for (const filter of req.filter ?? []) {
+      builder = builder.filter(
+        filter.attribute,
+        filter.operator,
+        ...conditionValues(filter),
+      );
+    }
+    return { items: [], count: await builder.count() };
   }
 
   async countScan(model: string, req: ReadRequest): Promise<ReadResult> {
-    void model;
-    void req;
-    throw new TheorydbError(
-      "ErrInvalidOperator",
-      "native count is not advertised",
-    );
+    let builder = this.client.scan(model);
+    if (req.index) builder = builder.usingIndex(req.index);
+    builder = applyReadOptions(builder, req);
+    for (const filter of req.filter ?? []) {
+      builder = builder.filter(
+        filter.attribute,
+        filter.operator,
+        ...conditionValues(filter),
+      );
+    }
+    return { items: [], count: await builder.count() };
   }
 
   async transitionAppendEvent(

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -36,6 +36,10 @@ export interface Driver {
     model: string,
     key: Record<string, unknown>,
   ): Promise<Record<string, unknown>>;
+  getOptional(
+    model: string,
+    key: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | undefined>;
   update(
     model: string,
     item: Record<string, unknown>,
@@ -129,6 +133,18 @@ export class TheorydbDriver implements Driver {
     key: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     return await this.client.get(model, key);
+  }
+
+  async getOptional(
+    model: string,
+    key: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | undefined> {
+    void model;
+    void key;
+    throw new TheorydbError(
+      "ErrInvalidOperator",
+      "optional get is not advertised",
+    );
   }
 
   async update(

--- a/contract-tests/runners/ts/src/load.ts
+++ b/contract-tests/runners/ts/src/load.ts
@@ -110,6 +110,9 @@ function validateStep(
     case "scan":
       requireReadRequest(step.scan, `${prefix}: scan`);
       break;
+    case "count":
+      requireCountRequest(step.count, `${prefix}: count`);
+      break;
     case "transition_append_event":
       requireTransitionActual(step.actual, `${prefix}: actual`);
       requireTransitionEvent(step.event, `${prefix}: event`);
@@ -121,6 +124,25 @@ function validateStep(
       throw new Error(
         `${filePath} ${label}[${index}]: unsupported op ${String(step.op)}`,
       );
+  }
+}
+
+function requireCountRequest(value: unknown, prefix: string): void {
+  requirePlainObject(value, `${prefix} is required`);
+  const request = value as { query?: unknown; scan?: unknown };
+  const hasQuery = request.query !== undefined;
+  const hasScan = request.scan !== undefined;
+  if (hasQuery === hasScan) {
+    throw new Error(`${prefix} requires exactly one of query or scan`);
+  }
+  if (hasQuery) {
+    requireReadRequest(request.query, `${prefix}.query`);
+    requireReadCondition(
+      (request.query as { partition?: unknown }).partition,
+      `${prefix}.query.partition`,
+    );
+  } else {
+    requireReadRequest(request.scan, `${prefix}.scan`);
   }
 }
 

--- a/contract-tests/runners/ts/src/load.ts
+++ b/contract-tests/runners/ts/src/load.ts
@@ -100,6 +100,7 @@ function validateStep(
       requirePlainObject(step.item, `${prefix}: item is required`);
       break;
     case "get":
+    case "get_optional":
     case "delete":
       requirePlainObject(step.key, `${prefix}: key is required`);
       break;

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -164,6 +164,23 @@ async function runStep(opts: {
     return;
   }
 
+  if (step.op === "count") {
+    assert.ok(step.count, "count request is required");
+    const res = step.count.query
+      ? await captureResult(() =>
+          driver.countQuery(modelName, step.count!.query!),
+        )
+      : await captureResult(() =>
+          driver.countScan(modelName, step.count!.scan!),
+        );
+    assertReadExpectation(step.expect, {
+      err: res.err,
+      result: res.value,
+      model,
+    });
+    return;
+  }
+
   if (step.op === "transition_append_event") {
     assert.ok(step.actual, "transition_append_event actual is required");
     assert.ok(step.event, "transition_append_event event is required");
@@ -202,7 +219,11 @@ function assertReadExpectation(
   expect: Step["expect"] | undefined,
   ctx: {
     err?: unknown;
-    result?: { items: Array<Record<string, unknown>>; cursor?: string };
+    result?: {
+      items: Array<Record<string, unknown>>;
+      cursor?: string;
+      count?: number;
+    };
     model: DmsModel;
   },
 ): void {
@@ -210,6 +231,7 @@ function assertReadExpectation(
   const { err, result, model } = ctx;
   const hasReadAssertion = expectationHasAnyKey(expect, [
     "item_count",
+    "count",
     "items_contains",
     "items_missing_fields",
     "cursor_equals",
@@ -255,6 +277,10 @@ function assertReadExpectation(
 
   if (expect.item_count !== undefined) {
     assert.equal(result.items.length, expect.item_count);
+  }
+
+  if (expect.count !== undefined) {
+    assert.equal(result.count, expect.count);
   }
 
   if (expect.items_contains) {

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -378,7 +378,6 @@ function assertExpectation(
   const hasItemAssertion = expectationHasAnyKey(expect, [
     "item_contains",
     "item_equals",
-    "item_absent",
     "item_has_fields",
     "item_missing_fields",
     "raw_attribute_types",

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -142,6 +142,30 @@ async function runStep(opts: {
     return;
   }
 
+  if (step.op === "get_optional") {
+    const key = step.key ?? {};
+    const res = await captureResult(() => driver.getOptional(modelName, key));
+
+    let raw: Record<string, AttributeValue> | undefined;
+    if (!res.err && res.value) {
+      raw = await getRawItem(ddb, tableName, model, key);
+      if (step.save) {
+        for (const [varName, attr] of Object.entries(step.save)) {
+          vars.set(varName, res.value[attr]);
+        }
+      }
+    }
+
+    assertExpectation(step.expect, {
+      err: res.err,
+      item: res.value,
+      raw,
+      model,
+      vars,
+    });
+    return;
+  }
+
   if (step.op === "query") {
     assert.ok(step.query, "query request is required");
     const res = await captureResult(() => driver.query(modelName, step.query!));
@@ -354,6 +378,7 @@ function assertExpectation(
   const hasItemAssertion = expectationHasAnyKey(expect, [
     "item_contains",
     "item_equals",
+    "item_absent",
     "item_has_fields",
     "item_missing_fields",
     "raw_attribute_types",
@@ -405,6 +430,11 @@ function assertExpectation(
   }
 
   if (err) return;
+
+  if (expect.item_absent !== undefined) {
+    if (expect.item_absent) assert.equal(item, undefined);
+    else assert.ok(item, "expected present item");
+  }
 
   if (expect.item_contains && item) {
     for (const [attr, want] of Object.entries(expect.item_contains)) {

--- a/contract-tests/runners/ts/src/types.ts
+++ b/contract-tests/runners/ts/src/types.ts
@@ -64,6 +64,7 @@ export interface Step {
   op:
     | "create"
     | "get"
+    | "get_optional"
     | "update"
     | "delete"
     | "query"
@@ -136,6 +137,7 @@ export interface Expectation {
   items_missing_fields?: string[];
   item_count?: number;
   count?: number;
+  item_absent?: boolean;
   cursor_equals?: string;
   item_has_fields?: string[];
   item_missing_fields?: string[];

--- a/contract-tests/runners/ts/src/types.ts
+++ b/contract-tests/runners/ts/src/types.ts
@@ -1,16 +1,7 @@
 export type DmsVersion = "0.1";
 
 export type ScalarType =
-  | "S"
-  | "N"
-  | "B"
-  | "BOOL"
-  | "NULL"
-  | "M"
-  | "L"
-  | "SS"
-  | "NS"
-  | "BS";
+  "S" | "N" | "B" | "BOOL" | "NULL" | "M" | "L" | "SS" | "NS" | "BS";
 
 export interface DmsDocument {
   dms_version: DmsVersion;
@@ -77,6 +68,7 @@ export interface Step {
     | "delete"
     | "query"
     | "scan"
+    | "count"
     | "sleep"
     | "save"
     | "transition_append_event"
@@ -89,11 +81,17 @@ export interface Step {
   key?: Record<string, unknown>;
   query?: ReadRequest;
   scan?: ReadRequest;
+  count?: CountRequest;
   actual?: TransitionActual;
   event?: TransitionEvent;
   ms?: number;
   save?: Record<string, string>;
   expect?: Expectation;
+}
+
+export interface CountRequest {
+  query?: ReadRequest;
+  scan?: ReadRequest;
 }
 
 export interface ReadRequest {
@@ -137,6 +135,7 @@ export interface Expectation {
   items_contains?: Array<Record<string, unknown>>;
   items_missing_fields?: string[];
   item_count?: number;
+  count?: number;
   cursor_equals?: string;
   item_has_fields?: string[];
   item_missing_fields?: string[];

--- a/contract-tests/scenarios/p1/51-native-count.yml
+++ b/contract-tests/scenarios/p1/51-native-count.yml
@@ -1,0 +1,74 @@
+name: "p1.native_count"
+dms_version: "0.1"
+requires_capabilities: ["count.native"]
+model: "User"
+table:
+  name: "users_contract"
+steps:
+  - op: create
+    item: { PK: "USER#COUNT", SK: "ITEM#001", emailHash: "count@example", nickname: "active" }
+    expect: { ok: true }
+
+  - op: create
+    item: { PK: "USER#COUNT", SK: "ITEM#002", emailHash: "count@example", nickname: "active" }
+    expect: { ok: true }
+
+  - op: create
+    item: { PK: "USER#COUNT", SK: "ITEM#003", emailHash: "count@example", nickname: "inactive" }
+    expect: { ok: true }
+
+  - op: create
+    item: { PK: "USER#OTHER_COUNT", SK: "ITEM#001", emailHash: "other-count@example", nickname: "active" }
+    expect: { ok: true }
+
+  - op: count
+    count:
+      query:
+        partition: { attribute: "PK", operator: "=", value: "USER#COUNT" }
+        sort: { attribute: "SK", operator: "begins_with", value: "ITEM#" }
+        filter:
+          - { attribute: "nickname", operator: "=", value: "active" }
+        projection: ["PK", "SK", "nickname"]
+    expect:
+      ok: true
+      count: 2
+      item_count: 0
+
+  - op: query
+    query:
+      partition: { attribute: "PK", operator: "=", value: "USER#COUNT" }
+      sort: { attribute: "SK", operator: "begins_with", value: "ITEM#" }
+      filter:
+        - { attribute: "nickname", operator: "=", value: "active" }
+      projection: ["PK", "SK", "nickname"]
+    expect:
+      ok: true
+      item_count: 2
+      items_contains:
+        - { PK: "USER#COUNT", SK: "ITEM#001", nickname: "active" }
+        - { PK: "USER#COUNT", SK: "ITEM#002", nickname: "active" }
+
+  - op: count
+    count:
+      scan:
+        filter:
+          - { attribute: "emailHash", operator: "=", value: "count@example" }
+          - { attribute: "nickname", operator: "=", value: "active" }
+        projection: ["PK", "SK", "emailHash", "nickname"]
+    expect:
+      ok: true
+      count: 2
+      item_count: 0
+
+  - op: scan
+    scan:
+      filter:
+        - { attribute: "emailHash", operator: "=", value: "count@example" }
+        - { attribute: "nickname", operator: "=", value: "active" }
+      projection: ["PK", "SK", "emailHash", "nickname"]
+    expect:
+      ok: true
+      item_count: 2
+      items_contains:
+        - { PK: "USER#COUNT", SK: "ITEM#001", emailHash: "count@example", nickname: "active" }
+        - { PK: "USER#COUNT", SK: "ITEM#002", emailHash: "count@example", nickname: "active" }

--- a/contract-tests/scenarios/p1/55-optional-get.yml
+++ b/contract-tests/scenarios/p1/55-optional-get.yml
@@ -1,0 +1,36 @@
+name: "p1.optional_get"
+dms_version: "0.1"
+requires_capabilities: ["get.optional"]
+model: "User"
+table:
+  name: "users_contract"
+steps:
+  - op: create
+    item:
+      PK: "USER#OPTIONAL"
+      SK: "PROFILE#1"
+      emailHash: "optional@example"
+      nickname: "present"
+    expect:
+      ok: true
+
+  - op: get_optional
+    key: { PK: "USER#OPTIONAL", SK: "PROFILE#1" }
+    expect:
+      ok: true
+      item_absent: false
+      item_contains:
+        PK: "USER#OPTIONAL"
+        SK: "PROFILE#1"
+        nickname: "present"
+
+  - op: get
+    key: { PK: "USER#OPTIONAL", SK: "PROFILE#missing" }
+    expect:
+      error: "ErrItemNotFound"
+
+  - op: get_optional
+    key: { PK: "USER#OPTIONAL", SK: "PROFILE#missing" }
+    expect:
+      ok: true
+      item_absent: true

--- a/internal/theorydb/query_executor.go
+++ b/internal/theorydb/query_executor.go
@@ -525,11 +525,13 @@ func executeReadWithPaginationConverted[T any](
 func configureQueryCountInput(queryInput *dynamodb.QueryInput) {
 	queryInput.Select = types.SelectCount
 	queryInput.Limit = nil
+	queryInput.ProjectionExpression = nil
 }
 
 func configureScanCountInput(scanInput *dynamodb.ScanInput) {
 	scanInput.Select = types.SelectCount
 	scanInput.Limit = nil
+	scanInput.ProjectionExpression = nil
 }
 
 func newQueryPaginator(client *dynamodb.Client, queryInput *dynamodb.QueryInput) *dynamodb.QueryPaginator {

--- a/pkg/query/count_helpers_test.go
+++ b/pkg/query/count_helpers_test.go
@@ -1,0 +1,75 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/stretchr/testify/require"
+)
+
+type covCountPage struct {
+	count   int32
+	scanned int32
+}
+
+type covCountPaginator struct {
+	pages []covCountPage
+	err   error
+	idx   int
+}
+
+func (p *covCountPaginator) HasMorePages() bool {
+	return p.idx < len(p.pages) || (p.err != nil && p.idx == 0)
+}
+
+func (p *covCountPaginator) NextPage(context.Context, ...func(*dynamodb.Options)) (*covCountPage, error) {
+	if p.err != nil {
+		p.idx++
+		return nil, p.err
+	}
+	page := p.pages[p.idx]
+	p.idx++
+	return &page, nil
+}
+
+func TestCountDynamoPagesAndWriteCountResult_COV5(t *testing.T) {
+	paginator := &covCountPaginator{
+		pages: []covCountPage{{count: 2, scanned: 5}, {count: 3, scanned: 8}},
+	}
+	count, scanned, err := countDynamoPages(
+		context.Background(),
+		"fixture",
+		paginator,
+		func(page *covCountPage) (int32, int32) { return page.count, page.scanned },
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), count)
+	require.Equal(t, int64(13), scanned)
+
+	var uintCount uint64
+	require.NoError(t, writeCountResult(&uintCount, count, scanned))
+	require.Equal(t, uint64(5), uintCount)
+
+	var structCount struct {
+		Count        uint64
+		ScannedCount int64
+	}
+	require.NoError(t, writeCountResult(&structCount, count, scanned))
+	require.Equal(t, uint64(5), structCount.Count)
+	require.Equal(t, int64(13), structCount.ScannedCount)
+
+	require.Error(t, writeCountResult(nil, count, scanned))
+	require.Error(t, writeCountResult(uintCount, count, scanned))
+	require.Error(t, writeCountResult(&uintCount, -1, scanned))
+
+	boom := errors.New("boom")
+	_, _, err = countDynamoPages(
+		context.Background(),
+		"fixture",
+		&covCountPaginator{err: boom},
+		func(page *covCountPage) (int32, int32) { return page.count, page.scanned },
+	)
+	require.ErrorIs(t, err, boom)
+}

--- a/pkg/query/count_helpers_test.go
+++ b/pkg/query/count_helpers_test.go
@@ -16,23 +16,25 @@ type covCountPage struct {
 
 type covCountPaginator struct {
 	pages []covCountPage
-	err   error
 	idx   int
+	fail  bool
 }
 
 func (p *covCountPaginator) HasMorePages() bool {
-	return p.idx < len(p.pages) || (p.err != nil && p.idx == 0)
+	return p.idx < len(p.pages) || (p.fail && p.idx == 0)
 }
 
 func (p *covCountPaginator) NextPage(context.Context, ...func(*dynamodb.Options)) (*covCountPage, error) {
-	if p.err != nil {
+	if p.fail {
 		p.idx++
-		return nil, p.err
+		return nil, errCovCountBoom
 	}
 	page := p.pages[p.idx]
 	p.idx++
 	return &page, nil
 }
+
+var errCovCountBoom = errors.New("boom")
 
 func TestCountDynamoPagesAndWriteCountResult_COV5(t *testing.T) {
 	paginator := &covCountPaginator{
@@ -64,12 +66,11 @@ func TestCountDynamoPagesAndWriteCountResult_COV5(t *testing.T) {
 	require.Error(t, writeCountResult(uintCount, count, scanned))
 	require.Error(t, writeCountResult(&uintCount, -1, scanned))
 
-	boom := errors.New("boom")
 	_, _, err = countDynamoPages(
 		context.Background(),
 		"fixture",
-		&covCountPaginator{err: boom},
+		&covCountPaginator{fail: true},
 		func(page *covCountPage) (int32, int32) { return page.count, page.scanned },
 	)
-	require.ErrorIs(t, err, boom)
+	require.ErrorIs(t, err, errCovCountBoom)
 }

--- a/pkg/query/cov5_query_methods_test.go
+++ b/pkg/query/cov5_query_methods_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -167,4 +168,40 @@ func TestQuery_FilterGroup_PreservesEarlierFilterPlaceholders_COV5(t *testing.T)
 	statusValue, ok := exec.lastScan.ExpressionAttributeValues[":v2"].(*types.AttributeValueMemberS)
 	require.True(t, ok)
 	require.Equal(t, "public", statusValue.Value)
+}
+
+type cov5OptionalErrorExecutor struct {
+	err error
+}
+
+func (e cov5OptionalErrorExecutor) ExecuteQuery(*core.CompiledQuery, any) error { return e.err }
+func (e cov5OptionalErrorExecutor) ExecuteScan(*core.CompiledQuery, any) error  { return e.err }
+
+func TestQuery_FirstOrNil(t *testing.T) {
+	t.Run("returns false without error for item not found", func(t *testing.T) {
+		q := New(&struct{}{}, cov5Metadata{
+			table:      "tbl",
+			primaryKey: core.KeySchema{PartitionKey: "pk"},
+		}, cov5OptionalErrorExecutor{})
+		q.Where("pk", "=", "p1")
+
+		var out struct{}
+		found, err := q.FirstOrNil(&out)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("returns real errors", func(t *testing.T) {
+		errBoom := errors.New("boom")
+		q := New(&struct{}{}, cov5Metadata{
+			table:      "tbl",
+			primaryKey: core.KeySchema{PartitionKey: "pk"},
+		}, cov5OptionalErrorExecutor{err: errBoom})
+		q.Where("pk", "=", "p1")
+
+		var out struct{}
+		found, err := q.FirstOrNil(&out)
+		require.ErrorIs(t, err, errBoom)
+		require.False(t, found)
+	})
 }

--- a/pkg/query/cov5_query_methods_test.go
+++ b/pkg/query/cov5_query_methods_test.go
@@ -205,3 +205,20 @@ func TestQuery_FirstOrNil(t *testing.T) {
 		require.False(t, found)
 	})
 }
+
+func TestFirstOrNil_PackageHelper_COV5(t *testing.T) {
+	var out struct{}
+	found, err := FirstOrNil(nil, &out)
+	require.Error(t, err)
+	require.False(t, found)
+
+	q := New(&struct{}{}, cov5Metadata{
+		table:      "tbl",
+		primaryKey: core.KeySchema{PartitionKey: "pk"},
+	}, cov5OptionalErrorExecutor{})
+	q.Where("pk", "=", "p1")
+
+	found, err = FirstOrNil(q, &out)
+	require.NoError(t, err)
+	require.False(t, found)
+}

--- a/pkg/query/executor.go
+++ b/pkg/query/executor.go
@@ -264,40 +264,68 @@ func setCountField(field reflect.Value, value int64) {
 	}
 }
 
-func countQueryPages(ctx context.Context, client DynamoDBAPI, input *dynamodb.QueryInput) (int64, int64, error) {
-	input.Select = types.SelectCount
-	input.Limit = nil
-	input.ProjectionExpression = nil
-	paginator := dynamodb.NewQueryPaginator(client, input)
+type countPaginator[O any] interface {
+	HasMorePages() bool
+	NextPage(context.Context, ...func(*dynamodb.Options)) (*O, error)
+}
+
+func countDynamoPages[O any](
+	ctx context.Context,
+	operation string,
+	paginator countPaginator[O],
+	extract func(*O) (int32, int32),
+) (int64, int64, error) {
 	var totalCount int64
 	var totalScanned int64
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return 0, 0, fmt.Errorf("failed to count query items: %w", err)
+			return 0, 0, fmt.Errorf("failed to count %s items: %w", operation, err)
 		}
-		totalCount += int64(page.Count)
-		totalScanned += int64(page.ScannedCount)
+		count, scanned := extract(page)
+		totalCount += int64(count)
+		totalScanned += int64(scanned)
 	}
 	return totalCount, totalScanned, nil
+}
+
+func countQueryPages(ctx context.Context, client DynamoDBAPI, input *dynamodb.QueryInput) (int64, int64, error) {
+	input.Select = types.SelectCount
+	input.Limit = nil
+	input.ProjectionExpression = nil
+	return countDynamoPages(ctx, "query", dynamodb.NewQueryPaginator(client, input), func(page *dynamodb.QueryOutput) (int32, int32) {
+		return page.Count, page.ScannedCount
+	})
 }
 
 func countScanPages(ctx context.Context, client DynamoDBAPI, input *dynamodb.ScanInput) (int64, int64, error) {
 	input.Select = types.SelectCount
 	input.Limit = nil
 	input.ProjectionExpression = nil
-	paginator := dynamodb.NewScanPaginator(client, input)
-	var totalCount int64
-	var totalScanned int64
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
+	return countDynamoPages(ctx, "scan", dynamodb.NewScanPaginator(client, input), func(page *dynamodb.ScanOutput) (int32, int32) {
+		return page.Count, page.ScannedCount
+	})
+}
+
+func executeCompiledRead(
+	input *core.CompiledQuery,
+	dest any,
+	pager pagedReadExecutor,
+	countFn func() (int64, int64, error),
+) error {
+	if isCountSelect(input.Select) {
+		count, scannedCount, err := countFn()
 		if err != nil {
-			return 0, 0, fmt.Errorf("failed to count scan items: %w", err)
+			return err
 		}
-		totalCount += int64(page.Count)
-		totalScanned += int64(page.ScannedCount)
+		return writeCountResult(dest, count, scannedCount)
 	}
-	return totalCount, totalScanned, nil
+
+	allItems, err := executePagedItems(input.Limit, pager)
+	if err != nil {
+		return err
+	}
+	return UnmarshalItems(allItems, dest)
 }
 
 // NewExecutor creates a new MainExecutor instance
@@ -323,26 +351,13 @@ func (e *MainExecutor) ExecuteQuery(input *core.CompiledQuery, dest any) error {
 	}
 
 	queryInput := buildDynamoQueryInput(input)
-	if isCountSelect(input.Select) {
-		count, scannedCount, err := countQueryPages(executorContext(e.ctx), e.client, queryInput)
-		if err != nil {
-			return err
-		}
-		return writeCountResult(dest, count, scannedCount)
-	}
-
-	pager := queryPager{
+	return executeCompiledRead(input, dest, queryPager{
 		client: e.client,
 		ctx:    e.ctx,
 		input:  queryInput,
-	}
-	allItems, err := executePagedItems(input.Limit, pager)
-	if err != nil {
-		return err
-	}
-
-	// Unmarshal the results into dest
-	return UnmarshalItems(allItems, dest)
+	}, func() (int64, int64, error) {
+		return countQueryPages(executorContext(e.ctx), e.client, queryInput)
+	})
 }
 
 // ExecuteScan implements QueryExecutor.ExecuteScan
@@ -352,26 +367,13 @@ func (e *MainExecutor) ExecuteScan(input *core.CompiledQuery, dest any) error {
 	}
 
 	scanInput := buildDynamoScanInput(input)
-	if isCountSelect(input.Select) {
-		count, scannedCount, err := countScanPages(executorContext(e.ctx), e.client, scanInput)
-		if err != nil {
-			return err
-		}
-		return writeCountResult(dest, count, scannedCount)
-	}
-
-	pager := scanPager{
+	return executeCompiledRead(input, dest, scanPager{
 		client: e.client,
 		ctx:    e.ctx,
 		input:  scanInput,
-	}
-	allItems, err := executePagedItems(input.Limit, pager)
-	if err != nil {
-		return err
-	}
-
-	// Unmarshal the results into dest
-	return UnmarshalItems(allItems, dest)
+	}, func() (int64, int64, error) {
+		return countScanPages(executorContext(e.ctx), e.client, scanInput)
+	})
 }
 
 // ExecuteGetItem implements GetItemExecutor.ExecuteGetItem.

--- a/pkg/query/executor.go
+++ b/pkg/query/executor.go
@@ -101,6 +101,11 @@ func buildDynamoQueryInput(input *core.CompiledQuery) *dynamodb.QueryInput {
 		queryInput.KeyConditionExpression = &input.KeyConditionExpression
 	}
 
+	// Set select mode
+	if input.Select != "" {
+		queryInput.Select = types.Select(input.Select)
+	}
+
 	// Set scan index forward
 	if input.ScanIndexForward != nil {
 		queryInput.ScanIndexForward = input.ScanIndexForward
@@ -125,6 +130,11 @@ func buildDynamoScanInput(input *core.CompiledQuery) *dynamodb.ScanInput {
 		&scanInput.ExclusiveStartKey,
 		&scanInput.ConsistentRead,
 	)
+
+	// Set select mode
+	if input.Select != "" {
+		scanInput.Select = types.Select(input.Select)
+	}
 
 	// Set segment and total segments for parallel scan
 	if input.Segment != nil {
@@ -198,6 +208,98 @@ func executePagedItems(limit *int32, pager pagedReadExecutor) ([]map[string]type
 	return allItems, nil
 }
 
+func executorContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+func isCountSelect(selectValue string) bool {
+	return strings.EqualFold(selectValue, "COUNT")
+}
+
+func writeCountResult(dest any, count int64, scannedCount int64) error {
+	if dest == nil {
+		return fmt.Errorf("destination must be a pointer")
+	}
+
+	value := reflect.ValueOf(dest)
+	if value.Kind() != reflect.Ptr || value.IsNil() {
+		return fmt.Errorf("destination must be a pointer")
+	}
+
+	elem := value.Elem()
+	switch elem.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		elem.SetInt(count)
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if count < 0 {
+			return fmt.Errorf("count is negative")
+		}
+		elem.SetUint(uint64(count))
+		return nil
+	case reflect.Struct:
+		if field := elem.FieldByName("Count"); field.IsValid() && field.CanSet() {
+			setCountField(field, count)
+		}
+		if field := elem.FieldByName("ScannedCount"); field.IsValid() && field.CanSet() {
+			setCountField(field, scannedCount)
+		}
+		return nil
+	default:
+		return fmt.Errorf("destination must be a pointer to an integer or struct")
+	}
+}
+
+func setCountField(field reflect.Value, value int64) {
+	switch field.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		field.SetInt(value)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if value >= 0 {
+			field.SetUint(uint64(value))
+		}
+	}
+}
+
+func countQueryPages(ctx context.Context, client DynamoDBAPI, input *dynamodb.QueryInput) (int64, int64, error) {
+	input.Select = types.SelectCount
+	input.Limit = nil
+	input.ProjectionExpression = nil
+	paginator := dynamodb.NewQueryPaginator(client, input)
+	var totalCount int64
+	var totalScanned int64
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to count query items: %w", err)
+		}
+		totalCount += int64(page.Count)
+		totalScanned += int64(page.ScannedCount)
+	}
+	return totalCount, totalScanned, nil
+}
+
+func countScanPages(ctx context.Context, client DynamoDBAPI, input *dynamodb.ScanInput) (int64, int64, error) {
+	input.Select = types.SelectCount
+	input.Limit = nil
+	input.ProjectionExpression = nil
+	paginator := dynamodb.NewScanPaginator(client, input)
+	var totalCount int64
+	var totalScanned int64
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to count scan items: %w", err)
+		}
+		totalCount += int64(page.Count)
+		totalScanned += int64(page.ScannedCount)
+	}
+	return totalCount, totalScanned, nil
+}
+
 // NewExecutor creates a new MainExecutor instance
 func NewExecutor(client DynamoDBAPI, ctx context.Context) *MainExecutor { //nolint:revive // context-as-argument: keep signature for compatibility
 	return &MainExecutor{
@@ -220,10 +322,19 @@ func (e *MainExecutor) ExecuteQuery(input *core.CompiledQuery, dest any) error {
 		return fmt.Errorf("compiled query cannot be nil")
 	}
 
+	queryInput := buildDynamoQueryInput(input)
+	if isCountSelect(input.Select) {
+		count, scannedCount, err := countQueryPages(executorContext(e.ctx), e.client, queryInput)
+		if err != nil {
+			return err
+		}
+		return writeCountResult(dest, count, scannedCount)
+	}
+
 	pager := queryPager{
 		client: e.client,
 		ctx:    e.ctx,
-		input:  buildDynamoQueryInput(input),
+		input:  queryInput,
 	}
 	allItems, err := executePagedItems(input.Limit, pager)
 	if err != nil {
@@ -240,10 +351,19 @@ func (e *MainExecutor) ExecuteScan(input *core.CompiledQuery, dest any) error {
 		return fmt.Errorf("compiled query cannot be nil")
 	}
 
+	scanInput := buildDynamoScanInput(input)
+	if isCountSelect(input.Select) {
+		count, scannedCount, err := countScanPages(executorContext(e.ctx), e.client, scanInput)
+		if err != nil {
+			return err
+		}
+		return writeCountResult(dest, count, scannedCount)
+	}
+
 	pager := scanPager{
 		client: e.client,
 		ctx:    e.ctx,
-		input:  buildDynamoScanInput(input),
+		input:  scanInput,
 	}
 	allItems, err := executePagedItems(input.Limit, pager)
 	if err != nil {
@@ -678,6 +798,11 @@ func (e *MainExecutor) ExecuteScanWithPagination(input *core.CompiledQuery, dest
 	// Set exclusive start key
 	if len(input.ExclusiveStartKey) > 0 {
 		scanInput.ExclusiveStartKey = input.ExclusiveStartKey
+	}
+
+	// Set select mode
+	if input.Select != "" {
+		scanInput.Select = types.Select(input.Select)
 	}
 
 	// Set segment and total segments for parallel scan

--- a/pkg/query/executor_test.go
+++ b/pkg/query/executor_test.go
@@ -442,3 +442,71 @@ func TestExecuteBatchGetHonorsNilRetryPolicy(t *testing.T) {
 	require.Len(t, items, 1)
 	assert.Equal(t, 1, callCount, "should not retry when retry policy is nil")
 }
+
+func TestMainExecutorExecuteQueryNativeCount(t *testing.T) {
+	ctx := context.Background()
+	limit := int32(10)
+	var captured *dynamodb.QueryInput
+	mockClient := &MockDynamoDBClient{
+		QueryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			captured = params
+			return &dynamodb.QueryOutput{Count: 2, ScannedCount: 5}, nil
+		},
+	}
+	executor := NewExecutor(mockClient, ctx)
+
+	var result struct {
+		Count        int64
+		ScannedCount int64
+	}
+	err := executor.ExecuteQuery(&core.CompiledQuery{
+		TableName:              "tbl",
+		KeyConditionExpression: "#pk = :pk",
+		ExpressionAttributeNames: map[string]string{
+			"#pk": "PK",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: "USER#1"},
+		},
+		ProjectionExpression: "#pk",
+		Limit:                &limit,
+		Select:               "COUNT",
+	}, &result)
+
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.Equal(t, types.SelectCount, captured.Select)
+	require.Nil(t, captured.ProjectionExpression)
+	require.Nil(t, captured.Limit)
+	require.Equal(t, int64(2), result.Count)
+	require.Equal(t, int64(5), result.ScannedCount)
+}
+
+func TestMainExecutorExecuteScanNativeCount(t *testing.T) {
+	ctx := context.Background()
+	limit := int32(10)
+	var captured *dynamodb.ScanInput
+	mockClient := &MockDynamoDBClient{
+		ScanFunc: func(ctx context.Context, params *dynamodb.ScanInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+			captured = params
+			return &dynamodb.ScanOutput{Count: 3, ScannedCount: 8}, nil
+		},
+	}
+	executor := NewExecutor(mockClient, ctx)
+
+	var count int64
+	err := executor.ExecuteScan(&core.CompiledQuery{
+		TableName:            "tbl",
+		FilterExpression:     "#status = :status",
+		ProjectionExpression: "#status",
+		Limit:                &limit,
+		Select:               "COUNT",
+	}, &count)
+
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.Equal(t, types.SelectCount, captured.Select)
+	require.Nil(t, captured.ProjectionExpression)
+	require.Nil(t, captured.Limit)
+	require.Equal(t, int64(3), count)
+}

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -615,13 +615,18 @@ func (q *Query) Count() (int64, error) {
 	if err := q.checkBuilderError(); err != nil {
 		return 0, err
 	}
-	compiled, err := q.Compile()
+	// Projection and limit are item-materialization controls; they do not
+	// change the matching item count. Compile a projection-free clone so
+	// Select=COUNT cannot leave unused projection expression names behind.
+	clone := *q
+	clone.projection = nil
+	compiled, err := clone.Compile()
 	if err != nil {
 		return 0, err
 	}
 
-	// Set select to COUNT for efficiency
 	compiled.Select = "COUNT"
+	compiled.Limit = nil
 
 	var result struct {
 		Count        int64

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -599,6 +599,43 @@ func (q *Query) First(dest any) error {
 	return q.firstInternal(dest)
 }
 
+// FirstOrNil executes the query and reports whether an item was found.
+// ErrItemNotFound is translated into (false, nil); all other errors are
+// returned unchanged.
+func (q *Query) FirstOrNil(dest any) (bool, error) {
+	err := q.First(dest)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, theorydbErrors.ErrItemNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+// FirstOrNil executes any TableTheory query and reports whether an item was
+// found. Queries that provide their own FirstOrNil implementation use it;
+// otherwise this helper falls back to First while only suppressing
+// ErrItemNotFound.
+func FirstOrNil(q core.Query, dest any) (bool, error) {
+	if q == nil {
+		return false, fmt.Errorf("query cannot be nil")
+	}
+	if optional, ok := q.(interface {
+		FirstOrNil(any) (bool, error)
+	}); ok {
+		return optional.FirstOrNil(dest)
+	}
+	err := q.First(dest)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, theorydbErrors.ErrItemNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
 // All executes the query and returns all results
 func (q *Query) All(dest any) error {
 	if err := q.checkBuilderError(); err != nil {

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -242,6 +242,81 @@ class Table[T]:
             ),
         )
 
+    def query_count(
+        self,
+        partition: Any,
+        *,
+        sort: SortKeyCondition | None = None,
+        index_name: str | None = None,
+        limit: int | None = None,
+        cursor: str | None = None,
+        scan_forward: bool = True,
+        consistent_read: bool = False,
+        projection: list[str] | None = None,
+        filter: FilterExpression | None = None,
+    ) -> int:
+        del limit, projection
+        partition_attr, sort_attr, index_type = self._resolve_index(index_name)
+        if index_type == "GSI" and consistent_read:
+            raise ValidationError("consistent_read is not supported for GSIs")
+
+        if partition is None:
+            raise ValidationError("partition is required")
+
+        names: dict[str, str] = {"#pk": partition_attr}
+        values: dict[str, Any] = {":pk": self._serializer.serialize(partition)}
+
+        key_expr = "#pk = :pk"
+        if sort is not None:
+            if sort_attr is None:
+                raise ValidationError("model/index does not define a sort key")
+            names["#sk"] = sort_attr
+            key_expr = self._apply_sort_condition(key_expr, sort, values)
+
+        req: dict[str, Any] = {
+            "TableName": self._table_name,
+            "KeyConditionExpression": key_expr,
+            "ExpressionAttributeNames": names,
+            "ExpressionAttributeValues": values,
+            "ScanIndexForward": scan_forward,
+            "ConsistentRead": consistent_read,
+            "Select": "COUNT",
+        }
+        if index_name is not None:
+            req["IndexName"] = index_name
+        if filter is not None:
+            req["FilterExpression"] = self._filter_expression(filter, names, values)
+
+        start_key: Any | None = None
+        if cursor is not None:
+            try:
+                decoded = decode_cursor(cursor)
+            except Exception as err:
+                raise ValidationError("invalid cursor") from err
+            if decoded.index is not None and decoded.index != index_name:
+                raise ValidationError("cursor index does not match query")
+            expected_sort = "ASC" if scan_forward else "DESC"
+            if decoded.sort is not None and decoded.sort != expected_sort:
+                raise ValidationError("cursor sort does not match query")
+            start_key = decoded.last_key
+
+        total = 0
+        while True:
+            if start_key is not None:
+                req["ExclusiveStartKey"] = start_key
+            else:
+                req.pop("ExclusiveStartKey", None)
+
+            try:
+                resp = self._client.query(**req)
+            except ClientError as err:  # pragma: no cover
+                raise _map_client_error(err) from err
+
+            total += int(resp.get("Count", 0))
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                return total
+
     def query_with_retry(
         self,
         partition: Any,
@@ -428,6 +503,75 @@ class Table[T]:
         items = [self._from_item(item) for item in resp.get("Items", [])]
         last = resp.get("LastEvaluatedKey")
         return Page(items=items, next_cursor=encode_cursor(last, index=index_name) if last else None)
+
+    def scan_count(
+        self,
+        *,
+        index_name: str | None = None,
+        limit: int | None = None,
+        cursor: str | None = None,
+        consistent_read: bool = False,
+        projection: list[str] | None = None,
+        filter: FilterExpression | None = None,
+        segment: int | None = None,
+        total_segments: int | None = None,
+    ) -> int:
+        del limit, projection
+        _, _, index_type = self._resolve_index(index_name)
+        if index_type == "GSI" and consistent_read:
+            raise ValidationError("consistent_read is not supported for GSIs")
+
+        req: dict[str, Any] = {
+            "TableName": self._table_name,
+            "ConsistentRead": consistent_read,
+            "Select": "COUNT",
+        }
+        names: dict[str, str] = {}
+        values: dict[str, Any] = {}
+        if index_name is not None:
+            req["IndexName"] = index_name
+        if filter is not None:
+            req["FilterExpression"] = self._filter_expression(filter, names, values)
+
+        if (segment is None) != (total_segments is None):
+            raise ValidationError("segment and total_segments must be provided together")
+        if segment is not None and total_segments is not None:
+            if segment < 0 or total_segments <= 0 or segment >= total_segments:
+                raise ValidationError("invalid segment/total_segments")
+            req["Segment"] = segment
+            req["TotalSegments"] = total_segments
+
+        if names:
+            req["ExpressionAttributeNames"] = names
+        if values:
+            req["ExpressionAttributeValues"] = values
+
+        start_key: Any | None = None
+        if cursor is not None:
+            try:
+                decoded = decode_cursor(cursor)
+            except Exception as err:
+                raise ValidationError("invalid cursor") from err
+            if decoded.index is not None and decoded.index != index_name:
+                raise ValidationError("cursor index does not match scan")
+            start_key = decoded.last_key
+
+        total = 0
+        while True:
+            if start_key is not None:
+                req["ExclusiveStartKey"] = start_key
+            else:
+                req.pop("ExclusiveStartKey", None)
+
+            try:
+                resp = self._client.scan(**req)
+            except ClientError as err:  # pragma: no cover
+                raise _map_client_error(err) from err
+
+            total += int(resp.get("Count", 0))
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                return total
 
     def scan_all(
         self,

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -998,6 +998,18 @@ class Table[T]:
             raise NotFoundError("item not found")
         return self._from_item(item)
 
+    def get_or_none(self, pk: Any, sk: Any | None = None, *, consistent_read: bool = False) -> T | None:
+        key = self._to_key(pk, sk)
+        try:
+            resp = self._client.get_item(TableName=self._table_name, Key=key, ConsistentRead=consistent_read)
+        except ClientError as err:  # pragma: no cover
+            raise _map_client_error(err) from err
+
+        item = resp.get("Item")
+        if not item:
+            return None
+        return self._from_item(item)
+
     def delete(
         self,
         pk: Any,

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -37,6 +37,8 @@ from .query import (
 )
 from .runtime import DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS, _is_lambda_timeout_error
 from .runtime import with_lambda_timeout as with_lambda_timeout_client
+from .table_count import query_count as _query_count
+from .table_count import scan_count as _scan_count
 from .transaction import (
     TransactConditionCheck,
     TransactDelete,
@@ -255,67 +257,18 @@ class Table[T]:
         projection: list[str] | None = None,
         filter: FilterExpression | None = None,
     ) -> int:
-        del limit, projection
-        partition_attr, sort_attr, index_type = self._resolve_index(index_name)
-        if index_type == "GSI" and consistent_read:
-            raise ValidationError("consistent_read is not supported for GSIs")
-
-        if partition is None:
-            raise ValidationError("partition is required")
-
-        names: dict[str, str] = {"#pk": partition_attr}
-        values: dict[str, Any] = {":pk": self._serializer.serialize(partition)}
-
-        key_expr = "#pk = :pk"
-        if sort is not None:
-            if sort_attr is None:
-                raise ValidationError("model/index does not define a sort key")
-            names["#sk"] = sort_attr
-            key_expr = self._apply_sort_condition(key_expr, sort, values)
-
-        req: dict[str, Any] = {
-            "TableName": self._table_name,
-            "KeyConditionExpression": key_expr,
-            "ExpressionAttributeNames": names,
-            "ExpressionAttributeValues": values,
-            "ScanIndexForward": scan_forward,
-            "ConsistentRead": consistent_read,
-            "Select": "COUNT",
-        }
-        if index_name is not None:
-            req["IndexName"] = index_name
-        if filter is not None:
-            req["FilterExpression"] = self._filter_expression(filter, names, values)
-
-        start_key: Any | None = None
-        if cursor is not None:
-            try:
-                decoded = decode_cursor(cursor)
-            except Exception as err:
-                raise ValidationError("invalid cursor") from err
-            if decoded.index is not None and decoded.index != index_name:
-                raise ValidationError("cursor index does not match query")
-            expected_sort = "ASC" if scan_forward else "DESC"
-            if decoded.sort is not None and decoded.sort != expected_sort:
-                raise ValidationError("cursor sort does not match query")
-            start_key = decoded.last_key
-
-        total = 0
-        while True:
-            if start_key is not None:
-                req["ExclusiveStartKey"] = start_key
-            else:
-                req.pop("ExclusiveStartKey", None)
-
-            try:
-                resp = self._client.query(**req)
-            except ClientError as err:  # pragma: no cover
-                raise _map_client_error(err) from err
-
-            total += int(resp.get("Count", 0))
-            start_key = resp.get("LastEvaluatedKey")
-            if not start_key:
-                return total
+        return _query_count(
+            self,
+            partition,
+            sort=sort,
+            index_name=index_name,
+            limit=limit,
+            cursor=cursor,
+            scan_forward=scan_forward,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+        )
 
     def query_with_retry(
         self,
@@ -516,62 +469,17 @@ class Table[T]:
         segment: int | None = None,
         total_segments: int | None = None,
     ) -> int:
-        del limit, projection
-        _, _, index_type = self._resolve_index(index_name)
-        if index_type == "GSI" and consistent_read:
-            raise ValidationError("consistent_read is not supported for GSIs")
-
-        req: dict[str, Any] = {
-            "TableName": self._table_name,
-            "ConsistentRead": consistent_read,
-            "Select": "COUNT",
-        }
-        names: dict[str, str] = {}
-        values: dict[str, Any] = {}
-        if index_name is not None:
-            req["IndexName"] = index_name
-        if filter is not None:
-            req["FilterExpression"] = self._filter_expression(filter, names, values)
-
-        if (segment is None) != (total_segments is None):
-            raise ValidationError("segment and total_segments must be provided together")
-        if segment is not None and total_segments is not None:
-            if segment < 0 or total_segments <= 0 or segment >= total_segments:
-                raise ValidationError("invalid segment/total_segments")
-            req["Segment"] = segment
-            req["TotalSegments"] = total_segments
-
-        if names:
-            req["ExpressionAttributeNames"] = names
-        if values:
-            req["ExpressionAttributeValues"] = values
-
-        start_key: Any | None = None
-        if cursor is not None:
-            try:
-                decoded = decode_cursor(cursor)
-            except Exception as err:
-                raise ValidationError("invalid cursor") from err
-            if decoded.index is not None and decoded.index != index_name:
-                raise ValidationError("cursor index does not match scan")
-            start_key = decoded.last_key
-
-        total = 0
-        while True:
-            if start_key is not None:
-                req["ExclusiveStartKey"] = start_key
-            else:
-                req.pop("ExclusiveStartKey", None)
-
-            try:
-                resp = self._client.scan(**req)
-            except ClientError as err:  # pragma: no cover
-                raise _map_client_error(err) from err
-
-            total += int(resp.get("Count", 0))
-            start_key = resp.get("LastEvaluatedKey")
-            if not start_key:
-                return total
+        return _scan_count(
+            self,
+            index_name=index_name,
+            limit=limit,
+            cursor=cursor,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+            segment=segment,
+            total_segments=total_segments,
+        )
 
     def scan_all(
         self,

--- a/py/src/theorydb_py/table_count.py
+++ b/py/src/theorydb_py/table_count.py
@@ -73,7 +73,11 @@ def scan_count(
     if index_type == "GSI" and consistent_read:
         raise ValidationError("consistent_read is not supported for GSIs")
 
-    req: dict[str, Any] = {"TableName": table._table_name, "ConsistentRead": consistent_read, "Select": "COUNT"}
+    req: dict[str, Any] = {
+        "TableName": table._table_name,
+        "ConsistentRead": consistent_read,
+        "Select": "COUNT",
+    }
     names: dict[str, str] = {}
     values: dict[str, Any] = {}
     if index_name is not None:

--- a/py/src/theorydb_py/table_count.py
+++ b/py/src/theorydb_py/table_count.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+from .aws_errors import map_client_error as _map_client_error
+from .errors import ValidationError
+from .query import FilterExpression, SortKeyCondition, decode_cursor
+
+
+def query_count(
+    table: Any,
+    partition: Any,
+    *,
+    sort: SortKeyCondition | None = None,
+    index_name: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+    scan_forward: bool = True,
+    consistent_read: bool = False,
+    projection: list[str] | None = None,
+    filter: FilterExpression | None = None,
+) -> int:
+    del limit, projection
+    partition_attr, sort_attr, index_type = table._resolve_index(index_name)
+    if index_type == "GSI" and consistent_read:
+        raise ValidationError("consistent_read is not supported for GSIs")
+    if partition is None:
+        raise ValidationError("partition is required")
+
+    names: dict[str, str] = {"#pk": partition_attr}
+    values: dict[str, Any] = {":pk": table._serializer.serialize(partition)}
+    key_expr = "#pk = :pk"
+    if sort is not None:
+        if sort_attr is None:
+            raise ValidationError("model/index does not define a sort key")
+        names["#sk"] = sort_attr
+        key_expr = table._apply_sort_condition(key_expr, sort, values)
+
+    req: dict[str, Any] = {
+        "TableName": table._table_name,
+        "KeyConditionExpression": key_expr,
+        "ExpressionAttributeNames": names,
+        "ExpressionAttributeValues": values,
+        "ScanIndexForward": scan_forward,
+        "ConsistentRead": consistent_read,
+        "Select": "COUNT",
+    }
+    if index_name is not None:
+        req["IndexName"] = index_name
+    if filter is not None:
+        req["FilterExpression"] = table._filter_expression(filter, names, values)
+
+    start_key = _query_count_start_key(cursor, index_name, scan_forward)
+    return _count_pages(table._client.query, req, start_key)
+
+
+def scan_count(
+    table: Any,
+    *,
+    index_name: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+    consistent_read: bool = False,
+    projection: list[str] | None = None,
+    filter: FilterExpression | None = None,
+    segment: int | None = None,
+    total_segments: int | None = None,
+) -> int:
+    del limit, projection
+    _, _, index_type = table._resolve_index(index_name)
+    if index_type == "GSI" and consistent_read:
+        raise ValidationError("consistent_read is not supported for GSIs")
+
+    req: dict[str, Any] = {"TableName": table._table_name, "ConsistentRead": consistent_read, "Select": "COUNT"}
+    names: dict[str, str] = {}
+    values: dict[str, Any] = {}
+    if index_name is not None:
+        req["IndexName"] = index_name
+    if filter is not None:
+        req["FilterExpression"] = table._filter_expression(filter, names, values)
+    _apply_scan_segments(req, segment, total_segments)
+    if names:
+        req["ExpressionAttributeNames"] = names
+    if values:
+        req["ExpressionAttributeValues"] = values
+
+    start_key = _scan_count_start_key(cursor, index_name)
+    return _count_pages(table._client.scan, req, start_key)
+
+
+def _query_count_start_key(cursor: str | None, index_name: str | None, scan_forward: bool) -> Any | None:
+    if cursor is None:
+        return None
+    try:
+        decoded = decode_cursor(cursor)
+    except Exception as err:
+        raise ValidationError("invalid cursor") from err
+    if decoded.index is not None and decoded.index != index_name:
+        raise ValidationError("cursor index does not match query")
+    expected_sort = "ASC" if scan_forward else "DESC"
+    if decoded.sort is not None and decoded.sort != expected_sort:
+        raise ValidationError("cursor sort does not match query")
+    return decoded.last_key
+
+
+def _scan_count_start_key(cursor: str | None, index_name: str | None) -> Any | None:
+    if cursor is None:
+        return None
+    try:
+        decoded = decode_cursor(cursor)
+    except Exception as err:
+        raise ValidationError("invalid cursor") from err
+    if decoded.index is not None and decoded.index != index_name:
+        raise ValidationError("cursor index does not match scan")
+    return decoded.last_key
+
+
+def _apply_scan_segments(req: dict[str, Any], segment: int | None, total_segments: int | None) -> None:
+    if (segment is None) != (total_segments is None):
+        raise ValidationError("segment and total_segments must be provided together")
+    if segment is None or total_segments is None:
+        return
+    if segment < 0 or total_segments <= 0 or segment >= total_segments:
+        raise ValidationError("invalid segment/total_segments")
+    req["Segment"] = segment
+    req["TotalSegments"] = total_segments
+
+
+def _count_pages(call: Any, req: dict[str, Any], start_key: Any | None) -> int:
+    total = 0
+    while True:
+        if start_key is not None:
+            req["ExclusiveStartKey"] = start_key
+        else:
+            req.pop("ExclusiveStartKey", None)
+        try:
+            resp = call(**req)
+        except ClientError as err:  # pragma: no cover
+            raise _map_client_error(err) from err
+        total += int(resp.get("Count", 0))
+        start_key = resp.get("LastEvaluatedKey")
+        if not start_key:
+            return total

--- a/py/tests/unit/test_table_unit_behaviors.py
+++ b/py/tests/unit/test_table_unit_behaviors.py
@@ -52,9 +52,13 @@ class _StubClient:
         self._last_key: dict | None = None
         self._count = 0
         self._scanned_count = 0
+        self._get_error: Exception | None = None
 
     def set_get_item(self, item: dict | None) -> None:
         self._get_item = item
+
+    def set_get_error(self, err: Exception | None) -> None:
+        self._get_error = err
 
     def set_update_attrs(self, attrs: dict | None) -> None:
         self._update_attrs = attrs
@@ -78,6 +82,8 @@ class _StubClient:
 
     def get_item(self, **req):  # noqa: ANN001
         self.get_reqs.append(req)
+        if self._get_error is not None:
+            raise self._get_error
         return {"Item": self._get_item} if self._get_item is not None else {}
 
     def delete_item(self, **req):  # noqa: ANN001
@@ -147,6 +153,25 @@ def test_table_put_get_delete_update_happy_path_and_validation() -> None:
     stub.set_get_item(None)
     with pytest.raises(NotFoundError):
         table.get("A", "1")
+
+    stub.set_get_item(table._to_item(Item(pk="A", sk="1", value=1)))
+    assert table.get_or_none("A", "1") == Item(pk="A", sk="1", value=1, note="")
+
+    stub.set_get_item(None)
+    assert table.get_or_none("A", "1") is None
+
+    stub.set_get_error(
+        ClientError({"Error": {"Code": "ValidationException", "Message": "real error"}}, "GetItem")
+    )
+    with pytest.raises(ValidationError, match="real error"):
+        table.get_or_none("A", "1")
+
+    stub.set_get_error(
+        ClientError({"Error": {"Code": "ResourceNotFoundException", "Message": "missing table"}}, "GetItem")
+    )
+    with pytest.raises(NotFoundError, match="missing table"):
+        table.get_or_none("A", "1")
+    stub.set_get_error(None)
 
     table.delete("A", "1", condition_expression="attribute_exists(PK)")
     assert stub.delete_reqs[0]["ConditionExpression"] == "attribute_exists(PK)"

--- a/py/tests/unit/test_table_unit_behaviors.py
+++ b/py/tests/unit/test_table_unit_behaviors.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 
 from theorydb_py import (
     EncryptionNotConfiguredError,
+    FilterCondition,
     ModelDefinition,
     NotFoundError,
     SortKeyCondition,
@@ -49,6 +50,8 @@ class _StubClient:
         self._update_attrs: dict | None = None
         self._items: list[dict] = []
         self._last_key: dict | None = None
+        self._count = 0
+        self._scanned_count = 0
 
     def set_get_item(self, item: dict | None) -> None:
         self._get_item = item
@@ -56,9 +59,18 @@ class _StubClient:
     def set_update_attrs(self, attrs: dict | None) -> None:
         self._update_attrs = attrs
 
-    def set_query_items(self, items: list[dict], *, last_key: dict | None = None) -> None:
+    def set_query_items(
+        self,
+        items: list[dict],
+        *,
+        last_key: dict | None = None,
+        count: int | None = None,
+        scanned_count: int | None = None,
+    ) -> None:
         self._items = items
         self._last_key = last_key
+        self._count = len(items) if count is None else count
+        self._scanned_count = self._count if scanned_count is None else scanned_count
 
     def put_item(self, **req):  # noqa: ANN001
         self.put_reqs.append(req)
@@ -78,16 +90,18 @@ class _StubClient:
 
     def query(self, **req):  # noqa: ANN001
         self.query_reqs.append(req)
-        out: dict = {"Items": self._items}
+        out: dict = {"Items": self._items, "Count": self._count, "ScannedCount": self._scanned_count}
         if self._last_key is not None:
             out["LastEvaluatedKey"] = self._last_key
+            self._last_key = None
         return out
 
     def scan(self, **req):  # noqa: ANN001
         self.scan_reqs.append(req)
-        out: dict = {"Items": self._items}
+        out: dict = {"Items": self._items, "Count": self._count, "ScannedCount": self._scanned_count}
         if self._last_key is not None:
             out["LastEvaluatedKey"] = self._last_key
+            self._last_key = None
         return out
 
 
@@ -145,6 +159,39 @@ def test_table_put_get_delete_update_happy_path_and_validation() -> None:
     stub.set_update_attrs(None)
     with pytest.raises(ValidationError, match="did not return Attributes"):
         table.update("A", "1", {"value": 3})
+
+
+def test_table_query_count_and_scan_count_use_select_count_without_materialization_controls() -> None:
+    model = ModelDefinition.from_dataclass(Item, table_name="tbl")
+    stub = _StubClient()
+    table: Table[Item] = Table(model, client=stub)
+    last_key = {"PK": {"S": "A"}, "SK": {"S": "1"}}
+    stub.set_query_items(
+        [table._to_item(Item(pk="A", sk="1", value=1))], last_key=last_key, count=2, scanned_count=5
+    )
+
+    query_count = table.query_count(
+        "A",
+        sort=SortKeyCondition.begins_with("ITEM#"),
+        limit=1,
+        projection=["PK"],
+        filter=FilterCondition.eq("value", 1),
+    )
+
+    assert query_count == 4
+    assert len(stub.query_reqs) == 2
+    assert stub.query_reqs[0]["Select"] == "COUNT"
+    assert "Limit" not in stub.query_reqs[0]
+    assert "ProjectionExpression" not in stub.query_reqs[0]
+    assert stub.query_reqs[1]["ExclusiveStartKey"] == last_key
+
+    stub.set_query_items([table._to_item(Item(pk="A", sk="1", value=1))], count=3, scanned_count=7)
+    scan_count = table.scan_count(limit=1, projection=["PK"], filter=FilterCondition.eq("value", 1))
+
+    assert scan_count == 3
+    assert stub.scan_reqs[0]["Select"] == "COUNT"
+    assert "Limit" not in stub.scan_reqs[0]
+    assert "ProjectionExpression" not in stub.scan_reqs[0]
 
 
 def test_table_populates_lifecycle_fields_and_initial_version() -> None:

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -24,7 +24,7 @@ import {
   type RetryOptions,
 } from './batch.js';
 import { mapDynamoError } from './dynamo-error.js';
-import { TheorydbError } from './errors.js';
+import { hasTheorydbErrorCode, TheorydbError } from './errors.js';
 import type { Model } from './model.js';
 import type { SendOptions } from './send-options.js';
 import {
@@ -232,6 +232,18 @@ export class TheorydbClient {
       return unmarshalItem(model, item, this.unmarshalOptions);
     } catch (err) {
       throw mapDynamoError(err);
+    }
+  }
+
+  async getOrNull(
+    modelName: string,
+    key: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | null> {
+    try {
+      return await this.get(modelName, key);
+    } catch (err) {
+      if (hasTheorydbErrorCode(err, 'ErrItemNotFound')) return null;
+      throw err;
     }
   }
 

--- a/ts/src/query-count.ts
+++ b/ts/src/query-count.ts
@@ -1,0 +1,24 @@
+export interface CountPage {
+  count: number;
+  cursor?: string;
+}
+
+export async function countAllPages(
+  initialCursor: string | undefined,
+  setCursor: (cursor: string | undefined) => void,
+  readPage: () => Promise<CountPage>,
+): Promise<number> {
+  let total = 0;
+  let cursor = initialCursor;
+  try {
+    do {
+      setCursor(cursor);
+      const page = await readPage();
+      total += page.count;
+      cursor = page.cursor;
+    } while (cursor);
+    return total;
+  } finally {
+    setCursor(initialCursor);
+  }
+}

--- a/ts/src/query.ts
+++ b/ts/src/query.ts
@@ -548,6 +548,163 @@ export class QueryBuilder {
     return page;
   }
 
+  async count(): Promise<number> {
+    const original = this.cursorToken;
+    try {
+      let total = 0;
+      let cursor = original;
+
+      for (;;) {
+        this.cursorToken = cursor;
+        const page = await this.countPage();
+        total += page.count;
+        if (!page.cursor) break;
+        cursor = page.cursor;
+      }
+
+      return total;
+    } finally {
+      this.cursorToken = original;
+    }
+  }
+
+  private async countPage(): Promise<{ count: number; cursor?: string }> {
+    const { pkName, pkSchema, skName, skSchema, index } =
+      this.resolveKeySchema();
+    if (this.pkValue === undefined)
+      throw new TheorydbError(
+        'ErrInvalidOperator',
+        'partitionKey() is required',
+      );
+
+    if (index?.type === 'GSI' && this.consistentReadEnabled) {
+      throw new TheorydbError(
+        'ErrInvalidOperator',
+        'Consistent reads are not supported on GSIs',
+      );
+    }
+    if (modelHasEncryptedAttributes(this.model) && !this.encryption) {
+      throw new TheorydbError(
+        'ErrEncryptionNotConfigured',
+        `Encryption is required for model: ${this.model.name}`,
+      );
+    }
+
+    const names: Record<string, string> = { '#pk': pkName };
+    const values: Record<string, AttributeValue> = {
+      ':pk': marshalScalar(pkSchema, this.pkValue),
+    };
+
+    let keyExpr = '#pk = :pk';
+    if (this.skCondition) {
+      if (!skName || !skSchema)
+        throw new TheorydbError(
+          'ErrInvalidOperator',
+          'sortKey() requires a sort key',
+        );
+      names['#sk'] = skName;
+
+      const { op, values: skValues } = this.skCondition;
+      switch (op) {
+        case 'begins_with': {
+          if (skValues.length !== 1)
+            throw new TheorydbError(
+              'ErrInvalidOperator',
+              'begins_with requires one value',
+            );
+          values[':sk'] = marshalScalar(skSchema, skValues[0]);
+          keyExpr += ' AND begins_with(#sk, :sk)';
+          break;
+        }
+        case 'between': {
+          if (skValues.length !== 2)
+            throw new TheorydbError(
+              'ErrInvalidOperator',
+              'between requires two values',
+            );
+          values[':sk0'] = marshalScalar(skSchema, skValues[0]);
+          values[':sk1'] = marshalScalar(skSchema, skValues[1]);
+          keyExpr += ' AND #sk BETWEEN :sk0 AND :sk1';
+          break;
+        }
+        default: {
+          if (skValues.length !== 1)
+            throw new TheorydbError(
+              'ErrInvalidOperator',
+              'sort operator requires one value',
+            );
+          values[':sk'] = marshalScalar(skSchema, skValues[0]);
+          keyExpr += ` AND #sk ${op} :sk`;
+          break;
+        }
+      }
+    }
+
+    const filter = this.filters.build();
+    if (filter.expression) {
+      for (const [k, v] of Object.entries(filter.names)) {
+        if (k in names) {
+          throw new TheorydbError(
+            'ErrInvalidOperator',
+            `ExpressionAttributeNames collision: ${k}`,
+          );
+        }
+        names[k] = v;
+      }
+      for (const [k, v] of Object.entries(filter.values)) {
+        if (k in values) {
+          throw new TheorydbError(
+            'ErrInvalidOperator',
+            `ExpressionAttributeValues collision: ${k}`,
+          );
+        }
+        values[k] = v;
+      }
+    }
+
+    let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+    if (this.cursorToken) {
+      const c = decodeCursor(this.cursorToken);
+      if (c.index && (this.indexName ?? undefined) !== c.index) {
+        throw new TheorydbError(
+          'ErrInvalidOperator',
+          'Cursor index does not match query',
+        );
+      }
+      if (c.sort && c.sort !== this.sortDir) {
+        throw new TheorydbError(
+          'ErrInvalidOperator',
+          'Cursor sort does not match query',
+        );
+      }
+      exclusiveStartKey = c.lastKey;
+    }
+
+    const resp = await this.ddb.send(
+      new QueryCommand({
+        TableName: this.model.tableName,
+        IndexName: index?.name,
+        KeyConditionExpression: keyExpr,
+        FilterExpression: filter.expression,
+        ExpressionAttributeNames: names,
+        ExpressionAttributeValues: values,
+        ConsistentRead: this.consistentReadEnabled || undefined,
+        ExclusiveStartKey: exclusiveStartKey,
+        ScanIndexForward: this.sortDir === 'ASC',
+        Select: 'COUNT',
+      }),
+      this.sendOptions,
+    );
+
+    const out: { count: number; cursor?: string } = { count: resp.Count ?? 0 };
+    if (resp.LastEvaluatedKey) {
+      const c: Cursor = { lastKey: resp.LastEvaluatedKey, sort: this.sortDir };
+      if (index) c.index = index.name;
+      out.cursor = encodeCursor(c);
+    }
+    return out;
+  }
+
   async all(): Promise<Array<Record<string, unknown>>> {
     const original = this.cursorToken;
     try {
@@ -570,7 +727,7 @@ export class QueryBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before summing.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async sum(field: string): Promise<number> {
     return sumField(await this.all(), field);
@@ -578,7 +735,7 @@ export class QueryBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before averaging.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async average(field: string): Promise<number> {
     return averageField(await this.all(), field);
@@ -586,7 +743,7 @@ export class QueryBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before selecting the minimum.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async min(field: string): Promise<unknown> {
     return minField(await this.all(), field);
@@ -594,7 +751,7 @@ export class QueryBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before selecting the maximum.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async max(field: string): Promise<unknown> {
     return maxField(await this.all(), field);
@@ -602,7 +759,7 @@ export class QueryBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before computing the aggregate.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async aggregate(...fields: string[]): Promise<AggregateResult> {
     return aggregateField(await this.all(), fields[0]);
@@ -610,7 +767,7 @@ export class QueryBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before counting distinct values.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async countDistinct(field: string): Promise<number> {
     return countDistinct(await this.all(), field);
@@ -618,7 +775,7 @@ export class QueryBuilder {
 
   /**
    * Client-side aggregation: the returned group query calls `all()` during `execute()` and keeps groups in memory.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   groupBy(field: string): GroupByQuery<Record<string, unknown>> {
     return new GroupByQuery(() => this.all(), field);
@@ -967,6 +1124,112 @@ export class ScanBuilder {
     return out;
   }
 
+  async count(): Promise<number> {
+    const original = this.cursorToken;
+    try {
+      let total = 0;
+      let cursor = original;
+
+      for (;;) {
+        this.cursorToken = cursor;
+        const page = await this.countPage();
+        total += page.count;
+        if (!page.cursor) break;
+        cursor = page.cursor;
+      }
+
+      return total;
+    } finally {
+      this.cursorToken = original;
+    }
+  }
+
+  private async countPage(): Promise<{ count: number; cursor?: string }> {
+    const index = this.indexName
+      ? this.model.indexes.get(this.indexName)
+      : undefined;
+    if (index?.type === 'GSI' && this.consistentReadEnabled) {
+      throw new TheorydbError(
+        'ErrInvalidOperator',
+        'Consistent reads are not supported on GSIs',
+      );
+    }
+    if (modelHasEncryptedAttributes(this.model) && !this.encryption) {
+      throw new TheorydbError(
+        'ErrEncryptionNotConfigured',
+        `Encryption is required for model: ${this.model.name}`,
+      );
+    }
+
+    const names: Record<string, string> = {};
+    let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+    if (this.cursorToken) {
+      const c = decodeCursor(this.cursorToken);
+      if (c.index && (this.indexName ?? undefined) !== c.index) {
+        throw new TheorydbError(
+          'ErrInvalidOperator',
+          'Cursor index does not match scan',
+        );
+      }
+      exclusiveStartKey = c.lastKey;
+    }
+
+    const filter = this.filters.build();
+    if (filter.expression) {
+      for (const [k, v] of Object.entries(filter.names)) {
+        if (k in names) {
+          throw new TheorydbError(
+            'ErrInvalidOperator',
+            `ExpressionAttributeNames collision: ${k}`,
+          );
+        }
+        names[k] = v;
+      }
+    }
+
+    if ((this.segment === undefined) !== (this.totalSegments === undefined)) {
+      throw new TheorydbError(
+        'ErrInvalidOperator',
+        'parallelScan requires both segment and totalSegments',
+      );
+    }
+    if (
+      this.segment !== undefined &&
+      this.totalSegments !== undefined &&
+      (this.segment < 0 || this.segment >= this.totalSegments)
+    ) {
+      throw new TheorydbError(
+        'ErrInvalidOperator',
+        'parallelScan segment must be < totalSegments',
+      );
+    }
+
+    const resp = await this.ddb.send(
+      new ScanCommand({
+        TableName: this.model.tableName,
+        IndexName: this.indexName,
+        FilterExpression: filter.expression,
+        ExpressionAttributeNames: Object.keys(names).length ? names : undefined,
+        ExpressionAttributeValues:
+          Object.keys(filter.values).length > 0 ? filter.values : undefined,
+        ConsistentRead: this.consistentReadEnabled || undefined,
+        ExclusiveStartKey: exclusiveStartKey,
+        Segment: this.segment,
+        TotalSegments: this.totalSegments,
+        Select: 'COUNT',
+      }),
+      this.sendOptions,
+    );
+
+    const out: { count: number; cursor?: string } = { count: resp.Count ?? 0 };
+    if (resp.LastEvaluatedKey) {
+      const c: Cursor = { lastKey: resp.LastEvaluatedKey };
+      if (this.indexName) c.index = this.indexName;
+      out.cursor = encodeCursor(c);
+    }
+    return out;
+  }
+
   async all(): Promise<Array<Record<string, unknown>>> {
     const original = this.cursorToken;
     try {
@@ -989,7 +1252,7 @@ export class ScanBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before summing.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async sum(field: string): Promise<number> {
     return sumField(await this.all(), field);
@@ -997,7 +1260,7 @@ export class ScanBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before averaging.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async average(field: string): Promise<number> {
     return averageField(await this.all(), field);
@@ -1005,7 +1268,7 @@ export class ScanBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before selecting the minimum.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async min(field: string): Promise<unknown> {
     return minField(await this.all(), field);
@@ -1013,7 +1276,7 @@ export class ScanBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before selecting the maximum.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async max(field: string): Promise<unknown> {
     return maxField(await this.all(), field);
@@ -1021,7 +1284,7 @@ export class ScanBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before computing the aggregate.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async aggregate(...fields: string[]): Promise<AggregateResult> {
     return aggregateField(await this.all(), fields[0]);
@@ -1029,7 +1292,7 @@ export class ScanBuilder {
 
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before counting distinct values.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   async countDistinct(field: string): Promise<number> {
     return countDistinct(await this.all(), field);
@@ -1037,7 +1300,7 @@ export class ScanBuilder {
 
   /**
    * Client-side aggregation: the returned group query calls `all()` during `execute()` and keeps groups in memory.
-   * Use only for bounded result sets. Prefer the planned native `count()`/server-side paths when they exist.
+   * Use only for bounded result sets; use native `count()` for count-only reads.
    */
   groupBy(field: string): GroupByQuery<Record<string, unknown>> {
     return new GroupByQuery(() => this.all(), field);

--- a/ts/src/query.ts
+++ b/ts/src/query.ts
@@ -35,6 +35,7 @@ import {
 } from './marshal.js';
 import type { AttributeSchema, IndexSchema, Model } from './model.js';
 import type { BuilderShape } from './optimizer.js';
+import { countAllPages } from './query-count.js';
 import type { SendOptions } from './send-options.js';
 
 export interface Page<T = Record<string, unknown>> {
@@ -549,23 +550,11 @@ export class QueryBuilder {
   }
 
   async count(): Promise<number> {
-    const original = this.cursorToken;
-    try {
-      let total = 0;
-      let cursor = original;
-
-      for (;;) {
-        this.cursorToken = cursor;
-        const page = await this.countPage();
-        total += page.count;
-        if (!page.cursor) break;
-        cursor = page.cursor;
-      }
-
-      return total;
-    } finally {
-      this.cursorToken = original;
-    }
+    return countAllPages(
+      this.cursorToken,
+      (cursor) => (this.cursorToken = cursor),
+      () => this.countPage(),
+    );
   }
 
   private async countPage(): Promise<{ count: number; cursor?: string }> {
@@ -1125,23 +1114,11 @@ export class ScanBuilder {
   }
 
   async count(): Promise<number> {
-    const original = this.cursorToken;
-    try {
-      let total = 0;
-      let cursor = original;
-
-      for (;;) {
-        this.cursorToken = cursor;
-        const page = await this.countPage();
-        total += page.count;
-        if (!page.cursor) break;
-        cursor = page.cursor;
-      }
-
-      return total;
-    } finally {
-      this.cursorToken = original;
-    }
+    return countAllPages(
+      this.cursorToken,
+      (cursor) => (this.cursorToken = cursor),
+      () => this.countPage(),
+    );
   }
 
   private async countPage(): Promise<{ count: number; cursor?: string }> {

--- a/ts/test/unit/client.test.ts
+++ b/ts/test/unit/client.test.ts
@@ -229,6 +229,47 @@ class StubDdb {
 
 {
   const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof GetItemCommand) {
+      return { Item: { PK: { S: 'A' }, SK: { S: 'B' }, version: { N: '1' } } };
+    }
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+  const got = await client.getOrNull('User', { PK: 'A', SK: 'B' });
+  assert.ok(got);
+  assert.equal(got.PK, 'A');
+  assert.equal(got.version, 1);
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof GetItemCommand) return {};
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+  const got = await client.getOrNull('User', { PK: 'A', SK: 'B' });
+  assert.equal(got, null);
+}
+
+{
+  const ddb = new StubDdb(() => {
+    throw new TheorydbError('ErrInvalidModel', 'boom');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+  await assert.rejects(
+    () => client.getOrNull('User', { PK: 'A', SK: 'B' }),
+    (e) => e instanceof TheorydbError && e.code === 'ErrInvalidModel',
+  );
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
     if (cmd instanceof PutItemCommand) return {};
     throw new Error('unexpected');
   });

--- a/ts/test/unit/query-builder.test.ts
+++ b/ts/test/unit/query-builder.test.ts
@@ -581,3 +581,60 @@ const User = defineModel({
     (e) => e instanceof TheorydbError && e.code === 'ErrInvalidOperator',
   );
 }
+
+{
+  const ddb = new StubDdb((cmd, call) => {
+    if (cmd instanceof QueryCommand) {
+      assert.equal(cmd.input.Select, 'COUNT');
+      assert.equal(cmd.input.Limit, undefined);
+      assert.equal(cmd.input.ProjectionExpression, undefined);
+      return call === 1
+        ? {
+            Count: 1,
+            LastEvaluatedKey: { PK: { S: 'A' }, SK: { S: '1' } },
+          }
+        : { Count: 2 };
+    }
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+
+  const count = await client
+    .query('User')
+    .partitionKey('A')
+    .sortKey('begins_with', 'ITEM#')
+    .filter('emailHash', '=', 'hash')
+    .limit(1)
+    .projection(['PK'])
+    .count();
+
+  assert.equal(count, 3);
+  assert.equal(ddb.calls, 2);
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof ScanCommand) {
+      assert.equal(cmd.input.Select, 'COUNT');
+      assert.equal(cmd.input.Limit, undefined);
+      assert.equal(cmd.input.ProjectionExpression, undefined);
+      return { Count: 4 };
+    }
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+
+  const count = await client
+    .scan('User')
+    .filter('emailHash', '=', 'hash')
+    .limit(1)
+    .projection(['PK'])
+    .count();
+
+  assert.equal(count, 4);
+  assert.equal(ddb.calls, 1);
+}


### PR DESCRIPTION
## Milestone
M9 count-and-optional-get — native count and no-error optional get exist in Go, TypeScript, and Python, scenario-pinned.

## Linear
Project: TableTheory Product Strengthening Program 2026-07 / milestone `count-and-optional-get`

Refs THE-2356
Refs THE-2357
Refs THE-2358
Refs THE-2359
Refs THE-2360
Refs THE-2361
Refs THE-2364
Refs THE-2366

## Affected runtimes
Go, TypeScript, Python, contract-test harness.

## Contract impact
- Adds P1 `51-native-count.yml` with capability `count.native` and count-step assertions requiring count results without materialized items.
- Adds P1 `55-optional-get.yml` with capability `get.optional`, pinning no-error misses only for the new optional operation.
- Extends Go/TS/Py contract runners with count and optional-get operations plus capability advertisement once each runtime converges.

## Backward compatibility
Additive. Existing get miss/error behavior is preserved. Existing user-visible `Count()`/`count()` result semantics are preserved while count execution uses DynamoDB `Select=COUNT` natively.

## Tasks
- [x] THE-2356 / TTIP-051: Add native-count scenario (capability-gated)
- [x] THE-2357 / TTIP-052: Native `Select=COUNT` count in Go
- [x] THE-2358 / TTIP-053: Native count in TypeScript
- [x] THE-2359 / TTIP-054: Native count in Python
- [x] THE-2360 / TTIP-055: Add optional-get scenario (capability-gated)
- [x] THE-2361 / TTIP-056: Optional get in Go
- [x] THE-2364 / TTIP-057: Optional get in TypeScript
- [x] THE-2366 / TTIP-058: Optional get in Python

## Validation
- [x] `make contract-tests` — PASS
- [x] `make test-unit` — PASS
- [x] `make rubric` — PASS (`pass=36 fail=0 blocked=0`)
- [x] `cd ts && npm run check` — PASS
- [x] `uv --directory py run pytest -q tests/unit` — PASS (`261 passed`)
- [x] `git diff --check project/tabletheory-product-strengthening-2026-07..HEAD` — PASS
- [x] Signature verification: `git log --show-signature project/tabletheory-product-strengthening-2026-07..HEAD` — all commits report `Good "git" signature`
- [x] Generated/key-contract guard — covered by `make contract-tests` (`generated-ts: PASS`, no generated/key-contract drift)

## Cross-repo coordination
None required; TableTheory-only additive API and scenario surface.
