### PR TITLE
M10 transactions/batches/iteration — THE-2367 THE-2369 THE-2371 THE-2373 THE-2375 THE-2376 THE-2377 THE-2378

### DIFF
--- a/contract-tests/runners/go/contract_test.go
+++ b/contract-tests/runners/go/contract_test.go
@@ -24,6 +24,11 @@ func TestContract_P1(t *testing.T) {
 	runContractScenarios(t, filepath.Join("contract-tests", "scenarios", "p1"))
 }
 
+func TestContract_P2(t *testing.T) {
+	t.Helper()
+	runContractScenarios(t, filepath.Join("contract-tests", "scenarios", "p2"))
+}
+
 func TestContract_Interop(t *testing.T) {
 	t.Helper()
 	if os.Getenv("CONTRACT_RUN_INTEROP") != "1" {

--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -54,6 +55,10 @@ type Driver interface {
 	Scan(ctx context.Context, model string, req ReadRequest) (ReadResult, error)
 	CountQuery(ctx context.Context, model string, req ReadRequest) (ReadResult, error)
 	CountScan(ctx context.Context, model string, req ReadRequest) (ReadResult, error)
+	TransactGet(ctx context.Context, model string, items []KeyedItem) (ReadResult, error)
+	BatchGet(ctx context.Context, model string, keys []map[string]any) (ReadResult, error)
+	BatchWrite(ctx context.Context, model string, puts []map[string]any, deletes []map[string]any) error
+	TransactWrite(ctx context.Context, model string, actions []TransactWriteAction) error
 	TransitionAppendEvent(ctx context.Context, actual TransitionActual, event TransitionEvent) error
 	ValidateProvenance(ctx context.Context, model string, item map[string]any) error
 }
@@ -81,6 +86,23 @@ type ReadResult struct {
 	Items  []map[string]any
 	Cursor string
 	Count  *int64
+}
+
+type KeyedItem struct {
+	Model string
+	Key   map[string]any
+}
+
+type TransactWriteAction struct {
+	Kind                      string
+	Model                     string
+	Item                      map[string]any
+	Key                       map[string]any
+	Set                       map[string]any
+	ConditionExpression       string
+	ExpressionAttributeNames  map[string]string
+	ExpressionAttributeValues map[string]any
+	IfNotExists               bool
 }
 
 type TransitionActual struct {
@@ -153,6 +175,10 @@ func (d *TheorydbDriver) Capabilities() []string {
 		"scan.basic",
 		"count.native",
 		"get.optional",
+		"transact_get",
+		"batch.get",
+		"batch.write",
+		"transact.write",
 		"release_state.write_policy",
 		"release_state.transactional_transition",
 		"release_state.provenance_confidence",
@@ -521,6 +547,183 @@ func countResult(q core.Query) (ReadResult, error) {
 	return ReadResult{Items: []map[string]any{}, Count: &count}, nil
 }
 
+func (d *TheorydbDriver) TransactGet(ctx context.Context, model string, items []KeyedItem) (ReadResult, error) {
+	getter, ok := d.db.(core.TransactGetter)
+	if !ok {
+		return ReadResult{}, fmt.Errorf("%w: transact get extension unavailable", theorydbErrors.ErrInvalidOperator)
+	}
+
+	requests := make([]core.TransactGetRequest, 0, len(items))
+	dests := make([]any, 0, len(items))
+	models := make([]string, 0, len(items))
+	for _, item := range items {
+		itemModel := item.Model
+		if itemModel == "" {
+			itemModel = model
+		}
+		empty, err := emptyModel(itemModel)
+		if err != nil {
+			return ReadResult{}, err
+		}
+		dest, err := newModelDest(itemModel)
+		if err != nil {
+			return ReadResult{}, err
+		}
+		key, err := keyPairFromMap(item.Key)
+		if err != nil {
+			return ReadResult{}, err
+		}
+		requests = append(requests, core.TransactGetRequest{
+			Model: empty,
+			Key:   key,
+			Dest:  dest,
+		})
+		dests = append(dests, dest)
+		models = append(models, itemModel)
+	}
+
+	results, err := getter.TransactGet(ctx, requests)
+	if err != nil {
+		return ReadResult{}, err
+	}
+	out := make([]map[string]any, 0, len(results))
+	for i, result := range results {
+		if !result.Found {
+			continue
+		}
+		normalized, err := normalizeModel(models[i], dests[i])
+		if err != nil {
+			return ReadResult{}, err
+		}
+		out = append(out, normalized)
+	}
+	return ReadResult{Items: out}, nil
+}
+
+func (d *TheorydbDriver) BatchGet(ctx context.Context, model string, keys []map[string]any) (ReadResult, error) {
+	keyPairs := make([]any, 0, len(keys))
+	for _, key := range keys {
+		pair, err := keyPairFromMap(key)
+		if err != nil {
+			return ReadResult{}, err
+		}
+		keyPairs = append(keyPairs, pair)
+	}
+
+	switch model {
+	case "User":
+		var out []User
+		err := d.db.WithContext(ctx).Model(&User{}).BatchGet(keyPairs, &out)
+		return ReadResult{Items: normalizeUsers(out)}, err
+	case "Order":
+		var out []Order
+		err := d.db.WithContext(ctx).Model(&Order{}).BatchGet(keyPairs, &out)
+		return ReadResult{Items: normalizeOrders(out)}, err
+	case "NumberPrecision":
+		var out []NumberPrecision
+		err := d.db.WithContext(ctx).Model(&NumberPrecision{}).BatchGet(keyPairs, &out)
+		return ReadResult{Items: normalizeNumberPrecisions(out)}, err
+	case "TypeMatrix":
+		var out []TypeMatrix
+		err := d.db.WithContext(ctx).Model(&TypeMatrix{}).BatchGet(keyPairs, &out)
+		return ReadResult{Items: normalizeTypeMatrices(out)}, err
+	case "SnakeCaseRecord":
+		var out []SnakeCaseRecord
+		err := d.db.WithContext(ctx).Model(&SnakeCaseRecord{}).BatchGet(keyPairs, &out)
+		return ReadResult{Items: normalizeSnakeCaseRecords(out)}, err
+	case "EncryptedRecord":
+		var out []EncryptedRecord
+		err := d.db.WithContext(ctx).Model(&EncryptedRecord{}).BatchGet(keyPairs, &out)
+		return ReadResult{Items: normalizeEncryptedRecords(out)}, err
+	case "ReleaseStateActual":
+		var out []ReleaseStateActual
+		err := d.db.WithContext(ctx).Model(&ReleaseStateActual{}).BatchGet(keyPairs, &out)
+		return ReadResult{Items: normalizeReleaseStateActuals(out)}, err
+	case "ReleaseStateEvent":
+		var out []ReleaseStateEvent
+		err := d.db.WithContext(ctx).Model(&ReleaseStateEvent{}).BatchGet(keyPairs, &out)
+		return ReadResult{Items: normalizeReleaseStateEvents(out)}, err
+	default:
+		return ReadResult{}, fmt.Errorf("%w: unknown model %q", theorydbErrors.ErrInvalidModel, model)
+	}
+}
+
+func (d *TheorydbDriver) BatchWrite(ctx context.Context, model string, puts []map[string]any, deletes []map[string]any) error {
+	putItems := make([]any, 0, len(puts))
+	for _, item := range puts {
+		instance, err := modelFromMap(model, item)
+		if err != nil {
+			return err
+		}
+		putItems = append(putItems, instance)
+	}
+
+	deleteKeys := make([]any, 0, len(deletes))
+	for _, key := range deletes {
+		pair, err := keyPairFromMap(key)
+		if err != nil {
+			return err
+		}
+		deleteKeys = append(deleteKeys, pair)
+	}
+
+	empty, err := emptyModel(model)
+	if err != nil {
+		return err
+	}
+	return d.db.WithContext(ctx).Model(empty).BatchWrite(putItems, deleteKeys)
+}
+
+func (d *TheorydbDriver) TransactWrite(ctx context.Context, model string, actions []TransactWriteAction) error {
+	return d.db.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
+		for _, action := range actions {
+			actionModel := action.Model
+			if actionModel == "" {
+				actionModel = model
+			}
+			conditions := transactConditionsFromAction(action)
+			switch strings.ToLower(action.Kind) {
+			case "put", "create":
+				instance, err := modelFromMap(actionModel, action.Item)
+				if err != nil {
+					return err
+				}
+				if action.IfNotExists || strings.EqualFold(action.Kind, "create") {
+					tx = tx.Create(instance, conditions...)
+				} else {
+					tx = tx.Put(instance, conditions...)
+				}
+			case "update":
+				item := mergeMaps(action.Key, action.Set)
+				instance, err := modelFromMap(actionModel, item)
+				if err != nil {
+					return err
+				}
+				fields, err := updateFieldNames(actionModel, action.Set)
+				if err != nil {
+					return err
+				}
+				tx = tx.Update(instance, fields, conditions...)
+			case "delete":
+				instance, err := modelFromMap(actionModel, action.Key)
+				if err != nil {
+					return err
+				}
+				tx = tx.Delete(instance, conditions...)
+			case "condition", "condition_check":
+				instance, err := modelFromMap(actionModel, action.Key)
+				if err != nil {
+					return err
+				}
+				tx = tx.ConditionCheck(instance, conditions...)
+			default:
+				return fmt.Errorf("%w: unsupported transact_write action %q", theorydbErrors.ErrInvalidOperator, action.Kind)
+			}
+		}
+		return nil
+	})
+}
+
 func (d *TheorydbDriver) TransitionAppendEvent(ctx context.Context, actual TransitionActual, event TransitionEvent) error {
 	if actual.Model != "ReleaseStateActual" || event.Model != "ReleaseStateEvent" {
 		return fmt.Errorf("%w: unsupported transition models %s/%s", theorydbErrors.ErrInvalidModel, actual.Model, event.Model)
@@ -629,6 +832,144 @@ func emptyModel(model string) (any, error) {
 	default:
 		return nil, fmt.Errorf("%w: unknown model %q", theorydbErrors.ErrInvalidModel, model)
 	}
+}
+
+func newModelDest(model string) (any, error) {
+	return emptyModel(model)
+}
+
+func normalizeModel(model string, value any) (map[string]any, error) {
+	switch model {
+	case "User":
+		if v, ok := value.(*User); ok {
+			return normalizeUser(*v), nil
+		}
+	case "Order":
+		if v, ok := value.(*Order); ok {
+			return normalizeOrder(*v), nil
+		}
+	case "NumberPrecision":
+		if v, ok := value.(*NumberPrecision); ok {
+			return normalizeNumberPrecision(*v), nil
+		}
+	case "TypeMatrix":
+		if v, ok := value.(*TypeMatrix); ok {
+			return normalizeTypeMatrix(*v), nil
+		}
+	case "SnakeCaseRecord":
+		if v, ok := value.(*SnakeCaseRecord); ok {
+			return normalizeSnakeCaseRecord(*v), nil
+		}
+	case "EncryptedRecord":
+		if v, ok := value.(*EncryptedRecord); ok {
+			return normalizeEncryptedRecord(*v), nil
+		}
+	case "ReleaseStateActual":
+		if v, ok := value.(*ReleaseStateActual); ok {
+			return normalizeReleaseStateActual(*v), nil
+		}
+	case "ReleaseStateEvent":
+		if v, ok := value.(*ReleaseStateEvent); ok {
+			return normalizeReleaseStateEvent(*v), nil
+		}
+	}
+	return nil, fmt.Errorf("%w: cannot normalize %T as %s", theorydbErrors.ErrInvalidModel, value, model)
+}
+
+func keyPairFromMap(key map[string]any) (core.KeyPair, error) {
+	pk, sk, err := keyValues(key)
+	if err != nil {
+		return core.KeyPair{}, err
+	}
+	return core.NewKeyPair(pk, sk), nil
+}
+
+func transactConditionsFromAction(action TransactWriteAction) []core.TransactCondition {
+	if strings.TrimSpace(action.ConditionExpression) == "" {
+		return nil
+	}
+	values := make(map[string]any, len(action.ExpressionAttributeValues))
+	for k, v := range action.ExpressionAttributeValues {
+		values[k] = v
+	}
+	return []core.TransactCondition{
+		{
+			Kind:       core.TransactConditionKindExpression,
+			Expression: action.ConditionExpression,
+			Values:     values,
+		},
+	}
+}
+
+func mergeMaps(left map[string]any, right map[string]any) map[string]any {
+	out := make(map[string]any, len(left)+len(right))
+	for k, v := range left {
+		out[k] = v
+	}
+	for k, v := range right {
+		out[k] = v
+	}
+	return out
+}
+
+func sortedMapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func updateFieldNames(model string, values map[string]any) ([]string, error) {
+	fields := sortedMapKeys(values)
+	instance, err := emptyModel(model)
+	if err != nil {
+		return nil, err
+	}
+	typ := reflect.TypeOf(instance)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	resolved := make([]string, 0, len(fields))
+	for _, field := range fields {
+		goName, ok := resolveGoFieldName(typ, field)
+		if !ok {
+			return nil, fmt.Errorf("%w: unknown update field %s", theorydbErrors.ErrInvalidModel, field)
+		}
+		resolved = append(resolved, goName)
+	}
+	return resolved, nil
+}
+
+func resolveGoFieldName(typ reflect.Type, attr string) (string, bool) {
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Name == "_" {
+			continue
+		}
+		candidates := []string{field.Name, lowerFirst(field.Name)}
+		if tag := field.Tag.Get("theorydb"); tag != "" {
+			for _, part := range strings.Split(tag, ",") {
+				if strings.HasPrefix(part, "attr:") {
+					candidates = append(candidates, strings.TrimPrefix(part, "attr:"))
+				}
+			}
+		}
+		for _, candidate := range candidates {
+			if candidate == attr || strings.EqualFold(candidate, attr) {
+				return field.Name, true
+			}
+		}
+	}
+	return "", false
+}
+
+func lowerFirst(value string) string {
+	if value == "" {
+		return value
+	}
+	return strings.ToLower(value[:1]) + value[1:]
 }
 
 func asStringSlice(v any) ([]string, error) {

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -199,6 +199,30 @@ func (r *Runner) runStep(t require.TestingT, ctx context.Context, s *scenario.Sc
 		r.assertReadResult(t, step.Expect, result, err, model)
 		return
 
+	case "transact_get":
+		require.NotNil(t, step.TransactGet, "transact_get request is required")
+		result, err := r.driver.TransactGet(ctx, modelName, transactGetItemsFromScenario(step.TransactGet))
+		r.assertReadResult(t, step.Expect, result, err, model)
+		return
+
+	case "batch_get":
+		require.NotNil(t, step.BatchGet, "batch_get request is required")
+		result, err := r.driver.BatchGet(ctx, modelName, cloneKeyMaps(step.BatchGet.Keys))
+		r.assertReadResult(t, step.Expect, result, err, model)
+		return
+
+	case "batch_write":
+		require.NotNil(t, step.BatchWrite, "batch_write request is required")
+		err := r.driver.BatchWrite(ctx, modelName, cloneKeyMaps(step.BatchWrite.Puts), cloneKeyMaps(step.BatchWrite.Deletes))
+		r.assertStepResult(t, step.Expect, nil, err, nil, model)
+		return
+
+	case "transact_write":
+		require.NotNil(t, step.TransactWrite, "transact_write request is required")
+		err := r.driver.TransactWrite(ctx, modelName, transactWriteActionsFromScenario(step.TransactWrite.Actions))
+		r.assertStepResult(t, step.Expect, nil, err, nil, model)
+		return
+
 	case "transition_append_event":
 		require.NotNil(t, step.Actual, "transition_append_event actual is required")
 		require.NotNil(t, step.Event, "transition_append_event event is required")
@@ -257,6 +281,68 @@ func readConditionFromScenario(cond scenario.ReadCondition) driver.ReadCondition
 		Value:     cond.Value,
 		Values:    append([]any(nil), cond.Values...),
 	}
+}
+
+func transactGetItemsFromScenario(req *scenario.TransactGetRequest) []driver.KeyedItem {
+	if req == nil {
+		return nil
+	}
+	items := make([]driver.KeyedItem, 0, len(req.Items))
+	for _, item := range req.Items {
+		items = append(items, driver.KeyedItem{
+			Model: item.Model,
+			Key:   cloneMap(item.Key),
+		})
+	}
+	return items
+}
+
+func transactWriteActionsFromScenario(actions []scenario.TransactWriteAction) []driver.TransactWriteAction {
+	out := make([]driver.TransactWriteAction, 0, len(actions))
+	for _, action := range actions {
+		out = append(out, driver.TransactWriteAction{
+			Kind:                      action.Kind,
+			Model:                     action.Model,
+			Item:                      cloneMap(action.Item),
+			Key:                       cloneMap(action.Key),
+			Set:                       cloneMap(action.Set),
+			ConditionExpression:       action.ConditionExpression,
+			ExpressionAttributeNames:  cloneStringMap(action.ExpressionAttributeNames),
+			ExpressionAttributeValues: cloneMap(action.ExpressionAttributeValues),
+			IfNotExists:               action.IfNotExists,
+		})
+	}
+	return out
+}
+
+func cloneKeyMaps(values []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(values))
+	for _, value := range values {
+		out = append(out, cloneMap(value))
+	}
+	return out
+}
+
+func cloneMap(value map[string]any) map[string]any {
+	if value == nil {
+		return nil
+	}
+	out := make(map[string]any, len(value))
+	for k, v := range value {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneStringMap(value map[string]string) map[string]string {
+	if value == nil {
+		return nil
+	}
+	out := make(map[string]string, len(value))
+	for k, v := range value {
+		out[k] = v
+	}
+	return out
 }
 
 func stepModelName(s *scenario.Scenario, step scenario.Step) string {

--- a/contract-tests/runners/go/internal/scenario/scenario.go
+++ b/contract-tests/runners/go/internal/scenario/scenario.go
@@ -31,26 +31,64 @@ type EncryptionConfig struct {
 }
 
 type Step struct {
-	Op                  string            `yaml:"op"`
-	Model               string            `yaml:"model"`
-	IfNotExists         bool              `yaml:"if_not_exists"`
-	Fields              []string          `yaml:"fields"`
-	ProtectedAttributes []string          `yaml:"protected_attributes"`
-	Item                map[string]any    `yaml:"item"`
-	Key                 map[string]any    `yaml:"key"`
-	Query               *ReadRequest      `yaml:"query"`
-	Scan                *ReadRequest      `yaml:"scan"`
-	Count               *CountRequest     `yaml:"count"`
-	Actual              *TransitionActual `yaml:"actual"`
-	Event               *TransitionEvent  `yaml:"event"`
-	Ms                  int               `yaml:"ms"`
-	Save                map[string]string `yaml:"save"`
-	Expect              Expectation       `yaml:"expect"`
+	Op                  string                `yaml:"op"`
+	Model               string                `yaml:"model"`
+	IfNotExists         bool                  `yaml:"if_not_exists"`
+	Fields              []string              `yaml:"fields"`
+	ProtectedAttributes []string              `yaml:"protected_attributes"`
+	Item                map[string]any        `yaml:"item"`
+	Key                 map[string]any        `yaml:"key"`
+	Query               *ReadRequest          `yaml:"query"`
+	Scan                *ReadRequest          `yaml:"scan"`
+	Count               *CountRequest         `yaml:"count"`
+	TransactGet         *TransactGetRequest   `yaml:"transact_get"`
+	BatchGet            *BatchGetRequest      `yaml:"batch_get"`
+	BatchWrite          *BatchWriteRequest    `yaml:"batch_write"`
+	TransactWrite       *TransactWriteRequest `yaml:"transact_write"`
+	Actual              *TransitionActual     `yaml:"actual"`
+	Event               *TransitionEvent      `yaml:"event"`
+	Ms                  int                   `yaml:"ms"`
+	Save                map[string]string     `yaml:"save"`
+	Expect              Expectation           `yaml:"expect"`
 }
 
 type CountRequest struct {
 	Query *ReadRequest `yaml:"query"`
 	Scan  *ReadRequest `yaml:"scan"`
+}
+
+type TransactGetRequest struct {
+	Items []KeyedItem `yaml:"items"`
+}
+
+type BatchGetRequest struct {
+	Keys []map[string]any `yaml:"keys"`
+}
+
+type BatchWriteRequest struct {
+	Puts    []map[string]any `yaml:"puts"`
+	Deletes []map[string]any `yaml:"deletes"`
+}
+
+type TransactWriteRequest struct {
+	Actions []TransactWriteAction `yaml:"actions"`
+}
+
+type KeyedItem struct {
+	Model string         `yaml:"model"`
+	Key   map[string]any `yaml:"key"`
+}
+
+type TransactWriteAction struct {
+	Kind                      string            `yaml:"kind"`
+	Model                     string            `yaml:"model"`
+	Item                      map[string]any    `yaml:"item"`
+	Key                       map[string]any    `yaml:"key"`
+	Set                       map[string]any    `yaml:"set"`
+	ConditionExpression       string            `yaml:"condition_expression"`
+	ExpressionAttributeNames  map[string]string `yaml:"expression_attribute_names"`
+	ExpressionAttributeValues map[string]any    `yaml:"expression_attribute_values"`
+	IfNotExists               bool              `yaml:"if_not_exists"`
 }
 
 type ReadRequest struct {
@@ -187,6 +225,32 @@ func validateStep(label string, i int, step Step) error {
 			return validateQueryReadRequest(step.Count.Query, fmt.Sprintf("%s count.query", prefix))
 		}
 		return validateScanReadRequest(step.Count.Scan, fmt.Sprintf("%s count.scan", prefix))
+	case "transact_get":
+		if step.TransactGet == nil || len(step.TransactGet.Items) == 0 {
+			return fmt.Errorf("%s transact_get: transact_get.items are required", prefix)
+		}
+		for j, item := range step.TransactGet.Items {
+			if len(item.Key) == 0 {
+				return fmt.Errorf("%s transact_get.items[%d]: key is required", prefix, j)
+			}
+		}
+	case "batch_get":
+		if step.BatchGet == nil || len(step.BatchGet.Keys) == 0 {
+			return fmt.Errorf("%s batch_get: batch_get.keys are required", prefix)
+		}
+	case "batch_write":
+		if step.BatchWrite == nil || (len(step.BatchWrite.Puts) == 0 && len(step.BatchWrite.Deletes) == 0) {
+			return fmt.Errorf("%s batch_write: batch_write.puts or batch_write.deletes are required", prefix)
+		}
+	case "transact_write":
+		if step.TransactWrite == nil || len(step.TransactWrite.Actions) == 0 {
+			return fmt.Errorf("%s transact_write: transact_write.actions are required", prefix)
+		}
+		for j, action := range step.TransactWrite.Actions {
+			if action.Kind == "" {
+				return fmt.Errorf("%s transact_write.actions[%d]: kind is required", prefix, j)
+			}
+		}
 	case "transition_append_event":
 		if step.Actual == nil {
 			return fmt.Errorf("%s transition_append_event: actual is required", prefix)

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -29,6 +29,11 @@ from theorydb_py import (
     RejectedDeployAuthorityEvidenceError,
     SortKeyCondition,
     Table,
+    TransactConditionCheck,
+    TransactDelete,
+    TransactPut,
+    TransactUpdate,
+    TransactWriteAction,
     ValidationError,
     VersionConflictError,
     WritePolicy,
@@ -393,6 +398,76 @@ class _TheorydbPyDriver:
         )
         return {"items": [], "count": count}
 
+    def transact_get(self, model: str, items: list[dict[str, Any]]) -> dict[str, Any]:
+        table = self._table(model)
+        keys = [_key_tuple(item["key"]) for item in items]
+        rows = table.transact_get(keys)
+        return {"items": [_contract_item(item) for item in rows if item is not None]}
+
+    def batch_get(self, model: str, keys: list[dict[str, Any]]) -> dict[str, Any]:
+        rows = self._table(model).batch_get([_key_tuple(key) for key in keys], consistent_read=True)
+        return {"items": [_contract_item(item) for item in rows]}
+
+    def batch_write(
+        self,
+        model: str,
+        puts: list[dict[str, Any]],
+        deletes: list[dict[str, Any]],
+    ) -> None:
+        self._table(model).batch_write(
+            puts=[self._item(model, item) for item in puts],
+            deletes=[_key_tuple(key) for key in deletes],
+        )
+
+    def transact_write(self, model: str, actions: list[dict[str, Any]]) -> None:
+        self._table(model).transact_write([self._transact_action(model, action) for action in actions])
+
+    def _transact_action(self, model: str, action: dict[str, Any]) -> TransactWriteAction[Any]:
+        kind = str(action["kind"]).lower()
+        action_model = action.get("model") or model
+        if action_model != model:
+            raise ValidationError("python transact_write runner supports one table per scenario")
+        condition_expression = action.get("condition_expression")
+        names = action.get("expression_attribute_names")
+        values = action.get("expression_attribute_values")
+
+        if kind in {"put", "create"}:
+            return TransactPut(
+                self._item(model, action["item"]),
+                condition_expression=condition_expression,
+                expression_attribute_names=names,
+                expression_attribute_values=values,
+            )
+        if kind == "update":
+            pk, sk = _key_tuple(action["key"])
+            return TransactUpdate(
+                pk=pk,
+                sk=sk,
+                updates=action.get("set", {}),
+                condition_expression=condition_expression,
+                expression_attribute_names=names,
+                expression_attribute_values=values,
+            )
+        if kind == "delete":
+            pk, sk = _key_tuple(action["key"])
+            return TransactDelete(
+                pk=pk,
+                sk=sk,
+                condition_expression=condition_expression,
+                expression_attribute_names=names,
+                expression_attribute_values=values,
+            )
+        if kind in {"condition", "condition_check"}:
+            pk, sk = _key_tuple(action["key"])
+            return TransactConditionCheck(
+                pk=pk,
+                sk=sk,
+                condition_expression=condition_expression,
+                expression_attribute_names=names,
+                expression_attribute_values=values,
+            )
+        raise ValidationError(f"unsupported transact_write action: {kind}")
+
     def transition_append_event(self, actual: dict[str, Any], event: dict[str, Any]) -> None:
         transition_release_state(
             self._table(actual["model"]),
@@ -497,6 +572,25 @@ def test_p1_contract_scenarios_execute_for_python(scenario: dict[str, Any]) -> N
     _run_scenario(client, driver, scenario, models)
 
 
+@pytest.mark.parametrize("scenario", _load_scenarios_from("p2"), ids=lambda scenario: str(scenario["name"]))
+def test_p2_contract_scenarios_execute_for_python(scenario: dict[str, Any]) -> None:
+    models = _load_models()
+    missing = _missing_capabilities(scenario, _supported_capabilities())
+    if missing:
+        pytest.skip(f"scenario requires unsupported capabilities: {', '.join(missing)}")
+
+    client = _dynamodb_client()
+    try:
+        client.list_tables(Limit=1)
+    except EndpointConnectionError:
+        if os.environ.get("SKIP_INTEGRATION") in {"1", "true"}:
+            pytest.skip("DynamoDB Local not reachable and SKIP_INTEGRATION is set")
+        raise
+
+    driver = _TheorydbPyDriver(client, encryption=scenario.get("encryption"))
+    _run_scenario(client, driver, scenario, models)
+
+
 @pytest.mark.parametrize(
     "scenario",
     _load_scenarios_from("interop"),
@@ -532,6 +626,10 @@ def _supported_capabilities() -> list[str]:
         "scan.basic",
         "count.native",
         "get.optional",
+        "transact_get",
+        "batch.get",
+        "batch.write",
+        "transact.write",
         "release_state.write_policy",
         "release_state.transactional_transition",
         "release_state.provenance_confidence",
@@ -565,6 +663,10 @@ def _sk_value(values: dict[str, Any]) -> Any:
     if "SK" in values:
         return values["SK"]
     return values["sk"]
+
+
+def _key_tuple(values: dict[str, Any]) -> tuple[Any, Any | None]:
+    return (_pk_value(values), _sk_value(values))
 
 
 def _condition_values(condition: dict[str, Any]) -> tuple[Any, ...]:
@@ -770,6 +872,27 @@ def _run_step(
         else:
             result, error = _capture_result(lambda: driver.count_scan(model_name, count_request["scan"]))
         _assert_read_expectation(step.get("expect", {}), error=error, result=result, model=model)
+        return
+
+    if step["op"] == "transact_get":
+        result, error = _capture_result(lambda: driver.transact_get(model_name, step["transact_get"]["items"]))
+        _assert_read_expectation(step.get("expect", {}), error=error, result=result, model=model)
+        return
+
+    if step["op"] == "batch_get":
+        result, error = _capture_result(lambda: driver.batch_get(model_name, step["batch_get"]["keys"]))
+        _assert_read_expectation(step.get("expect", {}), error=error, result=result, model=model)
+        return
+
+    if step["op"] == "batch_write":
+        request = step["batch_write"]
+        error = _capture_error(lambda: driver.batch_write(model_name, request.get("puts", []), request.get("deletes", [])))
+        _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
+        return
+
+    if step["op"] == "transact_write":
+        error = _capture_error(lambda: driver.transact_write(model_name, step["transact_write"]["actions"]))
+        _assert_expectation(step.get("expect", {}), error=error, model=model, variables=variables)
         return
 
     if step["op"] == "transition_append_event":
@@ -1069,6 +1192,8 @@ def _map_errors(error: Exception) -> list[str]:
             "consistent_read" in str(error)
             or "unsupported sort operator" in str(error)
             or "unsupported filter operator" in str(error)
+            or "at most 100" in str(error)
+            or "supports at most 100" in str(error)
         ):
             return ["ErrInvalidOperator"]
         return ["ErrInvalidModel"]

--- a/contract-tests/runners/ts/package.json
+++ b/contract-tests/runners/ts/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "npm run test:key-contract && npm run test:fixtures && npm run test:encoding && npm run test:reserved-words && npm run test:update-builder && npm run test:filters && npm run test:crypto && npm run test:contract:p0 && npm run test:contract:p1",
+    "test": "npm run test:key-contract && npm run test:fixtures && npm run test:encoding && npm run test:reserved-words && npm run test:update-builder && npm run test:filters && npm run test:crypto && npm run test:contract:p0 && npm run test:contract:p1 && npm run test:contract:p2",
     "test:crypto": "tsx test/crypto.contract.test.ts",
     "test:encoding": "tsx test/encoding.contract.test.ts",
     "test:fixtures": "tsx test/fixtures.test.ts",
@@ -14,7 +14,8 @@
     "test:contract:p0": "tsx test/contract.p0.test.ts",
     "test:contract:p1": "tsx test/contract.p1.test.ts",
     "test:contract:interop": "tsx test/contract.interop.test.ts",
-    "test:key-contract": "tsx test/key-contract.contract.test.ts"
+    "test:key-contract": "tsx test/key-contract.contract.test.ts",
+    "test:contract:p2": "tsx test/contract.p2.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1053.0"

--- a/contract-tests/runners/ts/src/driver.ts
+++ b/contract-tests/runners/ts/src/driver.ts
@@ -1,8 +1,10 @@
-import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import type { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { TheorydbClient } from "../../../../ts/src/client.js";
 import type { EncryptionProvider } from "../../../../ts/src/encryption.js";
 import { TheorydbError } from "../../../../ts/src/errors.js";
+import { marshalScalar } from "../../../../ts/src/marshal.js";
 import type { Model } from "../../../../ts/src/model.js";
+import type { TransactAction } from "../../../../ts/src/transaction.js";
 import {
   transitionReleaseState,
   validateDeployAuthorityMetadata,
@@ -52,6 +54,20 @@ export interface Driver {
   scan(model: string, req: ReadRequest): Promise<ReadResult>;
   countQuery(model: string, req: ReadRequest): Promise<ReadResult>;
   countScan(model: string, req: ReadRequest): Promise<ReadResult>;
+  transactGet(model: string, items: KeyedItem[]): Promise<ReadResult>;
+  batchGet(
+    model: string,
+    keys: Array<Record<string, unknown>>,
+  ): Promise<ReadResult>;
+  batchWrite(
+    model: string,
+    puts: Array<Record<string, unknown>>,
+    deletes: Array<Record<string, unknown>>,
+  ): Promise<void>;
+  transactWrite(
+    model: string,
+    actions: ScenarioTransactWriteAction[],
+  ): Promise<void>;
   transitionAppendEvent(
     actual: TransitionActual,
     event: TransitionEvent,
@@ -66,6 +82,23 @@ export interface ReadResult {
   items: Array<Record<string, unknown>>;
   cursor?: string;
   count?: number;
+}
+
+export interface KeyedItem {
+  model?: string;
+  key: Record<string, unknown>;
+}
+
+export interface ScenarioTransactWriteAction {
+  kind: string;
+  model?: string;
+  item?: Record<string, unknown>;
+  key?: Record<string, unknown>;
+  set?: Record<string, unknown>;
+  conditionExpression?: string;
+  expressionAttributeNames?: Record<string, string>;
+  expressionAttributeValues?: Record<string, unknown>;
+  ifNotExists?: boolean;
 }
 
 export interface TransitionActual {
@@ -83,6 +116,7 @@ export interface TransitionEvent {
 export class TheorydbDriver implements Driver {
   private readonly client: TheorydbClient;
   private readonly exactNumbers: boolean;
+  private readonly models: Map<string, Model>;
 
   constructor(
     ddb: DynamoDBClient,
@@ -90,6 +124,7 @@ export class TheorydbDriver implements Driver {
     opts: { exactNumbers?: boolean; encryption?: EncryptionProvider } = {},
   ) {
     this.exactNumbers = opts.exactNumbers ?? false;
+    this.models = new Map(models.map((model) => [model.name, model]));
     this.client = new TheorydbClient(ddb, {
       ...(this.exactNumbers ? { numberUnmarshalMode: "string" } : {}),
       ...(opts.encryption ? { encryption: opts.encryption } : {}),
@@ -110,6 +145,10 @@ export class TheorydbDriver implements Driver {
       "scan.basic",
       "count.native",
       "get.optional",
+      "transact_get",
+      "batch.get",
+      "batch.write",
+      "transact.write",
       "release_state.write_policy",
       "release_state.transactional_transition",
       "release_state.provenance_confidence",
@@ -250,6 +289,190 @@ export class TheorydbDriver implements Driver {
       );
     }
     return { items: [], count: await builder.count() };
+  }
+
+  async transactGet(model: string, items: KeyedItem[]): Promise<ReadResult> {
+    const rows = await this.client.transactGet(
+      items.map((item) => ({
+        model: item.model ?? model,
+        key: item.key,
+      })),
+    );
+    return {
+      items: rows.filter(
+        (row): row is Record<string, unknown> => row !== undefined,
+      ),
+    };
+  }
+
+  async batchGet(
+    model: string,
+    keys: Array<Record<string, unknown>>,
+  ): Promise<ReadResult> {
+    const result = await this.client.batchGet(model, keys);
+    return { items: result.items };
+  }
+
+  async batchWrite(
+    model: string,
+    puts: Array<Record<string, unknown>>,
+    deletes: Array<Record<string, unknown>>,
+  ): Promise<void> {
+    const result = await this.client.batchWrite(model, {
+      puts: puts.map((item) => contractItemForModel(model, item)),
+      deletes,
+    });
+    if (result.unprocessed.length > 0) {
+      throw new TheorydbError(
+        "ErrInvalidOperator",
+        `batch write left ${result.unprocessed.length} unprocessed items`,
+      );
+    }
+  }
+
+  async transactWrite(
+    model: string,
+    actions: ScenarioTransactWriteAction[],
+  ): Promise<void> {
+    await this.client.transactWrite(
+      actions.map((action) => this.toTransactAction(model, action)),
+    );
+  }
+
+  private toTransactAction(
+    defaultModel: string,
+    action: ScenarioTransactWriteAction,
+  ): TransactAction {
+    const modelName = action.model ?? defaultModel;
+    switch (action.kind.toLowerCase()) {
+      case "put":
+      case "create":
+        if (!action.item) {
+          throw new TheorydbError(
+            "ErrInvalidModel",
+            "put action requires item",
+          );
+        }
+        return {
+          kind: "put",
+          model: modelName,
+          item: contractItemForModel(modelName, action.item),
+          ifNotExists:
+            action.ifNotExists || action.kind.toLowerCase() === "create",
+        };
+      case "update":
+        return this.toUpdateAction(modelName, action);
+      case "delete":
+        if (!action.key) {
+          throw new TheorydbError(
+            "ErrInvalidModel",
+            "delete action requires key",
+          );
+        }
+        return {
+          kind: "delete",
+          model: modelName,
+          key: action.key,
+          conditionExpression: action.conditionExpression,
+          expressionAttributeNames: action.expressionAttributeNames,
+          expressionAttributeValues: this.expressionValues(
+            modelName,
+            action.expressionAttributeValues,
+          ),
+        };
+      case "condition":
+      case "condition_check":
+        if (!action.key || !action.conditionExpression) {
+          throw new TheorydbError(
+            "ErrInvalidModel",
+            "condition action requires key and conditionExpression",
+          );
+        }
+        return {
+          kind: "condition",
+          model: modelName,
+          key: action.key,
+          conditionExpression: action.conditionExpression,
+          expressionAttributeNames: action.expressionAttributeNames,
+          expressionAttributeValues: this.expressionValues(
+            modelName,
+            action.expressionAttributeValues,
+          ),
+        };
+      default:
+        throw new TheorydbError(
+          "ErrInvalidOperator",
+          `unsupported transact_write action: ${action.kind}`,
+        );
+    }
+  }
+
+  private toUpdateAction(
+    modelName: string,
+    action: ScenarioTransactWriteAction,
+  ): TransactAction {
+    if (!action.key || !action.set) {
+      throw new TheorydbError(
+        "ErrInvalidModel",
+        "update action requires key and set",
+      );
+    }
+    const model = this.requireScenarioModel(modelName);
+    const names: Record<string, string> = {
+      ...(action.expressionAttributeNames ?? {}),
+    };
+    const values: Record<string, AttributeValue> =
+      this.expressionValues(modelName, action.expressionAttributeValues) ?? {};
+    const assignments: string[] = [];
+    for (const [index, [field, value]] of Object.entries(
+      action.set,
+    ).entries()) {
+      const attr = model.attributes.get(field);
+      if (!attr) {
+        throw new TheorydbError(
+          "ErrInvalidModel",
+          `unknown update field ${field}`,
+        );
+      }
+      const name = `#u${index}`;
+      const valueName = `:u${index}`;
+      names[name] = attr.attribute;
+      values[valueName] = marshalScalar(attr, value);
+      assignments.push(`${name} = ${valueName}`);
+    }
+    return {
+      kind: "update",
+      model: modelName,
+      key: action.key,
+      updateExpression: `SET ${assignments.join(", ")}`,
+      conditionExpression: action.conditionExpression,
+      expressionAttributeNames: names,
+      expressionAttributeValues: values,
+    };
+  }
+
+  private expressionValues(
+    modelName: string,
+    values: Record<string, unknown> | undefined,
+  ): Record<string, AttributeValue> | undefined {
+    if (!values) return undefined;
+    const model = this.requireScenarioModel(modelName);
+    const fallbackSchema =
+      model.attributes.get(model.roles.pk) ?? model.schema.attributes[0];
+    if (!fallbackSchema) return undefined;
+    const out: Record<string, AttributeValue> = {};
+    for (const [key, value] of Object.entries(values)) {
+      out[key] = marshalScalar(fallbackSchema, value);
+    }
+    return out;
+  }
+
+  private requireScenarioModel(name: string): Model {
+    const model = this.models.get(name);
+    if (!model) {
+      throw new TheorydbError("ErrInvalidModel", `unknown model: ${name}`);
+    }
+    return model;
   }
 
   async transitionAppendEvent(

--- a/contract-tests/runners/ts/src/load.ts
+++ b/contract-tests/runners/ts/src/load.ts
@@ -114,6 +114,57 @@ function validateStep(
     case "count":
       requireCountRequest(step.count, `${prefix}: count`);
       break;
+    case "transact_get": {
+      requirePlainObject(
+        step.transact_get,
+        `${prefix}: transact_get is required`,
+      );
+      const request = step.transact_get as { items?: unknown };
+      if (!Array.isArray(request.items) || request.items.length === 0) {
+        throw new Error(`${prefix}: transact_get.items are required`);
+      }
+      for (const [itemIndex, item] of request.items.entries()) {
+        requirePlainObject(
+          (item as { key?: unknown }).key,
+          `${prefix}: transact_get.items[${itemIndex}].key is required`,
+        );
+      }
+      break;
+    }
+    case "batch_get": {
+      requirePlainObject(step.batch_get, `${prefix}: batch_get is required`);
+      const request = step.batch_get as { keys?: unknown };
+      if (!Array.isArray(request.keys) || request.keys.length === 0) {
+        throw new Error(`${prefix}: batch_get.keys are required`);
+      }
+      break;
+    }
+    case "batch_write": {
+      requirePlainObject(
+        step.batch_write,
+        `${prefix}: batch_write is required`,
+      );
+      const request = step.batch_write as { puts?: unknown; deletes?: unknown };
+      const puts = Array.isArray(request.puts) ? request.puts.length : 0;
+      const deletes = Array.isArray(request.deletes)
+        ? request.deletes.length
+        : 0;
+      if (puts + deletes === 0) {
+        throw new Error(`${prefix}: batch_write.puts or deletes are required`);
+      }
+      break;
+    }
+    case "transact_write": {
+      requirePlainObject(
+        step.transact_write,
+        `${prefix}: transact_write is required`,
+      );
+      const request = step.transact_write as { actions?: unknown };
+      if (!Array.isArray(request.actions) || request.actions.length === 0) {
+        throw new Error(`${prefix}: transact_write.actions are required`);
+      }
+      break;
+    }
     case "transition_append_event":
       requireTransitionActual(step.actual, `${prefix}: actual`);
       requireTransitionEvent(step.event, `${prefix}: event`);

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -205,6 +205,67 @@ async function runStep(opts: {
     return;
   }
 
+  if (step.op === "transact_get") {
+    assert.ok(step.transact_get, "transact_get request is required");
+    const res = await captureResult(() =>
+      driver.transactGet(modelName, step.transact_get!.items),
+    );
+    assertReadExpectation(step.expect, {
+      err: res.err,
+      result: res.value,
+      model,
+    });
+    return;
+  }
+
+  if (step.op === "batch_get") {
+    assert.ok(step.batch_get, "batch_get request is required");
+    const res = await captureResult(() =>
+      driver.batchGet(modelName, step.batch_get!.keys),
+    );
+    assertReadExpectation(step.expect, {
+      err: res.err,
+      result: res.value,
+      model,
+    });
+    return;
+  }
+
+  if (step.op === "batch_write") {
+    assert.ok(step.batch_write, "batch_write request is required");
+    const err = await captureError(() =>
+      driver.batchWrite(
+        modelName,
+        step.batch_write!.puts ?? [],
+        step.batch_write!.deletes ?? [],
+      ),
+    );
+    assertExpectation(step.expect, { err, model, vars });
+    return;
+  }
+
+  if (step.op === "transact_write") {
+    assert.ok(step.transact_write, "transact_write request is required");
+    const err = await captureError(() =>
+      driver.transactWrite(
+        modelName,
+        step.transact_write!.actions.map((action) => ({
+          kind: action.kind,
+          model: action.model,
+          item: action.item,
+          key: action.key,
+          set: action.set,
+          conditionExpression: action.condition_expression,
+          expressionAttributeNames: action.expression_attribute_names,
+          expressionAttributeValues: action.expression_attribute_values,
+          ifNotExists: action.if_not_exists,
+        })),
+      ),
+    );
+    assertExpectation(step.expect, { err, model, vars });
+    return;
+  }
+
   if (step.op === "transition_append_event") {
     assert.ok(step.actual, "transition_append_event actual is required");
     assert.ok(step.event, "transition_append_event event is required");

--- a/contract-tests/runners/ts/src/types.ts
+++ b/contract-tests/runners/ts/src/types.ts
@@ -1,7 +1,16 @@
 export type DmsVersion = "0.1";
 
 export type ScalarType =
-  "S" | "N" | "B" | "BOOL" | "NULL" | "M" | "L" | "SS" | "NS" | "BS";
+  | "S"
+  | "N"
+  | "B"
+  | "BOOL"
+  | "NULL"
+  | "M"
+  | "L"
+  | "SS"
+  | "NS"
+  | "BS";
 
 export interface DmsDocument {
   dms_version: DmsVersion;
@@ -70,6 +79,10 @@ export interface Step {
     | "query"
     | "scan"
     | "count"
+    | "transact_get"
+    | "batch_get"
+    | "batch_write"
+    | "transact_write"
     | "sleep"
     | "save"
     | "transition_append_event"
@@ -83,11 +96,49 @@ export interface Step {
   query?: ReadRequest;
   scan?: ReadRequest;
   count?: CountRequest;
+  transact_get?: TransactGetRequest;
+  batch_get?: BatchGetRequest;
+  batch_write?: BatchWriteRequest;
+  transact_write?: TransactWriteRequest;
   actual?: TransitionActual;
   event?: TransitionEvent;
   ms?: number;
   save?: Record<string, string>;
   expect?: Expectation;
+}
+
+export interface TransactGetRequest {
+  items: KeyedItem[];
+}
+
+export interface BatchGetRequest {
+  keys: Array<Record<string, unknown>>;
+}
+
+export interface BatchWriteRequest {
+  puts?: Array<Record<string, unknown>>;
+  deletes?: Array<Record<string, unknown>>;
+}
+
+export interface TransactWriteRequest {
+  actions: TransactWriteAction[];
+}
+
+export interface KeyedItem {
+  model?: string;
+  key: Record<string, unknown>;
+}
+
+export interface TransactWriteAction {
+  kind: string;
+  model?: string;
+  item?: Record<string, unknown>;
+  key?: Record<string, unknown>;
+  set?: Record<string, unknown>;
+  condition_expression?: string;
+  expression_attribute_names?: Record<string, string>;
+  expression_attribute_values?: Record<string, unknown>;
+  if_not_exists?: boolean;
 }
 
 export interface CountRequest {

--- a/contract-tests/runners/ts/test/contract.p2.test.ts
+++ b/contract-tests/runners/ts/test/contract.p2.test.ts
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+
+import { loadModelsDir, loadScenariosDir } from "../src/load.js";
+import {
+  TheorydbDriver,
+  encryptionProviderForScenario,
+} from "../src/driver.js";
+import { pingDynamo, runScenario } from "../src/runner.js";
+import { defineModel } from "../../../../ts/src/model.js";
+import type { Driver } from "../src/driver.js";
+import type { Scenario } from "../src/types.js";
+
+function contractRoot(): string {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, "..", "..", ".."); // runners/ts/test -> contract-tests
+}
+
+test("P2 contract scenarios (ts runner)", async (t) => {
+  const root = contractRoot();
+  const models = await loadModelsDir(path.join(root, "dms", "v0.1", "models"));
+  const scenarios = await loadScenariosDir(path.join(root, "scenarios", "p2"));
+  assert.ok(models.size > 0);
+  assert.ok(scenarios.length > 0);
+
+  const endpoint = process.env.DYNAMODB_ENDPOINT ?? "http://localhost:8000";
+  const skipIntegration =
+    process.env.SKIP_INTEGRATION === "true" ||
+    process.env.SKIP_INTEGRATION === "1";
+  const ddb = new DynamoDBClient({
+    region: process.env.AWS_REGION ?? "us-east-1",
+    endpoint,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "dummy",
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "dummy",
+    },
+  });
+
+  try {
+    await pingDynamo(ddb);
+  } catch (err) {
+    if (skipIntegration) {
+      t.skip(
+        `DynamoDB Local not reachable (SKIP_INTEGRATION set; endpoint: ${endpoint})`,
+      );
+      return;
+    }
+    throw err;
+  }
+
+  const compiled = Array.from(models.values()).map((m) => defineModel(m));
+  for (const s of scenarios) {
+    await t.test(s.name, async (st) => {
+      const driver = new TheorydbDriver(ddb, compiled, {
+        exactNumbers: true,
+        encryption: encryptionProviderForScenario(s.encryption),
+      });
+      const missing = missingCapabilities(s, driver);
+      if (missing.length > 0) {
+        st.skip(
+          `scenario requires unsupported capabilities: ${missing.join(", ")}`,
+        );
+        return;
+      }
+
+      await runScenario({ ddb, driver, scenario: s, models });
+    });
+  }
+});
+
+function missingCapabilities(scenario: Scenario, driver: Driver): string[] {
+  const supported = new Set(driver.capabilities());
+  return (scenario.requires_capabilities ?? []).filter(
+    (capability) => !supported.has(capability),
+  );
+}

--- a/contract-tests/scenarios/p1/59-transact-get.yml
+++ b/contract-tests/scenarios/p1/59-transact-get.yml
@@ -1,0 +1,134 @@
+name: "p1.transact_get"
+dms_version: "0.1"
+requires_capabilities: ["transact_get"]
+model: "User"
+table:
+  name: "users_contract"
+steps:
+  - op: create
+    item: { PK: "USER#TG", SK: "ITEM#001", emailHash: "tg@example", nickname: "one" }
+    expect: { ok: true }
+
+  - op: create
+    item: { PK: "USER#TG", SK: "ITEM#002", emailHash: "tg@example", nickname: "two" }
+    expect: { ok: true }
+
+  - op: transact_get
+    transact_get:
+      items:
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#MISSING" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#002" } }
+    expect:
+      ok: true
+      item_count: 2
+      items_contains:
+        - { PK: "USER#TG", SK: "ITEM#001", nickname: "one" }
+        - { PK: "USER#TG", SK: "ITEM#002", nickname: "two" }
+
+  - op: transact_get
+    transact_get:
+      items:
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+        - { key: { PK: "USER#TG", SK: "ITEM#001" } }
+    expect:
+      error: "ErrInvalidOperator"

--- a/contract-tests/scenarios/p2/01-batch-get.yml
+++ b/contract-tests/scenarios/p2/01-batch-get.yml
@@ -1,0 +1,430 @@
+name: "p2.batch_get_chunking"
+dms_version: "0.1"
+requires_capabilities: ["batch.get"]
+model: "User"
+table:
+  name: "users_contract"
+steps:
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#001", emailHash: "bg@example", nickname: "n001" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#002", emailHash: "bg@example", nickname: "n002" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#003", emailHash: "bg@example", nickname: "n003" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#004", emailHash: "bg@example", nickname: "n004" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#005", emailHash: "bg@example", nickname: "n005" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#006", emailHash: "bg@example", nickname: "n006" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#007", emailHash: "bg@example", nickname: "n007" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#008", emailHash: "bg@example", nickname: "n008" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#009", emailHash: "bg@example", nickname: "n009" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#010", emailHash: "bg@example", nickname: "n010" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#011", emailHash: "bg@example", nickname: "n011" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#012", emailHash: "bg@example", nickname: "n012" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#013", emailHash: "bg@example", nickname: "n013" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#014", emailHash: "bg@example", nickname: "n014" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#015", emailHash: "bg@example", nickname: "n015" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#016", emailHash: "bg@example", nickname: "n016" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#017", emailHash: "bg@example", nickname: "n017" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#018", emailHash: "bg@example", nickname: "n018" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#019", emailHash: "bg@example", nickname: "n019" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#020", emailHash: "bg@example", nickname: "n020" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#021", emailHash: "bg@example", nickname: "n021" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#022", emailHash: "bg@example", nickname: "n022" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#023", emailHash: "bg@example", nickname: "n023" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#024", emailHash: "bg@example", nickname: "n024" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#025", emailHash: "bg@example", nickname: "n025" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#026", emailHash: "bg@example", nickname: "n026" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#027", emailHash: "bg@example", nickname: "n027" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#028", emailHash: "bg@example", nickname: "n028" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#029", emailHash: "bg@example", nickname: "n029" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#030", emailHash: "bg@example", nickname: "n030" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#031", emailHash: "bg@example", nickname: "n031" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#032", emailHash: "bg@example", nickname: "n032" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#033", emailHash: "bg@example", nickname: "n033" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#034", emailHash: "bg@example", nickname: "n034" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#035", emailHash: "bg@example", nickname: "n035" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#036", emailHash: "bg@example", nickname: "n036" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#037", emailHash: "bg@example", nickname: "n037" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#038", emailHash: "bg@example", nickname: "n038" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#039", emailHash: "bg@example", nickname: "n039" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#040", emailHash: "bg@example", nickname: "n040" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#041", emailHash: "bg@example", nickname: "n041" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#042", emailHash: "bg@example", nickname: "n042" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#043", emailHash: "bg@example", nickname: "n043" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#044", emailHash: "bg@example", nickname: "n044" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#045", emailHash: "bg@example", nickname: "n045" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#046", emailHash: "bg@example", nickname: "n046" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#047", emailHash: "bg@example", nickname: "n047" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#048", emailHash: "bg@example", nickname: "n048" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#049", emailHash: "bg@example", nickname: "n049" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#050", emailHash: "bg@example", nickname: "n050" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#051", emailHash: "bg@example", nickname: "n051" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#052", emailHash: "bg@example", nickname: "n052" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#053", emailHash: "bg@example", nickname: "n053" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#054", emailHash: "bg@example", nickname: "n054" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#055", emailHash: "bg@example", nickname: "n055" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#056", emailHash: "bg@example", nickname: "n056" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#057", emailHash: "bg@example", nickname: "n057" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#058", emailHash: "bg@example", nickname: "n058" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#059", emailHash: "bg@example", nickname: "n059" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#060", emailHash: "bg@example", nickname: "n060" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#061", emailHash: "bg@example", nickname: "n061" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#062", emailHash: "bg@example", nickname: "n062" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#063", emailHash: "bg@example", nickname: "n063" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#064", emailHash: "bg@example", nickname: "n064" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#065", emailHash: "bg@example", nickname: "n065" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#066", emailHash: "bg@example", nickname: "n066" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#067", emailHash: "bg@example", nickname: "n067" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#068", emailHash: "bg@example", nickname: "n068" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#069", emailHash: "bg@example", nickname: "n069" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#070", emailHash: "bg@example", nickname: "n070" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#071", emailHash: "bg@example", nickname: "n071" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#072", emailHash: "bg@example", nickname: "n072" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#073", emailHash: "bg@example", nickname: "n073" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#074", emailHash: "bg@example", nickname: "n074" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#075", emailHash: "bg@example", nickname: "n075" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#076", emailHash: "bg@example", nickname: "n076" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#077", emailHash: "bg@example", nickname: "n077" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#078", emailHash: "bg@example", nickname: "n078" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#079", emailHash: "bg@example", nickname: "n079" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#080", emailHash: "bg@example", nickname: "n080" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#081", emailHash: "bg@example", nickname: "n081" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#082", emailHash: "bg@example", nickname: "n082" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#083", emailHash: "bg@example", nickname: "n083" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#084", emailHash: "bg@example", nickname: "n084" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#085", emailHash: "bg@example", nickname: "n085" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#086", emailHash: "bg@example", nickname: "n086" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#087", emailHash: "bg@example", nickname: "n087" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#088", emailHash: "bg@example", nickname: "n088" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#089", emailHash: "bg@example", nickname: "n089" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#090", emailHash: "bg@example", nickname: "n090" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#091", emailHash: "bg@example", nickname: "n091" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#092", emailHash: "bg@example", nickname: "n092" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#093", emailHash: "bg@example", nickname: "n093" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#094", emailHash: "bg@example", nickname: "n094" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#095", emailHash: "bg@example", nickname: "n095" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#096", emailHash: "bg@example", nickname: "n096" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#097", emailHash: "bg@example", nickname: "n097" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#098", emailHash: "bg@example", nickname: "n098" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#099", emailHash: "bg@example", nickname: "n099" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#100", emailHash: "bg@example", nickname: "n100" }
+    expect: { ok: true }
+  - op: create
+    item: { PK: "USER#BG", SK: "ITEM#101", emailHash: "bg@example", nickname: "n101" }
+    expect: { ok: true }
+
+  - op: batch_get
+    batch_get:
+      keys:
+        - { PK: "USER#BG", SK: "ITEM#001" }
+        - { PK: "USER#BG", SK: "ITEM#002" }
+        - { PK: "USER#BG", SK: "ITEM#003" }
+        - { PK: "USER#BG", SK: "ITEM#004" }
+        - { PK: "USER#BG", SK: "ITEM#005" }
+        - { PK: "USER#BG", SK: "ITEM#006" }
+        - { PK: "USER#BG", SK: "ITEM#007" }
+        - { PK: "USER#BG", SK: "ITEM#008" }
+        - { PK: "USER#BG", SK: "ITEM#009" }
+        - { PK: "USER#BG", SK: "ITEM#010" }
+        - { PK: "USER#BG", SK: "ITEM#011" }
+        - { PK: "USER#BG", SK: "ITEM#012" }
+        - { PK: "USER#BG", SK: "ITEM#013" }
+        - { PK: "USER#BG", SK: "ITEM#014" }
+        - { PK: "USER#BG", SK: "ITEM#015" }
+        - { PK: "USER#BG", SK: "ITEM#016" }
+        - { PK: "USER#BG", SK: "ITEM#017" }
+        - { PK: "USER#BG", SK: "ITEM#018" }
+        - { PK: "USER#BG", SK: "ITEM#019" }
+        - { PK: "USER#BG", SK: "ITEM#020" }
+        - { PK: "USER#BG", SK: "ITEM#021" }
+        - { PK: "USER#BG", SK: "ITEM#022" }
+        - { PK: "USER#BG", SK: "ITEM#023" }
+        - { PK: "USER#BG", SK: "ITEM#024" }
+        - { PK: "USER#BG", SK: "ITEM#025" }
+        - { PK: "USER#BG", SK: "ITEM#026" }
+        - { PK: "USER#BG", SK: "ITEM#027" }
+        - { PK: "USER#BG", SK: "ITEM#028" }
+        - { PK: "USER#BG", SK: "ITEM#029" }
+        - { PK: "USER#BG", SK: "ITEM#030" }
+        - { PK: "USER#BG", SK: "ITEM#031" }
+        - { PK: "USER#BG", SK: "ITEM#032" }
+        - { PK: "USER#BG", SK: "ITEM#033" }
+        - { PK: "USER#BG", SK: "ITEM#034" }
+        - { PK: "USER#BG", SK: "ITEM#035" }
+        - { PK: "USER#BG", SK: "ITEM#036" }
+        - { PK: "USER#BG", SK: "ITEM#037" }
+        - { PK: "USER#BG", SK: "ITEM#038" }
+        - { PK: "USER#BG", SK: "ITEM#039" }
+        - { PK: "USER#BG", SK: "ITEM#040" }
+        - { PK: "USER#BG", SK: "ITEM#041" }
+        - { PK: "USER#BG", SK: "ITEM#042" }
+        - { PK: "USER#BG", SK: "ITEM#043" }
+        - { PK: "USER#BG", SK: "ITEM#044" }
+        - { PK: "USER#BG", SK: "ITEM#045" }
+        - { PK: "USER#BG", SK: "ITEM#046" }
+        - { PK: "USER#BG", SK: "ITEM#047" }
+        - { PK: "USER#BG", SK: "ITEM#048" }
+        - { PK: "USER#BG", SK: "ITEM#049" }
+        - { PK: "USER#BG", SK: "ITEM#050" }
+        - { PK: "USER#BG", SK: "ITEM#051" }
+        - { PK: "USER#BG", SK: "ITEM#052" }
+        - { PK: "USER#BG", SK: "ITEM#053" }
+        - { PK: "USER#BG", SK: "ITEM#054" }
+        - { PK: "USER#BG", SK: "ITEM#055" }
+        - { PK: "USER#BG", SK: "ITEM#056" }
+        - { PK: "USER#BG", SK: "ITEM#057" }
+        - { PK: "USER#BG", SK: "ITEM#058" }
+        - { PK: "USER#BG", SK: "ITEM#059" }
+        - { PK: "USER#BG", SK: "ITEM#060" }
+        - { PK: "USER#BG", SK: "ITEM#061" }
+        - { PK: "USER#BG", SK: "ITEM#062" }
+        - { PK: "USER#BG", SK: "ITEM#063" }
+        - { PK: "USER#BG", SK: "ITEM#064" }
+        - { PK: "USER#BG", SK: "ITEM#065" }
+        - { PK: "USER#BG", SK: "ITEM#066" }
+        - { PK: "USER#BG", SK: "ITEM#067" }
+        - { PK: "USER#BG", SK: "ITEM#068" }
+        - { PK: "USER#BG", SK: "ITEM#069" }
+        - { PK: "USER#BG", SK: "ITEM#070" }
+        - { PK: "USER#BG", SK: "ITEM#071" }
+        - { PK: "USER#BG", SK: "ITEM#072" }
+        - { PK: "USER#BG", SK: "ITEM#073" }
+        - { PK: "USER#BG", SK: "ITEM#074" }
+        - { PK: "USER#BG", SK: "ITEM#075" }
+        - { PK: "USER#BG", SK: "ITEM#076" }
+        - { PK: "USER#BG", SK: "ITEM#077" }
+        - { PK: "USER#BG", SK: "ITEM#078" }
+        - { PK: "USER#BG", SK: "ITEM#079" }
+        - { PK: "USER#BG", SK: "ITEM#080" }
+        - { PK: "USER#BG", SK: "ITEM#081" }
+        - { PK: "USER#BG", SK: "ITEM#082" }
+        - { PK: "USER#BG", SK: "ITEM#083" }
+        - { PK: "USER#BG", SK: "ITEM#084" }
+        - { PK: "USER#BG", SK: "ITEM#085" }
+        - { PK: "USER#BG", SK: "ITEM#086" }
+        - { PK: "USER#BG", SK: "ITEM#087" }
+        - { PK: "USER#BG", SK: "ITEM#088" }
+        - { PK: "USER#BG", SK: "ITEM#089" }
+        - { PK: "USER#BG", SK: "ITEM#090" }
+        - { PK: "USER#BG", SK: "ITEM#091" }
+        - { PK: "USER#BG", SK: "ITEM#092" }
+        - { PK: "USER#BG", SK: "ITEM#093" }
+        - { PK: "USER#BG", SK: "ITEM#094" }
+        - { PK: "USER#BG", SK: "ITEM#095" }
+        - { PK: "USER#BG", SK: "ITEM#096" }
+        - { PK: "USER#BG", SK: "ITEM#097" }
+        - { PK: "USER#BG", SK: "ITEM#098" }
+        - { PK: "USER#BG", SK: "ITEM#099" }
+        - { PK: "USER#BG", SK: "ITEM#100" }
+        - { PK: "USER#BG", SK: "ITEM#101" }
+    expect:
+      ok: true
+      item_count: 101
+
+  - op: get
+    key: { PK: "USER#BG", SK: "ITEM#001" }
+    expect:
+      ok: true
+      item_contains: { PK: "USER#BG", SK: "ITEM#001", nickname: "n001" }
+
+  - op: get
+    key: { PK: "USER#BG", SK: "ITEM#101" }
+    expect:
+      ok: true
+      item_contains: { PK: "USER#BG", SK: "ITEM#101", nickname: "n101" }

--- a/contract-tests/scenarios/p2/02-batch-write.yml
+++ b/contract-tests/scenarios/p2/02-batch-write.yml
@@ -1,0 +1,134 @@
+name: "p2.batch_write_chunking"
+dms_version: "0.1"
+requires_capabilities: ["batch.write", "batch.get"]
+model: "User"
+table:
+  name: "users_contract"
+steps:
+  - op: batch_write
+    batch_write:
+      puts:
+        - { PK: "USER#BW", SK: "ITEM#001", emailHash: "bw@example", nickname: "w001" }
+        - { PK: "USER#BW", SK: "ITEM#002", emailHash: "bw@example", nickname: "w002" }
+        - { PK: "USER#BW", SK: "ITEM#003", emailHash: "bw@example", nickname: "w003" }
+        - { PK: "USER#BW", SK: "ITEM#004", emailHash: "bw@example", nickname: "w004" }
+        - { PK: "USER#BW", SK: "ITEM#005", emailHash: "bw@example", nickname: "w005" }
+        - { PK: "USER#BW", SK: "ITEM#006", emailHash: "bw@example", nickname: "w006" }
+        - { PK: "USER#BW", SK: "ITEM#007", emailHash: "bw@example", nickname: "w007" }
+        - { PK: "USER#BW", SK: "ITEM#008", emailHash: "bw@example", nickname: "w008" }
+        - { PK: "USER#BW", SK: "ITEM#009", emailHash: "bw@example", nickname: "w009" }
+        - { PK: "USER#BW", SK: "ITEM#010", emailHash: "bw@example", nickname: "w010" }
+        - { PK: "USER#BW", SK: "ITEM#011", emailHash: "bw@example", nickname: "w011" }
+        - { PK: "USER#BW", SK: "ITEM#012", emailHash: "bw@example", nickname: "w012" }
+        - { PK: "USER#BW", SK: "ITEM#013", emailHash: "bw@example", nickname: "w013" }
+        - { PK: "USER#BW", SK: "ITEM#014", emailHash: "bw@example", nickname: "w014" }
+        - { PK: "USER#BW", SK: "ITEM#015", emailHash: "bw@example", nickname: "w015" }
+        - { PK: "USER#BW", SK: "ITEM#016", emailHash: "bw@example", nickname: "w016" }
+        - { PK: "USER#BW", SK: "ITEM#017", emailHash: "bw@example", nickname: "w017" }
+        - { PK: "USER#BW", SK: "ITEM#018", emailHash: "bw@example", nickname: "w018" }
+        - { PK: "USER#BW", SK: "ITEM#019", emailHash: "bw@example", nickname: "w019" }
+        - { PK: "USER#BW", SK: "ITEM#020", emailHash: "bw@example", nickname: "w020" }
+        - { PK: "USER#BW", SK: "ITEM#021", emailHash: "bw@example", nickname: "w021" }
+        - { PK: "USER#BW", SK: "ITEM#022", emailHash: "bw@example", nickname: "w022" }
+        - { PK: "USER#BW", SK: "ITEM#023", emailHash: "bw@example", nickname: "w023" }
+        - { PK: "USER#BW", SK: "ITEM#024", emailHash: "bw@example", nickname: "w024" }
+        - { PK: "USER#BW", SK: "ITEM#025", emailHash: "bw@example", nickname: "w025" }
+        - { PK: "USER#BW", SK: "ITEM#026", emailHash: "bw@example", nickname: "w026" }
+    expect: { ok: true }
+
+  - op: batch_get
+    batch_get:
+      keys:
+        - { PK: "USER#BW", SK: "ITEM#001" }
+        - { PK: "USER#BW", SK: "ITEM#002" }
+        - { PK: "USER#BW", SK: "ITEM#003" }
+        - { PK: "USER#BW", SK: "ITEM#004" }
+        - { PK: "USER#BW", SK: "ITEM#005" }
+        - { PK: "USER#BW", SK: "ITEM#006" }
+        - { PK: "USER#BW", SK: "ITEM#007" }
+        - { PK: "USER#BW", SK: "ITEM#008" }
+        - { PK: "USER#BW", SK: "ITEM#009" }
+        - { PK: "USER#BW", SK: "ITEM#010" }
+        - { PK: "USER#BW", SK: "ITEM#011" }
+        - { PK: "USER#BW", SK: "ITEM#012" }
+        - { PK: "USER#BW", SK: "ITEM#013" }
+        - { PK: "USER#BW", SK: "ITEM#014" }
+        - { PK: "USER#BW", SK: "ITEM#015" }
+        - { PK: "USER#BW", SK: "ITEM#016" }
+        - { PK: "USER#BW", SK: "ITEM#017" }
+        - { PK: "USER#BW", SK: "ITEM#018" }
+        - { PK: "USER#BW", SK: "ITEM#019" }
+        - { PK: "USER#BW", SK: "ITEM#020" }
+        - { PK: "USER#BW", SK: "ITEM#021" }
+        - { PK: "USER#BW", SK: "ITEM#022" }
+        - { PK: "USER#BW", SK: "ITEM#023" }
+        - { PK: "USER#BW", SK: "ITEM#024" }
+        - { PK: "USER#BW", SK: "ITEM#025" }
+        - { PK: "USER#BW", SK: "ITEM#026" }
+    expect:
+      ok: true
+      item_count: 26
+
+  - op: get
+    key: { PK: "USER#BW", SK: "ITEM#001" }
+    expect:
+      ok: true
+      item_contains: { PK: "USER#BW", SK: "ITEM#001", nickname: "w001" }
+
+  - op: get
+    key: { PK: "USER#BW", SK: "ITEM#026" }
+    expect:
+      ok: true
+      item_contains: { PK: "USER#BW", SK: "ITEM#026", nickname: "w026" }
+
+  - op: batch_write
+    batch_write:
+      deletes:
+        - { PK: "USER#BW", SK: "ITEM#001" }
+        - { PK: "USER#BW", SK: "ITEM#002" }
+        - { PK: "USER#BW", SK: "ITEM#003" }
+    expect: { ok: true }
+
+  - op: batch_get
+    batch_get:
+      keys:
+        - { PK: "USER#BW", SK: "ITEM#001" }
+        - { PK: "USER#BW", SK: "ITEM#002" }
+        - { PK: "USER#BW", SK: "ITEM#003" }
+        - { PK: "USER#BW", SK: "ITEM#004" }
+        - { PK: "USER#BW", SK: "ITEM#005" }
+        - { PK: "USER#BW", SK: "ITEM#006" }
+        - { PK: "USER#BW", SK: "ITEM#007" }
+        - { PK: "USER#BW", SK: "ITEM#008" }
+        - { PK: "USER#BW", SK: "ITEM#009" }
+        - { PK: "USER#BW", SK: "ITEM#010" }
+        - { PK: "USER#BW", SK: "ITEM#011" }
+        - { PK: "USER#BW", SK: "ITEM#012" }
+        - { PK: "USER#BW", SK: "ITEM#013" }
+        - { PK: "USER#BW", SK: "ITEM#014" }
+        - { PK: "USER#BW", SK: "ITEM#015" }
+        - { PK: "USER#BW", SK: "ITEM#016" }
+        - { PK: "USER#BW", SK: "ITEM#017" }
+        - { PK: "USER#BW", SK: "ITEM#018" }
+        - { PK: "USER#BW", SK: "ITEM#019" }
+        - { PK: "USER#BW", SK: "ITEM#020" }
+        - { PK: "USER#BW", SK: "ITEM#021" }
+        - { PK: "USER#BW", SK: "ITEM#022" }
+        - { PK: "USER#BW", SK: "ITEM#023" }
+        - { PK: "USER#BW", SK: "ITEM#024" }
+        - { PK: "USER#BW", SK: "ITEM#025" }
+        - { PK: "USER#BW", SK: "ITEM#026" }
+    expect:
+      ok: true
+      item_count: 23
+
+  - op: get
+    key: { PK: "USER#BW", SK: "ITEM#001" }
+    expect:
+      error: "ErrItemNotFound"
+
+  - op: get
+    key: { PK: "USER#BW", SK: "ITEM#026" }
+    expect:
+      ok: true
+      item_contains: { PK: "USER#BW", SK: "ITEM#026", nickname: "w026" }

--- a/contract-tests/scenarios/p2/03-transact-write.yml
+++ b/contract-tests/scenarios/p2/03-transact-write.yml
@@ -1,0 +1,163 @@
+name: "p2.transact_write_atomicity"
+dms_version: "0.1"
+requires_capabilities: ["transact.write"]
+model: "User"
+table:
+  name: "users_contract"
+steps:
+  - op: create
+    item: { PK: "USER#TXW", SK: "ITEM#001", emailHash: "txw@example", nickname: "seed" }
+    expect: { ok: true }
+
+  - op: transact_write
+    transact_write:
+      actions:
+        - kind: "update"
+          key: { PK: "USER#TXW", SK: "ITEM#001" }
+          set: { nickname: "updated" }
+          condition_expression: "attribute_exists(PK)"
+        - kind: "put"
+          item: { PK: "USER#TXW", SK: "ITEM#002", emailHash: "txw@example", nickname: "created" }
+    expect: { ok: true }
+
+  - op: get
+    key: { PK: "USER#TXW", SK: "ITEM#001" }
+    expect:
+      ok: true
+      item_contains: { PK: "USER#TXW", SK: "ITEM#001", nickname: "updated" }
+
+  - op: get
+    key: { PK: "USER#TXW", SK: "ITEM#002" }
+    expect:
+      ok: true
+      item_contains: { PK: "USER#TXW", SK: "ITEM#002", nickname: "created" }
+
+  - op: transact_write
+    transact_write:
+      actions:
+        - kind: "update"
+          key: { PK: "USER#TXW", SK: "ITEM#001" }
+          set: { nickname: "should-not-write" }
+          condition_expression: "attribute_not_exists(PK)"
+        - kind: "put"
+          item: { PK: "USER#TXW", SK: "ITEM#003", emailHash: "txw@example", nickname: "rolled-back" }
+    expect:
+      error: "ErrConditionFailed"
+
+  - op: get
+    key: { PK: "USER#TXW", SK: "ITEM#001" }
+    expect:
+      ok: true
+      item_contains: { PK: "USER#TXW", SK: "ITEM#001", nickname: "updated" }
+
+  - op: get
+    key: { PK: "USER#TXW", SK: "ITEM#003" }
+    expect:
+      error: "ErrItemNotFound"
+
+  - op: transact_write
+    transact_write:
+      actions:
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+        - { kind: "condition", key: { PK: "USER#TXW", SK: "ITEM#001" }, condition_expression: "attribute_exists(PK)" }
+    expect:
+      error: "ErrInvalidOperator"

--- a/internal/theorydb/theorydb.go
+++ b/internal/theorydb/theorydb.go
@@ -282,6 +282,18 @@ func (db *DB) TransactWrite(ctx context.Context, fn func(core.TransactionBuilder
 	return builder.Execute()
 }
 
+// TransactGet executes a DynamoDB TransactGetItems request through the additive
+// core.TransactGetter extension interface.
+func (db *DB) TransactGet(ctx context.Context, requests []core.TransactGetRequest) ([]core.TransactGetResult, error) {
+	if ctx == nil {
+		ctx = db.ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return transaction.TransactGet(ctx, db.session, db.registry, db.converter, requests)
+}
+
 // AutoMigrate creates or updates tables based on the given models
 func (db *DB) AutoMigrate(models ...any) error {
 	manager := schema.NewManager(db.session, db.registry)

--- a/internal/theorydb/transact_get_test.go
+++ b/internal/theorydb/transact_get_test.go
@@ -1,0 +1,58 @@
+package theorydb
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	"github.com/theory-cloud/tabletheory/pkg/session"
+)
+
+type transactGetUser struct {
+	ID    string `theorydb:"pk"`
+	Email string
+}
+
+func TestDBTransactGetExtension(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DynamoDB_20120810.TransactGetItems", r.Header.Get("X-Amz-Target"))
+		w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+		_, err := w.Write([]byte(`{"Responses":[{"Item":{"id":{"S":"user-1"},"email":{"S":"one@example.test"}}}]}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	db, err := New(session.Config{
+		Region:   "us-east-1",
+		Endpoint: server.URL,
+		AWSConfigOptions: []func(*config.LoadOptions) error{
+			config.WithRegion("us-east-1"),
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("dummy", "dummy", "")),
+		},
+	})
+	require.NoError(t, err)
+
+	rawDB, ok := db.(*DB)
+	require.True(t, ok)
+	rawDB.ctx = nil
+	getter, ok := db.(core.TransactGetter)
+	require.True(t, ok)
+
+	dest := &transactGetUser{}
+	var nilCtx context.Context
+	results, err := getter.TransactGet(nilCtx, []core.TransactGetRequest{
+		{Model: &transactGetUser{}, Key: "user-1", Dest: dest},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Found)
+	assert.Equal(t, "user-1", dest.ID)
+	assert.Equal(t, "one@example.test", dest.Email)
+}

--- a/pkg/core/interfaces.go
+++ b/pkg/core/interfaces.go
@@ -85,6 +85,37 @@ type ExtendedDB interface {
 	TransactWrite(ctx context.Context, fn func(TransactionBuilder) error) error
 }
 
+// TransactGetter is an additive extension interface for DynamoDB TransactGetItems
+// support. It is intentionally separate from DB/ExtendedDB so existing mocks and
+// implementations of those exported interfaces remain source-compatible.
+type TransactGetter interface {
+	// TransactGet retrieves up to 100 items atomically using DynamoDB TransactGetItems.
+	// Missing items are represented by a TransactGetResult with Found=false; they
+	// are not collapsed into ErrItemNotFound because DynamoDB TransactGetItems
+	// returns sparse responses for absent keys.
+	TransactGet(ctx context.Context, requests []TransactGetRequest) ([]TransactGetResult, error)
+}
+
+// TransactGetRequest describes one item in a TransactGetItems request.
+type TransactGetRequest struct {
+	// Model identifies the TableTheory model shape used to derive the table and
+	// primary-key schema. A zero value is invalid.
+	Model any
+	// Key is either a core.KeyPair, a model-shaped key struct, or a primitive
+	// partition-key value for single-key models.
+	Key any
+	// Dest is an optional pointer populated when the item exists.
+	Dest any
+	// Projection limits the returned attributes for this item when non-empty.
+	Projection []string
+}
+
+// TransactGetResult reports whether the item for a TransactGetRequest existed.
+// When Found is true and the request supplied Dest, Dest has been populated.
+type TransactGetResult struct {
+	Found bool
+}
+
 // TransactionBuilder defines the fluent DSL for composing DynamoDB transactions
 type TransactionBuilder interface {
 	// Put adds a put (upsert) operation

--- a/pkg/transaction/builder.go
+++ b/pkg/transaction/builder.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	maxTransactOperations = 25
+	maxTransactOperations = 100
 )
 
 var retrySchedule = []time.Duration{
@@ -193,7 +193,7 @@ func (b *Builder) addOperation(opType operationType, model any, fields []string,
 		return
 	}
 	if len(b.operations) >= maxTransactOperations {
-		b.recordError(fmt.Errorf("dynamodb transactions support up to %d operations", maxTransactOperations))
+		b.recordError(fmt.Errorf("%w: dynamodb transactions support up to %d operations", customerrors.ErrInvalidOperator, maxTransactOperations))
 		return
 	}
 

--- a/pkg/transaction/transact_get.go
+++ b/pkg/transaction/transact_get.go
@@ -1,0 +1,327 @@
+package transaction
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/theory-cloud/tabletheory/internal/encryption"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	customerrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/model"
+	"github.com/theory-cloud/tabletheory/pkg/query"
+	"github.com/theory-cloud/tabletheory/pkg/session"
+	pkgTypes "github.com/theory-cloud/tabletheory/pkg/types"
+)
+
+const maxTransactGetItems = 100
+
+type dynamoTransactGetAPI interface {
+	TransactGetItems(ctx context.Context, params *dynamodb.TransactGetItemsInput, optFns ...func(*dynamodb.Options)) (*dynamodb.TransactGetItemsOutput, error)
+}
+
+// TransactGet executes a DynamoDB TransactGetItems request against TableTheory
+// models. The result slice preserves request order and reports missing items as
+// Found=false instead of returning ErrItemNotFound.
+func TransactGet(
+	ctx context.Context,
+	sess *session.Session,
+	registry *model.Registry,
+	converter *pkgTypes.Converter,
+	requests []core.TransactGetRequest,
+) ([]core.TransactGetResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if len(requests) == 0 {
+		return nil, errors.New("transact get requires at least one item")
+	}
+	if len(requests) > maxTransactGetItems {
+		return nil, fmt.Errorf("%w: dynamodb TransactGetItems supports up to %d items", customerrors.ErrInvalidOperator, maxTransactGetItems)
+	}
+	if sess == nil {
+		return nil, errors.New("dynamodb session is not configured")
+	}
+	if registry == nil {
+		return nil, errors.New("model registry is not configured")
+	}
+	if converter == nil {
+		converter = pkgTypes.NewConverter()
+	}
+
+	items, metas, err := buildTransactGetItems(registry, converter, requests)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := sess.Client()
+	if err != nil {
+		return nil, err
+	}
+	return transactGetWithClient(ctx, client, sess, requests, metas, items)
+}
+
+func transactGetWithClient(
+	ctx context.Context,
+	client dynamoTransactGetAPI,
+	sess *session.Session,
+	requests []core.TransactGetRequest,
+	metas []*model.Metadata,
+	items []types.TransactGetItem,
+) ([]core.TransactGetResult, error) {
+	output, err := client.TransactGetItems(ctx, &dynamodb.TransactGetItemsInput{TransactItems: items})
+	if err != nil {
+		return nil, err
+	}
+
+	return collectTransactGetResults(ctx, sess, requests, metas, output.Responses)
+}
+
+func buildTransactGetItems(
+	registry *model.Registry,
+	converter *pkgTypes.Converter,
+	requests []core.TransactGetRequest,
+) ([]types.TransactGetItem, []*model.Metadata, error) {
+	items := make([]types.TransactGetItem, 0, len(requests))
+	metas := make([]*model.Metadata, 0, len(requests))
+	for i, req := range requests {
+		metadata, err := transactGetMetadata(registry, req.Model, i)
+		if err != nil {
+			return nil, nil, err
+		}
+		key, err := buildTransactGetKey(metadata, converter, req.Key)
+		if err != nil {
+			return nil, nil, fmt.Errorf("transact get item %d key: %w", i, err)
+		}
+
+		get := &types.Get{
+			TableName: aws.String(metadata.TableName),
+			Key:       key,
+		}
+		if len(req.Projection) > 0 {
+			expr, names, err := buildTransactGetProjection(metadata, req.Projection)
+			if err != nil {
+				return nil, nil, fmt.Errorf("transact get item %d projection: %w", i, err)
+			}
+			get.ProjectionExpression = aws.String(expr)
+			get.ExpressionAttributeNames = names
+		}
+		items = append(items, types.TransactGetItem{Get: get})
+		metas = append(metas, metadata)
+	}
+	return items, metas, nil
+}
+
+func transactGetMetadata(registry *model.Registry, modelValue any, index int) (*model.Metadata, error) {
+	if modelValue == nil {
+		return nil, fmt.Errorf("transact get item %d model cannot be nil", index)
+	}
+	if err := registry.Register(modelValue); err != nil {
+		return nil, err
+	}
+	return registry.GetMetadata(modelValue)
+}
+
+func collectTransactGetResults(
+	ctx context.Context,
+	sess *session.Session,
+	requests []core.TransactGetRequest,
+	metas []*model.Metadata,
+	responses []types.ItemResponse,
+) ([]core.TransactGetResult, error) {
+	results := make([]core.TransactGetResult, len(requests))
+	for i := range requests {
+		if i >= len(responses) || len(responses[i].Item) == 0 {
+			results[i] = core.TransactGetResult{Found: false}
+			continue
+		}
+
+		item := cloneAttributeMap(responses[i].Item)
+		if err := decryptTransactGetItem(ctx, sess, metas[i], item); err != nil {
+			return nil, err
+		}
+		if requests[i].Dest != nil {
+			if err := query.UnmarshalItem(item, requests[i].Dest); err != nil {
+				return nil, err
+			}
+		}
+		results[i] = core.TransactGetResult{Found: true}
+	}
+
+	return results, nil
+}
+
+func buildTransactGetKey(metadata *model.Metadata, converter *pkgTypes.Converter, key any) (map[string]types.AttributeValue, error) {
+	if metadata == nil || metadata.PrimaryKey == nil || metadata.PrimaryKey.PartitionKey == nil {
+		return nil, fmt.Errorf("model primary key is required")
+	}
+	if key == nil {
+		return nil, fmt.Errorf("key cannot be nil")
+	}
+
+	if pair, ok := key.(core.KeyPair); ok {
+		return keyFromValues(metadata, converter, pair.PartitionKey, pair.SortKey, true)
+	}
+	if m, ok := key.(map[string]any); ok {
+		pk, pkOK := valueFromKeyMap(m, metadata.PrimaryKey.PartitionKey)
+		var sk any
+		skOK := true
+		if metadata.PrimaryKey.SortKey != nil {
+			sk, skOK = valueFromKeyMap(m, metadata.PrimaryKey.SortKey)
+		}
+		if !pkOK || !skOK {
+			return nil, fmt.Errorf("missing primary key attributes")
+		}
+		return keyFromValues(metadata, converter, pk, sk, true)
+	}
+
+	value := reflect.ValueOf(key)
+	if value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return nil, fmt.Errorf("key pointer cannot be nil")
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		if metadata.PrimaryKey.SortKey != nil {
+			return nil, fmt.Errorf("composite key requires both partition and sort key")
+		}
+		return keyFromValues(metadata, converter, key, nil, false)
+	}
+
+	pk := value.Field(metadata.PrimaryKey.PartitionKey.Index).Interface()
+	var sk any
+	hasSK := false
+	if metadata.PrimaryKey.SortKey != nil {
+		sk = value.Field(metadata.PrimaryKey.SortKey.Index).Interface()
+		hasSK = true
+	}
+	return keyFromValues(metadata, converter, pk, sk, hasSK)
+}
+
+func keyFromValues(metadata *model.Metadata, converter *pkgTypes.Converter, pk any, sk any, hasSK bool) (map[string]types.AttributeValue, error) {
+	pkAV, err := converter.ToAttributeValue(pk)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert partition key: %w", err)
+	}
+	key := map[string]types.AttributeValue{
+		metadata.PrimaryKey.PartitionKey.DBName: pkAV,
+	}
+	if metadata.PrimaryKey.SortKey != nil {
+		if !hasSK || sk == nil {
+			return nil, fmt.Errorf("sort key %s is required", metadata.PrimaryKey.SortKey.Name)
+		}
+		skAV, err := converter.ToAttributeValue(sk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert sort key: %w", err)
+		}
+		key[metadata.PrimaryKey.SortKey.DBName] = skAV
+	}
+	return key, nil
+}
+
+func valueFromKeyMap(values map[string]any, field *model.FieldMetadata) (any, bool) {
+	if field == nil {
+		return nil, false
+	}
+	for _, name := range []string{field.Name, field.DBName} {
+		if v, ok := values[name]; ok {
+			return v, true
+		}
+	}
+	for k, v := range values {
+		if strings.EqualFold(k, field.Name) || strings.EqualFold(k, field.DBName) {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func buildTransactGetProjection(metadata *model.Metadata, fields []string) (string, map[string]string, error) {
+	names := make(map[string]string, len(fields))
+	parts := make([]string, 0, len(fields))
+	for i, field := range fields {
+		dbName, err := resolveProjectionField(metadata, field)
+		if err != nil {
+			return "", nil, err
+		}
+		placeholder := fmt.Sprintf("#p%d", i)
+		names[placeholder] = dbName
+		parts = append(parts, placeholder)
+	}
+	return strings.Join(parts, ", "), names, nil
+}
+
+func resolveProjectionField(metadata *model.Metadata, field string) (string, error) {
+	if metadata == nil {
+		return "", fmt.Errorf("model metadata is required")
+	}
+	if meta := metadata.Fields[field]; meta != nil {
+		return meta.DBName, nil
+	}
+	if meta := metadata.FieldsByDBName[field]; meta != nil {
+		return meta.DBName, nil
+	}
+	for _, meta := range metadata.Fields {
+		if meta == nil {
+			continue
+		}
+		if strings.EqualFold(field, meta.Name) || strings.EqualFold(field, meta.DBName) {
+			return meta.DBName, nil
+		}
+	}
+	return "", fmt.Errorf("unknown projection field %s", field)
+}
+
+func decryptTransactGetItem(ctx context.Context, sess *session.Session, metadata *model.Metadata, item map[string]types.AttributeValue) error {
+	if len(item) == 0 || !encryption.MetadataHasEncryptedFields(metadata) {
+		return nil
+	}
+	if err := encryption.FailClosedIfEncryptedWithoutKMSKeyARN(sess, metadata); err != nil {
+		return err
+	}
+	cfg := sess.Config()
+	keyARN := ""
+	var rng io.Reader
+	if cfg != nil {
+		keyARN = cfg.KMSKeyARN
+		rng = cfg.EncryptionRand
+	}
+	var svc *encryption.Service
+	if cfg != nil && cfg.KMSClient != nil {
+		svc = encryption.NewServiceWithRand(keyARN, cfg.KMSClient, rng)
+	} else {
+		svc = encryption.NewServiceFromAWSConfigWithRand(keyARN, sess.AWSConfig(), rng)
+	}
+	for attrName, attrValue := range item {
+		fieldMeta, ok := metadata.FieldsByDBName[attrName]
+		if !ok || fieldMeta == nil || !fieldMeta.IsEncrypted {
+			continue
+		}
+		decrypted, err := svc.DecryptAttributeValue(ctx, fieldMeta.DBName, attrValue)
+		if err != nil {
+			return &customerrors.EncryptedFieldError{
+				Operation: "decrypt",
+				Field:     fieldMeta.Name,
+				Err:       err,
+			}
+		}
+		item[attrName] = decrypted
+	}
+	return nil
+}
+
+func cloneAttributeMap(in map[string]types.AttributeValue) map[string]types.AttributeValue {
+	out := make(map[string]types.AttributeValue, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/assert"
@@ -46,6 +50,24 @@ type Order struct {
 	CustomerID string
 	Status     string
 	Total      float64
+}
+
+type SecretRecord struct {
+	ID     string `theorydb:"pk"`
+	Secret string `theorydb:"encrypted"`
+}
+
+type mockTransactGetClient struct {
+	input *dynamodb.TransactGetItemsInput
+	out   *dynamodb.TransactGetItemsOutput
+	err   error
+}
+
+func (m *mockTransactGetClient) TransactGetItems(ctx context.Context, params *dynamodb.TransactGetItemsInput, optFns ...func(*dynamodb.Options)) (*dynamodb.TransactGetItemsOutput, error) {
+	_ = ctx
+	_ = optFns
+	m.input = params
+	return m.out, m.err
 }
 
 func setupTest(t *testing.T) (*Transaction, *model.Registry) {
@@ -511,7 +533,287 @@ func TestTransactionBuilderOperationLimit(t *testing.T) {
 
 	err := builder.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "25")
+	assert.ErrorIs(t, err, customerrors.ErrInvalidOperator)
+	assert.Contains(t, err.Error(), "100")
+}
+
+func TestTransactGetBuildsItemsAndCollectsResponses(t *testing.T) {
+	registry := model.NewRegistry()
+	converter := pkgTypes.NewConverter()
+
+	requests := []core.TransactGetRequest{
+		{
+			Model:      &User{},
+			Key:        map[string]any{"ID": "user-1"},
+			Projection: []string{"ID", "Email"},
+			Dest:       &User{},
+		},
+		{
+			Model: &User{},
+			Key:   core.NewKeyPair("user-2"),
+			Dest:  &User{},
+		},
+	}
+
+	items, metas, err := buildTransactGetItems(registry, converter, requests)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	require.Len(t, metas, 2)
+	require.NotNil(t, items[0].Get)
+	assert.Equal(t, "Users", aws.ToString(items[0].Get.TableName))
+	assert.Equal(t, "#p0, #p1", aws.ToString(items[0].Get.ProjectionExpression))
+	assert.Equal(t, map[string]string{"#p0": "id", "#p1": "email"}, items[0].Get.ExpressionAttributeNames)
+	assert.Equal(t, &types.AttributeValueMemberS{Value: "user-1"}, items[0].Get.Key["id"])
+
+	results, err := collectTransactGetResults(
+		context.Background(),
+		nil,
+		requests,
+		metas,
+		[]types.ItemResponse{
+			{Item: map[string]types.AttributeValue{
+				"id":      &types.AttributeValueMemberS{Value: "user-1"},
+				"email":   &types.AttributeValueMemberS{Value: "one@example.test"},
+				"version": &types.AttributeValueMemberN{Value: "7"},
+			}},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.True(t, results[0].Found)
+	assert.False(t, results[1].Found)
+	dest, ok := requests[0].Dest.(*User)
+	require.True(t, ok)
+	assert.Equal(t, "user-1", dest.ID)
+	assert.Equal(t, "one@example.test", dest.Email)
+	assert.Equal(t, 7, dest.Version)
+}
+
+func TestTransactGetWithClientExecutesRequest(t *testing.T) {
+	registry := model.NewRegistry()
+	converter := pkgTypes.NewConverter()
+	requests := []core.TransactGetRequest{
+		{Model: &User{}, Key: "user-1", Dest: &User{}},
+	}
+	items, metas, err := buildTransactGetItems(registry, converter, requests)
+	require.NoError(t, err)
+
+	client := &mockTransactGetClient{
+		out: &dynamodb.TransactGetItemsOutput{
+			Responses: []types.ItemResponse{
+				{Item: map[string]types.AttributeValue{
+					"id":    &types.AttributeValueMemberS{Value: "user-1"},
+					"email": &types.AttributeValueMemberS{Value: "one@example.test"},
+				}},
+			},
+		},
+	}
+
+	results, err := transactGetWithClient(context.Background(), client, nil, requests, metas, items)
+	require.NoError(t, err)
+	require.NotNil(t, client.input)
+	assert.Len(t, client.input.TransactItems, 1)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Found)
+}
+
+func TestTransactGetExecutesAgainstDynamoClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DynamoDB_20120810.TransactGetItems", r.Header.Get("X-Amz-Target"))
+		w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+		_, err := w.Write([]byte(`{"Responses":[{"Item":{"id":{"S":"user-1"},"email":{"S":"one@example.test"}}}]}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	sess, err := session.NewSession(&session.Config{
+		Region:   "us-east-1",
+		Endpoint: server.URL,
+		AWSConfigOptions: []func(*config.LoadOptions) error{
+			config.WithRegion("us-east-1"),
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("dummy", "dummy", "")),
+		},
+	})
+	require.NoError(t, err)
+
+	dest := &User{}
+	results, err := TransactGet(
+		context.Background(),
+		sess,
+		model.NewRegistry(),
+		pkgTypes.NewConverter(),
+		[]core.TransactGetRequest{{Model: &User{}, Key: "user-1", Dest: dest}},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Found)
+	assert.Equal(t, "user-1", dest.ID)
+	assert.Equal(t, "one@example.test", dest.Email)
+}
+
+func TestTransactGetWithClientPropagatesErrors(t *testing.T) {
+	want := errors.New("transact get failed")
+	_, err := transactGetWithClient(
+		context.Background(),
+		&mockTransactGetClient{err: want},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	assert.ErrorIs(t, err, want)
+}
+
+func TestTransactGetBuildsValidationErrors(t *testing.T) {
+	registry := model.NewRegistry()
+	converter := pkgTypes.NewConverter()
+
+	_, _, err := buildTransactGetItems(registry, converter, []core.TransactGetRequest{{Key: "missing-model"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model cannot be nil")
+
+	_, _, err = buildTransactGetItems(registry, converter, []core.TransactGetRequest{{Model: &Account{}, Key: "pk-only"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "composite key requires")
+}
+
+func TestTransactGetValidatesInputs(t *testing.T) {
+	registry := model.NewRegistry()
+	converter := pkgTypes.NewConverter()
+
+	_, err := TransactGet(context.Background(), nil, registry, converter, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one")
+
+	requests := make([]core.TransactGetRequest, maxTransactGetItems+1)
+	for i := range requests {
+		requests[i] = core.TransactGetRequest{Model: &User{}, Key: "x"}
+	}
+	_, err = TransactGet(context.Background(), nil, registry, converter, requests)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, customerrors.ErrInvalidOperator)
+
+	_, err = TransactGet(context.Background(), nil, registry, converter, []core.TransactGetRequest{
+		{Model: &User{}, Key: "x"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session is not configured")
+
+	_, err = TransactGet(context.Background(), &session.Session{}, nil, converter, []core.TransactGetRequest{
+		{Model: &User{}, Key: "x"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registry is not configured")
+
+	_, err = TransactGet(context.Background(), &session.Session{}, registry, nil, []core.TransactGetRequest{
+		{Model: &User{}, Key: "x"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DynamoDB client is nil")
+
+	_, err = TransactGet(context.Background(), &session.Session{}, registry, nil, []core.TransactGetRequest{
+		{Model: &Account{}, Key: "pk-only"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "composite key requires")
+}
+
+func TestTransactGetKeyAndProjectionVariants(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&User{}))
+	require.NoError(t, registry.Register(&Account{}))
+	converter := pkgTypes.NewConverter()
+
+	userMeta, err := registry.GetMetadata(&User{})
+	require.NoError(t, err)
+	userKey, err := buildTransactGetKey(userMeta, converter, "user-primitive")
+	require.NoError(t, err)
+	assert.Equal(t, &types.AttributeValueMemberS{Value: "user-primitive"}, userKey["id"])
+
+	accountMeta, err := registry.GetMetadata(&Account{})
+	require.NoError(t, err)
+	accountKey, err := buildTransactGetKey(
+		accountMeta,
+		converter,
+		Account{AccountID: "acct-1", UserID: "user-1"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &types.AttributeValueMemberS{Value: "acct-1"}, accountKey["accountID"])
+	assert.Equal(t, &types.AttributeValueMemberS{Value: "user-1"}, accountKey["userID"])
+
+	accountKey, err = buildTransactGetKey(
+		accountMeta,
+		converter,
+		map[string]any{"accountID": "acct-2", "userID": "user-2"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &types.AttributeValueMemberS{Value: "acct-2"}, accountKey["accountID"])
+	assert.Equal(t, &types.AttributeValueMemberS{Value: "user-2"}, accountKey["userID"])
+
+	_, err = resolveProjectionField(userMeta, "email")
+	require.NoError(t, err)
+	_, err = resolveProjectionField(userMeta, "missing")
+	require.Error(t, err)
+
+	value, ok := valueFromKeyMap(map[string]any{"ACCOUNTID": "acct-upper"}, accountMeta.PrimaryKey.PartitionKey)
+	require.True(t, ok)
+	assert.Equal(t, "acct-upper", value)
+	_, ok = valueFromKeyMap(map[string]any{"other": "value"}, accountMeta.PrimaryKey.PartitionKey)
+	assert.False(t, ok)
+
+	_, err = keyFromValues(accountMeta, converter, "acct", nil, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sort key")
+
+	_, err = buildTransactGetKey(userMeta, converter, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key cannot be nil")
+
+	var nilUser *User
+	_, err = buildTransactGetKey(userMeta, converter, nilUser)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pointer cannot be nil")
+}
+
+func TestTransactGetEncryptedMetadataFailsClosed(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&SecretRecord{}))
+	metadata, err := registry.GetMetadata(&SecretRecord{})
+	require.NoError(t, err)
+
+	err = decryptTransactGetItem(context.Background(), nil, metadata, map[string]types.AttributeValue{
+		"secret": &types.AttributeValueMemberS{Value: "ciphertext"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, customerrors.ErrEncryptionNotConfigured)
+}
+
+func TestTransactGetDecryptsFailClosedEnvelopeErrors(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&SecretRecord{}))
+	metadata, err := registry.GetMetadata(&SecretRecord{})
+	require.NoError(t, err)
+
+	sess, err := session.NewSession(&session.Config{
+		Region:    "us-east-1",
+		KMSKeyARN: "arn:aws:kms:us-east-1:111111111111:key/test",
+		AWSConfigOptions: []func(*config.LoadOptions) error{
+			config.WithRegion("us-east-1"),
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("dummy", "dummy", "")),
+		},
+	})
+	require.NoError(t, err)
+
+	err = decryptTransactGetItem(context.Background(), sess, metadata, map[string]types.AttributeValue{
+		"id": &types.AttributeValueMemberS{Value: "record-1"},
+	})
+	require.NoError(t, err)
+
+	err = decryptTransactGetItem(context.Background(), sess, metadata, map[string]types.AttributeValue{
+		"secret": &types.AttributeValueMemberS{Value: "not-an-envelope"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, customerrors.ErrInvalidEncryptedEnvelope)
 }
 
 func TestTransactionBuilderMissingKey(t *testing.T) {

--- a/py/docs/api-reference.md
+++ b/py/docs/api-reference.md
@@ -77,7 +77,12 @@ All query parameters are listed above:
 ### `query_all(...) -> list[T]`
 
 Accepts the same query parameters and follows cursors until exhaustion. It materializes every matching item into a Python
-list; prefer page-by-page `query` calls for large partitions.
+list; prefer `query_iter(...)` or page-by-page `query` calls for large partitions.
+
+### `query_iter(...) -> Iterator[Page[T]]`
+
+Accepts the same query parameters and yields one `Page[T]` at a time. This is the preferred large-result path because the
+next DynamoDB page is fetched only when the caller advances the generator; breaking out of the loop stops pagination.
 
 ### `query_with_retry(..., max_retries=5, initial_delay_seconds=0.1, max_delay_seconds=5.0, backoff_factor=2.0, retry_on_empty=True, retry_on_error=True, verify=None, sleep=time.sleep) -> Page[T]`
 
@@ -90,7 +95,12 @@ Runs a DynamoDB Scan and returns a page with `items` and `next_cursor`.
 ### `scan_all(...) -> list[T]`
 
 Accepts the same scan parameters and follows cursors until exhaustion. It materializes every scanned item into a Python
-list; prefer page-by-page `scan` calls for large tables.
+list; prefer `scan_iter(...)` or page-by-page `scan` calls for large tables.
+
+### `scan_iter(...) -> Iterator[Page[T]]`
+
+Accepts the same scan parameters and yields one `Page[T]` at a time. Use it for large scans so consumers can stop early
+without fetching the remaining pages.
 
 ### `scan_all_segments(*, total_segments, index_name=None, limit=None, consistent_read=False, projection=None, filter=None, max_workers=None) -> list[T]`
 
@@ -118,7 +128,10 @@ Actual signatures and defaults:
 
 - `batch_get(keys, *, consistent_read=False, projection=None, max_retries=5, sleep=time.sleep) -> list[T]`
 - `batch_write(*, puts=(), deletes=(), max_retries=5, sleep=time.sleep) -> None`
+- `transact_get(keys, *, projection=None) -> list[T | None]`
 - `transact_write(actions) -> None`
+
+`transact_get` accepts 1-100 keys and returns one result slot per requested key; missing items are `None`.
 
 `transact_write(actions)` accepts a sequence of dataclass actions:
 

--- a/py/docs/core-patterns.md
+++ b/py/docs/core-patterns.md
@@ -46,6 +46,19 @@ page2 = table.query("A", cursor=page1.next_cursor) if page1.next_cursor else Non
 table.batch_write(puts=[Note(pk="A", sk="2", value=1)], deletes=[("A", "1")])
 ```
 
+## Pattern: Lazy pagination for large reads
+
+Use `query_iter` and `scan_iter` when a caller may stop before consuming every page. The generator fetches the next
+DynamoDB page only when iteration advances:
+
+```python
+for page in table.query_iter("USER#1", limit=100):
+    for item in page.items:
+        if should_stop(item):
+            break
+    break  # no additional page is fetched
+```
+
 ## Pattern: Aggregations are client-side
 
 `sum_field`, `average_field`, `min_field`, `max_field`, `aggregate_field`, `count_distinct`, and `group_by(...).execute()`
@@ -69,4 +82,3 @@ from tabletheory_py.mocks import ANY, FakeDynamoDBClient
 fake = FakeDynamoDBClient()
 fake.expect("put_item", {"TableName": "notes", "Item": {"PK": ANY, "SK": ANY}})
 ```
-

--- a/py/src/theorydb_py/mocks.py
+++ b/py/src/theorydb_py/mocks.py
@@ -112,6 +112,9 @@ class FakeDynamoDBClient:
     def transact_write_items(self, **kwargs: Any) -> Mapping[str, Any]:
         return self._handle("transact_write_items", kwargs)
 
+    def transact_get_items(self, **kwargs: Any) -> Mapping[str, Any]:
+        return self._handle("transact_get_items", kwargs)
+
     def create_table(self, **kwargs: Any) -> Mapping[str, Any]:
         return self._handle("create_table", kwargs)
 

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import time
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import MISSING, fields, is_dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -37,8 +37,13 @@ from .query import (
 )
 from .runtime import DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS, _is_lambda_timeout_error
 from .runtime import with_lambda_timeout as with_lambda_timeout_client
+from .table_all import query_all as _query_all
+from .table_all import scan_all as _scan_all_pages
 from .table_count import query_count as _query_count
 from .table_count import scan_count as _scan_count
+from .table_iterators import query_iter as _query_iter
+from .table_iterators import scan_iter as _scan_iter
+from .table_transact_get import transact_get as _transact_get
 from .transaction import (
     TransactConditionCheck,
     TransactDelete,
@@ -345,27 +350,44 @@ class Table[T]:
         projection: list[str] | None = None,
         filter: FilterExpression | None = None,
     ) -> list[T]:
-        out: list[T] = []
-        next_cursor: str | None = cursor
+        return _query_all(
+            self,
+            partition,
+            sort=sort,
+            index_name=index_name,
+            limit=limit,
+            cursor=cursor,
+            scan_forward=scan_forward,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+        )
 
-        while True:
-            page = self.query(
-                partition,
-                sort=sort,
-                index_name=index_name,
-                limit=limit,
-                cursor=next_cursor,
-                scan_forward=scan_forward,
-                consistent_read=consistent_read,
-                projection=projection,
-                filter=filter,
-            )
-            out.extend(page.items)
-            if page.next_cursor is None:
-                break
-            next_cursor = page.next_cursor
-
-        return out
+    def query_iter(
+        self,
+        partition: Any,
+        *,
+        sort: SortKeyCondition | None = None,
+        index_name: str | None = None,
+        limit: int | None = None,
+        cursor: str | None = None,
+        scan_forward: bool = True,
+        consistent_read: bool = False,
+        projection: list[str] | None = None,
+        filter: FilterExpression | None = None,
+    ) -> Iterator[Page[T]]:
+        return _query_iter(
+            self,
+            partition,
+            sort=sort,
+            index_name=index_name,
+            limit=limit,
+            cursor=cursor,
+            scan_forward=scan_forward,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+        )
 
     def describe_query(
         self,
@@ -493,26 +515,41 @@ class Table[T]:
         segment: int | None = None,
         total_segments: int | None = None,
     ) -> list[T]:
-        out: list[T] = []
-        next_cursor: str | None = cursor
+        return _scan_all_pages(
+            self,
+            index_name=index_name,
+            limit=limit,
+            cursor=cursor,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+            segment=segment,
+            total_segments=total_segments,
+        )
 
-        while True:
-            page = self.scan(
-                index_name=index_name,
-                limit=limit,
-                cursor=next_cursor,
-                consistent_read=consistent_read,
-                projection=projection,
-                filter=filter,
-                segment=segment,
-                total_segments=total_segments,
-            )
-            out.extend(page.items)
-            if page.next_cursor is None:
-                break
-            next_cursor = page.next_cursor
-
-        return out
+    def scan_iter(
+        self,
+        *,
+        index_name: str | None = None,
+        limit: int | None = None,
+        cursor: str | None = None,
+        consistent_read: bool = False,
+        projection: list[str] | None = None,
+        filter: FilterExpression | None = None,
+        segment: int | None = None,
+        total_segments: int | None = None,
+    ) -> Iterator[Page[T]]:
+        return _scan_iter(
+            self,
+            index_name=index_name,
+            limit=limit,
+            cursor=cursor,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+            segment=segment,
+            total_segments=total_segments,
+        )
 
     def describe_scan(
         self,
@@ -780,6 +817,9 @@ class Table[T]:
                     attempts += 1
                     if sleep is not None:
                         sleep(_backoff_seconds(attempts))
+
+    def transact_get(self, keys: Sequence[Any], *, projection: list[str] | None = None) -> list[T | None]:
+        return _transact_get(self, keys, projection=projection)
 
     def transact_write(self, actions: Sequence[TransactWriteAction[T]]) -> None:
         if not actions:

--- a/py/src/theorydb_py/table_all.py
+++ b/py/src/theorydb_py/table_all.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .query import FilterExpression, SortKeyCondition
+
+if TYPE_CHECKING:
+    from .table import Table
+
+
+def query_all(
+    table: Table[Any],
+    partition: Any,
+    *,
+    sort: SortKeyCondition | None = None,
+    index_name: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+    scan_forward: bool = True,
+    consistent_read: bool = False,
+    projection: list[str] | None = None,
+    filter: FilterExpression | None = None,
+) -> list[Any]:
+    out: list[Any] = []
+    next_cursor: str | None = cursor
+    while True:
+        page = table.query(
+            partition,
+            sort=sort,
+            index_name=index_name,
+            limit=limit,
+            cursor=next_cursor,
+            scan_forward=scan_forward,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+        )
+        out.extend(page.items)
+        if page.next_cursor is None:
+            break
+        next_cursor = page.next_cursor
+    return out
+
+
+def scan_all(
+    table: Table[Any],
+    *,
+    index_name: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+    consistent_read: bool = False,
+    projection: list[str] | None = None,
+    filter: FilterExpression | None = None,
+    segment: int | None = None,
+    total_segments: int | None = None,
+) -> list[Any]:
+    out: list[Any] = []
+    next_cursor: str | None = cursor
+    while True:
+        page = table.scan(
+            index_name=index_name,
+            limit=limit,
+            cursor=next_cursor,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+            segment=segment,
+            total_segments=total_segments,
+        )
+        out.extend(page.items)
+        if page.next_cursor is None:
+            break
+        next_cursor = page.next_cursor
+    return out

--- a/py/src/theorydb_py/table_iterators.py
+++ b/py/src/theorydb_py/table_iterators.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+from .query import FilterExpression, Page, SortKeyCondition
+
+if TYPE_CHECKING:
+    from .table import Table
+
+
+def query_iter(
+    table: Table[Any],
+    partition: Any,
+    *,
+    sort: SortKeyCondition | None = None,
+    index_name: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+    scan_forward: bool = True,
+    consistent_read: bool = False,
+    projection: list[str] | None = None,
+    filter: FilterExpression | None = None,
+) -> Iterator[Page[Any]]:
+    next_cursor: str | None = cursor
+    while True:
+        page = table.query(
+            partition,
+            sort=sort,
+            index_name=index_name,
+            limit=limit,
+            cursor=next_cursor,
+            scan_forward=scan_forward,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+        )
+        yield page
+        if page.next_cursor is None:
+            break
+        next_cursor = page.next_cursor
+
+
+def scan_iter(
+    table: Table[Any],
+    *,
+    index_name: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+    consistent_read: bool = False,
+    projection: list[str] | None = None,
+    filter: FilterExpression | None = None,
+    segment: int | None = None,
+    total_segments: int | None = None,
+) -> Iterator[Page[Any]]:
+    next_cursor: str | None = cursor
+    while True:
+        page = table.scan(
+            index_name=index_name,
+            limit=limit,
+            cursor=next_cursor,
+            consistent_read=consistent_read,
+            projection=projection,
+            filter=filter,
+            segment=segment,
+            total_segments=total_segments,
+        )
+        yield page
+        if page.next_cursor is None:
+            break
+        next_cursor = page.next_cursor

--- a/py/src/theorydb_py/table_transact_get.py
+++ b/py/src/theorydb_py/table_transact_get.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from botocore.exceptions import ClientError
+
+from .aws_errors import map_client_error as _map_client_error
+from .errors import ValidationError
+
+if TYPE_CHECKING:
+    from .table import Table
+
+
+def transact_get(
+    table: Table[Any],
+    keys: Sequence[Any],
+    *,
+    projection: list[str] | None = None,
+) -> list[Any | None]:
+    if not keys:
+        raise ValidationError("transact_get keys are required")
+    if len(keys) > 100:
+        raise ValidationError("DynamoDB TransactGetItems supports at most 100 items")
+
+    transact_items: list[dict[str, Any]] = []
+    names: dict[str, str] | None = None
+    projection_expression: str | None = None
+    if projection is not None:
+        names = {}
+        projection_expression = table._projection_expression(projection, names)
+
+    for key in keys:
+        pk, sk = _normalize_key(table, key)
+        get: dict[str, Any] = {"TableName": table._table_name, "Key": table._to_key(pk, sk)}
+        if projection_expression is not None:
+            get["ProjectionExpression"] = projection_expression
+            if names:
+                get["ExpressionAttributeNames"] = names
+        transact_items.append({"Get": get})
+
+    try:
+        resp = table._client.transact_get_items(TransactItems=transact_items)
+    except ClientError as err:  # pragma: no cover
+        raise _map_client_error(err) from err
+
+    out: list[Any | None] = []
+    for response in resp.get("Responses", []):
+        item = response.get("Item")
+        out.append(table._from_item(item) if item else None)
+    while len(out) < len(keys):
+        out.append(None)
+    return out
+
+
+def _normalize_key(table: Table[Any], key: Any) -> tuple[Any, Any | None]:
+    if table._model.sk is None:
+        if isinstance(key, tuple):
+            if len(key) != 2:
+                raise ValidationError("expected key tuple (pk, None) for pk-only models")
+            pk, sk = key
+            if sk is not None:
+                raise ValidationError("sk must be None for pk-only models")
+            return pk, None
+        return key, None
+
+    if not isinstance(key, tuple) or len(key) != 2:
+        raise ValidationError("expected key tuple (pk, sk)")
+    pk, sk = key
+    return pk, sk

--- a/py/tests/unit/test_table_all.py
+++ b/py/tests/unit/test_table_all.py
@@ -82,3 +82,55 @@ def test_scan_all_paginates_until_cursor_exhausted() -> None:
     items = table.scan_all()
     assert [i.version for i in items] == [1, 2]
     client.assert_no_pending()
+
+
+def test_query_iter_fetches_next_page_lazily() -> None:
+    client = FakeDynamoDBClient()
+    model = ModelDefinition.from_dataclass(User, table_name="users")
+    table: Table[User] = Table(model, client=client)
+
+    last = {"PK": {"S": "A"}, "SK": {"S": "1"}}
+    client.expect(
+        "query",
+        response={
+            "Items": [{"PK": {"S": "A"}, "SK": {"S": "1"}, "version": {"N": "1"}}],
+            "LastEvaluatedKey": last,
+        },
+    )
+    client.expect(
+        "query",
+        response={"Items": [{"PK": {"S": "A"}, "SK": {"S": "2"}, "version": {"N": "2"}}]},
+    )
+
+    iterator = table.query_iter("A")
+    page = next(iterator)
+    assert [item.version for item in page.items] == [1]
+    iterator.close()
+
+    assert len(client._expected) == 1  # noqa: SLF001 - asserts lazy early-stop behavior
+
+
+def test_scan_iter_fetches_next_page_lazily() -> None:
+    client = FakeDynamoDBClient()
+    model = ModelDefinition.from_dataclass(User, table_name="users")
+    table: Table[User] = Table(model, client=client)
+
+    last = {"PK": {"S": "A"}, "SK": {"S": "1"}}
+    client.expect(
+        "scan",
+        response={
+            "Items": [{"PK": {"S": "A"}, "SK": {"S": "1"}, "version": {"N": "1"}}],
+            "LastEvaluatedKey": last,
+        },
+    )
+    client.expect(
+        "scan",
+        response={"Items": [{"PK": {"S": "A"}, "SK": {"S": "2"}, "version": {"N": "2"}}]},
+    )
+
+    iterator = table.scan_iter()
+    page = next(iterator)
+    assert [item.version for item in page.items] == [1]
+    iterator.close()
+
+    assert len(client._expected) == 1  # noqa: SLF001 - asserts lazy early-stop behavior

--- a/py/tests/unit/test_table_batch_retries.py
+++ b/py/tests/unit/test_table_batch_retries.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from theorydb_py import BatchRetryExceededError, ModelDefinition, Table, theorydb_field
+from theorydb_py import BatchRetryExceededError, ModelDefinition, Table, ValidationError, theorydb_field
 
 
 @dataclass(frozen=True)
@@ -86,3 +86,42 @@ def test_batch_write_retry_limit_exceeded() -> None:
 
     with pytest.raises(BatchRetryExceededError):
         table.batch_write(puts=[Note(pk="A", sk="1", value=1)], max_retries=0, sleep=lambda _: None)
+
+
+def test_transact_get_returns_ordered_found_and_missing_slots() -> None:
+    model = ModelDefinition.from_dataclass(Note, table_name="tbl")
+    base_table: Table[Note] = Table(model, client=object())
+    client = FakeTransactGetClient(
+        response={
+            "Responses": [
+                {"Item": base_table._to_item(Note(pk="A", sk="1", value=1))},
+                {},
+            ]
+        }
+    )
+    table: Table[Note] = Table(model, client=client)
+
+    got = table.transact_get([("A", "1"), ("A", "missing")])
+
+    assert got == [Note(pk="A", sk="1", value=1), None]
+    assert len(client.requests[0]["TransactItems"]) == 2
+
+
+def test_transact_get_rejects_empty_and_over_limit() -> None:
+    model = ModelDefinition.from_dataclass(Note, table_name="tbl")
+    table: Table[Note] = Table(model, client=object())
+
+    with pytest.raises(ValidationError):
+        table.transact_get([])
+    with pytest.raises(ValidationError):
+        table.transact_get([("A", "1")] * 101)
+
+
+class FakeTransactGetClient:
+    def __init__(self, *, response):
+        self.response = response
+        self.requests = []
+
+    def transact_get_items(self, **kwargs):
+        self.requests.append(kwargs)
+        return self.response

--- a/ts/docs/api-reference.md
+++ b/ts/docs/api-reference.md
@@ -172,9 +172,15 @@ Key, cursor, and page methods:
 - `projection(fields: string[]): this`
 - `cursor(encoded: string): this`
 - `page(): Promise<Page>`
+- `pages(): AsyncGenerator<Page>`
+- `items(): AsyncGenerator<Record<string, unknown>>`
 - `all(): Promise<Array<Record<string, unknown>>>`
 - `pageWithRetry(options?): Promise<Page>`
 - `describe(): BuilderShape`
+
+Prefer `pages()` or `items()` for large result sets. They fetch one DynamoDB page at a time and stop fetching when the
+consumer breaks out of the `for await` loop. `all()` is a convenience helper for bounded result sets because it follows
+every cursor and materializes every matching item.
 
 Filter expressions are implemented:
 
@@ -226,10 +232,13 @@ Actual signatures:
 
 - `batchGet(modelName: string, keys: Array<Record<string, unknown>>, opts?: RetryOptions & { consistentRead?: boolean }): Promise<BatchGetResult>`
 - `batchWrite(modelName: string, request: { puts?: Array<Record<string, unknown>>; deletes?: Array<Record<string, unknown>> }, opts?: RetryOptions): Promise<BatchWriteResult>`
+- `transactGet(actions: TransactGetAction[]): Promise<Array<Record<string, unknown> | undefined>>`
 - `transactWrite(actions: TransactAction[]): Promise<void>`
 
 `batchGet` defaults to `consistentRead: true`, `maxAttempts: 5`, and `baseDelayMs: 25`. `batchWrite` defaults to
 `maxAttempts: 5` and `baseDelayMs: 25`.
+
+`transactGet` accepts 1-100 items and returns one result slot per requested item; missing items are `undefined`.
 
 `TransactAction` is a discriminated union of:
 

--- a/ts/docs/core-patterns.md
+++ b/ts/docs/core-patterns.md
@@ -56,6 +56,19 @@ const page2 = page1.cursor
   : { items: [] };
 ```
 
+For large partitions or scans, prefer the lazy async iterators so callers can stop early without fetching the remaining
+pages:
+
+```ts
+for await (const item of db
+  .query('User')
+  .partitionKey('U#1')
+  .limit(100)
+  .items()) {
+  if (shouldStop(item)) break; // no additional page is fetched after break
+}
+```
+
 ## Pattern: Aggregations are client-side
 
 `db.query(...).sum(...)`, `average(...)`, `min(...)`, `max(...)`, `aggregate(...)`, `countDistinct(...)`, and

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -6,11 +6,13 @@ import {
   DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
+  TransactGetItemsCommand,
   TransactWriteItemsCommand,
   UpdateItemCommand,
   type ConditionCheck,
   type Delete,
   type Put,
+  type TransactGetItem,
   type Update,
   type TransactWriteItem,
   type WriteRequest,
@@ -38,7 +40,7 @@ import {
   type UnmarshalOptions,
 } from './marshal.js';
 import { QueryBuilder, ScanBuilder } from './query.js';
-import type { TransactAction } from './transaction.js';
+import type { TransactAction, TransactGetAction } from './transaction.js';
 import { UpdateBuilder } from './update-builder.js';
 import {
   decryptItemAttributes,
@@ -540,7 +542,72 @@ export class TheorydbClient {
     return { unprocessed };
   }
 
+  async transactGet(
+    actions: TransactGetAction[],
+  ): Promise<Array<Record<string, unknown> | undefined>> {
+    if (actions.length === 0) {
+      throw new TheorydbError(
+        'ErrInvalidOperator',
+        'TransactGetItems requires at least one item',
+      );
+    }
+    if (actions.length > 100) {
+      throw new TheorydbError(
+        'ErrInvalidOperator',
+        'DynamoDB TransactGetItems supports up to 100 items',
+      );
+    }
+
+    const models = actions.map((action) => this.requireModel(action.model));
+    const transactItems: TransactGetItem[] = actions.map((action, index) => {
+      const model = models[index]!;
+      const get: NonNullable<TransactGetItem['Get']> = {
+        TableName: model.tableName,
+        Key: marshalKey(model, action.key),
+      };
+      if (action.projection && action.projection.length > 0) {
+        const projection = buildProjectionExpression(model, action.projection);
+        get.ProjectionExpression = projection.expression;
+        get.ExpressionAttributeNames = projection.names;
+      }
+      return { Get: get };
+    });
+
+    let resp;
+    try {
+      resp = await this.ddb.send(
+        new TransactGetItemsCommand({ TransactItems: transactItems }),
+        this.sendOptions,
+      );
+    } catch (err) {
+      throw mapDynamoError(err);
+    }
+
+    const responses = resp.Responses ?? [];
+    return Promise.all(
+      actions.map(async (_, index) => {
+        const item = responses[index]?.Item;
+        if (!item || Object.keys(item).length === 0) return undefined;
+        const model = models[index]!;
+        const provider = modelHasEncryptedAttributes(model)
+          ? this.requireEncryption(model)
+          : undefined;
+        const plain = provider
+          ? await decryptItemAttributes(model, item, provider)
+          : item;
+        return unmarshalItem(model, plain, this.unmarshalOptions);
+      }),
+    );
+  }
+
   async transactWrite(actions: TransactAction[]): Promise<void> {
+    if (actions.length > 100) {
+      throw new TheorydbError(
+        'ErrInvalidOperator',
+        'DynamoDB TransactWriteItems supports up to 100 actions',
+      );
+    }
+
     const transactItems: TransactWriteItem[] = [];
 
     for (const a of actions) {
@@ -703,6 +770,21 @@ function policyFieldsForUpdate(
   if (model.roles.updatedAt) out.push(model.roles.updatedAt);
   if (model.roles.version) out.push(model.roles.version);
   return out;
+}
+
+function buildProjectionExpression(
+  model: Model,
+  fields: readonly string[],
+): { expression: string; names: Record<string, string> } {
+  const names: Record<string, string> = {};
+  const parts: string[] = [];
+  fields.forEach((field, index) => {
+    const attr = model.attributes.get(field)?.attribute ?? field;
+    const placeholder = `#p${index}`;
+    names[placeholder] = attr;
+    parts.push(placeholder);
+  });
+  return { expression: parts.join(', '), names };
 }
 
 function hasProtectedAttributes(model: Model): boolean {

--- a/ts/src/query-concurrency.ts
+++ b/ts/src/query-concurrency.ts
@@ -1,0 +1,34 @@
+import { TheorydbError } from './errors.js';
+
+export async function mapConcurrent<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  if (!Number.isFinite(concurrency) || concurrency <= 0) {
+    throw new TheorydbError(
+      'ErrInvalidOperator',
+      'concurrency must be a positive number',
+    );
+  }
+  if (items.length === 0) return [];
+
+  const limit = Math.min(items.length, Math.floor(concurrency));
+  const out: R[] = new Array<R>(items.length);
+  let next = 0;
+
+  const workers = Array.from({ length: limit }, async () => {
+    let done = false;
+    while (!done) {
+      const idx = next;
+      next += 1;
+      if (idx >= items.length) {
+        done = true;
+        continue;
+      }
+      out[idx] = await fn(items[idx]!);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}

--- a/ts/src/query-iterators.ts
+++ b/ts/src/query-iterators.ts
@@ -1,0 +1,31 @@
+import type { Page } from './query.js';
+
+export async function* pageIterator<T>(
+  getCursor: () => string | undefined,
+  setCursor: (cursor: string | undefined) => void,
+  loadPage: () => Promise<Page<T>>,
+): AsyncGenerator<Page<T>> {
+  const original = getCursor();
+  try {
+    let cursor = original;
+    for (;;) {
+      setCursor(cursor);
+      const page = await loadPage();
+      yield page;
+      if (!page.cursor) break;
+      cursor = page.cursor;
+    }
+  } finally {
+    setCursor(original);
+  }
+}
+
+export async function* itemIterator<T>(
+  pages: AsyncIterable<Page<T>>,
+): AsyncGenerator<T> {
+  for await (const page of pages) {
+    for (const item of page.items) {
+      yield item;
+    }
+  }
+}

--- a/ts/src/query.ts
+++ b/ts/src/query.ts
@@ -35,6 +35,8 @@ import {
 } from './marshal.js';
 import type { AttributeSchema, IndexSchema, Model } from './model.js';
 import type { BuilderShape } from './optimizer.js';
+import { mapConcurrent } from './query-concurrency.js';
+import { itemIterator, pageIterator } from './query-iterators.js';
 import { countAllPages } from './query-count.js';
 import type { SendOptions } from './send-options.js';
 
@@ -714,6 +716,20 @@ export class QueryBuilder {
     }
   }
 
+  pages(): AsyncGenerator<Page<Record<string, unknown>>> {
+    return pageIterator(
+      () => this.cursorToken,
+      (cursor) => {
+        this.cursorToken = cursor;
+      },
+      () => this.page(),
+    );
+  }
+
+  items(): AsyncGenerator<Record<string, unknown>> {
+    return itemIterator(this.pages());
+  }
+
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before summing.
    * Use only for bounded result sets; use native `count()` for count-only reads.
@@ -1227,6 +1243,20 @@ export class ScanBuilder {
     }
   }
 
+  pages(): AsyncGenerator<Page<Record<string, unknown>>> {
+    return pageIterator(
+      () => this.cursorToken,
+      (cursor) => {
+        this.cursorToken = cursor;
+      },
+      () => this.page(),
+    );
+  }
+
+  items(): AsyncGenerator<Record<string, unknown>> {
+    return itemIterator(this.pages());
+  }
+
   /**
    * Client-side aggregation: calls `all()` and materializes every matching item before summing.
    * Use only for bounded result sets; use native `count()` for count-only reads.
@@ -1460,37 +1490,4 @@ export class ScanBuilder {
 
     return lastPage ?? { items: [] };
   }
-}
-
-async function mapConcurrent<T, R>(
-  items: T[],
-  concurrency: number,
-  fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-  if (!Number.isFinite(concurrency) || concurrency <= 0) {
-    throw new TheorydbError(
-      'ErrInvalidOperator',
-      'concurrency must be a positive number',
-    );
-  }
-  if (items.length === 0) return [];
-
-  const limit = Math.min(items.length, Math.floor(concurrency));
-  const out: R[] = new Array<R>(items.length);
-  let next = 0;
-
-  const workers = Array.from({ length: limit }, async () => {
-    let done = false;
-    while (!done) {
-      const idx = next;
-      next += 1;
-      if (idx >= items.length) {
-        done = true;
-        continue;
-      }
-      out[idx] = await fn(items[idx]!);
-    }
-  });
-  await Promise.all(workers);
-  return out;
 }

--- a/ts/src/transaction.ts
+++ b/ts/src/transaction.ts
@@ -54,3 +54,9 @@ export type TransactAction =
       expressionAttributeNames?: Record<string, string>;
       expressionAttributeValues?: Record<string, AttributeValue>;
     };
+
+export type TransactGetAction = {
+  model: string;
+  key: Record<string, unknown>;
+  projection?: string[];
+};

--- a/ts/test/unit/query-builder.test.ts
+++ b/ts/test/unit/query-builder.test.ts
@@ -638,3 +638,78 @@ const User = defineModel({
   assert.equal(count, 4);
   assert.equal(ddb.calls, 1);
 }
+
+{
+  const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof QueryCommand) {
+      return {
+        Items: [{ PK: { S: 'LAZY' }, SK: { S: '1' }, version: { N: '0' } }],
+        LastEvaluatedKey: { PK: { S: 'LAZY' }, SK: { S: '1' } },
+      };
+    }
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+  let pages = 0;
+  for await (const page of client.query('User').partitionKey('LAZY').pages()) {
+    pages += 1;
+    assert.equal(page.items.length, 1);
+    break;
+  }
+  assert.equal(pages, 1);
+  assert.equal(ddb.calls, 1);
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof QueryCommand) {
+      return {
+        Items: [
+          { PK: { S: 'LAZYITEMS' }, SK: { S: '1' }, version: { N: '0' } },
+          { PK: { S: 'LAZYITEMS' }, SK: { S: '2' }, version: { N: '0' } },
+        ],
+        LastEvaluatedKey: { PK: { S: 'LAZYITEMS' }, SK: { S: '2' } },
+      };
+    }
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+  let items = 0;
+  for await (const item of client
+    .query('User')
+    .partitionKey('LAZYITEMS')
+    .items()) {
+    items += 1;
+    assert.equal(item.PK, 'LAZYITEMS');
+    break;
+  }
+  assert.equal(items, 1);
+  assert.equal(ddb.calls, 1);
+}
+
+{
+  const ddb = new StubDdb((cmd) => {
+    if (cmd instanceof ScanCommand) {
+      return {
+        Items: [{ PK: { S: 'SCANLAZY' }, SK: { S: '1' }, version: { N: '0' } }],
+        LastEvaluatedKey: { PK: { S: 'SCANLAZY' }, SK: { S: '1' } },
+      };
+    }
+    throw new Error('unexpected');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+  let pages = 0;
+  for await (const page of client.scan('User').pages()) {
+    pages += 1;
+    assert.equal(page.items[0]?.PK, 'SCANLAZY');
+    break;
+  }
+  assert.equal(pages, 1);
+  assert.equal(ddb.calls, 1);
+}


### PR DESCRIPTION
## Summary

- Adds M10 capability-gated contract operations and scenarios for `transact_get`, `batch_get`, `batch_write`, and generic `transact_write` across Go, TypeScript, and Python runners.
- Adds additive Go `TransactGet` support via a new extension interface, plus TypeScript `transactGet` and Python `transact_get` runtime surfaces.
- Pins batch chunking and generic transaction atomicity/cap behavior, and documents/adds lazy pagination surfaces for TypeScript (`pages()`/`items()`) and Python (`query_iter`/`scan_iter`).

## Linear

- THE-2367 / TTIP-059
- THE-2369 / TTIP-060
- THE-2371 / TTIP-061
- THE-2373 / TTIP-062
- THE-2375 / TTIP-063
- THE-2376 / TTIP-064
- THE-2377 / TTIP-065
- THE-2378 / TTIP-066

## Validation

- `make contract-tests` — PASS
- `make test-unit` — PASS
- `make rubric` — PASS (`Status: PASS (pass=36 fail=0 blocked=0)`)
- `cd ts && npm run check` — PASS
- `uv --directory py run pytest -q tests/unit` — PASS (`265 passed`)
- `cd py && python -m unittest` — exit 5, `Ran 0 tests` / `NO TESTS RAN` (known non-authoritative stdlib discovery path; pytest is the repo-local authoritative Python unit gate for this wave)
- `git diff --check` — PASS

## Notes

- No DMS changes.
- No release-lane/version changes.
- No cloud/AWS mutation or live proof claimed; validation is repo-local contract/runtime proof.
