### PR TITLE
feat(api): add typed API surfaces

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,6 +18,7 @@ TheoryCloud TableTheory subtree. This page is the Go API reference.
 - [Core Interfaces](#core-interfaces)
   - [DB Interface](#db-interface)
   - [LambdaDB](#lambdadb-struct)
+- [Typed Go APIs](#typed-go-apis)
 - [Query Builder](#query-builder)
 - [Transaction Builder](#transaction-builder)
 - [Update Builder](#update-builder)
@@ -209,7 +210,49 @@ memory/X-Ray configuration.
 
 Returns memory usage statistics useful for tuning Lambda memory allocation.
 
+
 ---
+
+## Typed Go APIs
+
+The generic Go layer is additive. Existing `db.Model(&User{})` calls remain supported; typed handles wrap the same
+runtime behavior while removing destination `any` plumbing at common call sites.
+
+```go
+modelOfUser := tabletheory.ModelOf[User]
+users := modelOfUser(db)
+
+created := User{PK: "TENANT#demo", SK: "USER#ada", Name: "Ada"}
+if err := users.Create(&created); err != nil {
+    return err
+}
+
+key := users.Key("TENANT#demo", "USER#ada")
+found, err := users.Get(key)
+if err != nil {
+    return err
+}
+
+found.Name = "Ada Lovelace"
+if err := users.Update(&found, "Name"); err != nil {
+    return err
+}
+
+first, err := users.Query().
+    Where("SK", query.OpBeginsWith, "USER#").
+    First()
+```
+
+Primary typed entry points:
+
+- `tabletheory.ModelOf` / `typed.ModelOf` create a model-typed handle from an existing `core.DB`.
+- `Model[T].Query().First() (T, error)` and `All() ([]T, error)` allocate correctly typed destinations internally.
+- `Model[T].Key(pk, sk...)` returns a `typed.Key[T]`, so a key for one model type is not assignable to another model
+  type.
+- `query.OpEqual`, `query.OpBeginsWith`, `query.OpBetween`, and the other `query.Op*` constants are exported for
+  typo-resistant operator spelling. `query.Between(lo, hi)` preserves the existing two-value `BETWEEN` operand shape.
+
+See `examples/typed-go` for a compile-checked typed CRUD/query flow.
 
 ## Query Builder
 
@@ -221,7 +264,7 @@ The `Query` interface is returned by `db.Model()`.
 
 Adds a condition. Translates to `KeyConditionExpression` if field is a key, or `FilterExpression` otherwise.
 
-- **op**: `=`, `>`, `<`, `>=`, `<=`, `BEGINS_WITH`, `BETWEEN`.
+- **op**: `=`, `>`, `<`, `>=`, `<=`, `BEGINS_WITH`, `BETWEEN`; prefer exported `query.Op*` constants in new Go code (for example `query.OpBeginsWith`) and `query.Between(lo, hi)` for the two-value `BETWEEN` operand shape.
 
 #### `Index(name string) Query`
 
@@ -397,10 +440,19 @@ Appends elements to a list.
 Creates a table based on struct tags.
 
 - **Warning**: For development use. Production should use Terraform/CDK.
+- **Deprecation notice**: this compatibility method accepts `opts ...any`. Prefer `CreateTableWithOptions(model, opts ...schema.TableOption)` through `*tabletheory.DB` or the additive `core.TypedExtendedDB` extension interface.
+
+#### `CreateTableWithOptions(model any, opts ...schema.TableOption) error`
+
+Creates a table using concrete `schema.TableOption` values without the legacy `opts ...any` boundary.
 
 #### `AutoMigrate(models ...any) error`
 
 Checks if tables exist and creates them if missing.
+
+#### `AutoMigrateWithTypedOptions(model any, opts ...schema.AutoMigrateOption) error`
+
+Runs enhanced auto-migration using concrete `schema.AutoMigrateOption` values. The legacy `AutoMigrateWithOptions(model, opts ...any)` surface remains for backward compatibility and is planned for v2 removal.
 
 #### `EnsureTable(model any) error`
 

--- a/examples/typed-go/main.go
+++ b/examples/typed-go/main.go
@@ -1,0 +1,41 @@
+// Package main shows the additive Go typed API surface without performing
+// network I/O. The example accepts an existing TableTheory DB handle from the
+// application's normal initialization path (for example LambdaInit or New).
+package main
+
+import (
+	"github.com/theory-cloud/tabletheory"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	"github.com/theory-cloud/tabletheory/pkg/query"
+)
+
+type User struct {
+	PK      string `theorydb:"pk" json:"PK"`
+	SK      string `theorydb:"sk" json:"SK"`
+	Name    string `json:"name"`
+	Version int64  `theorydb:"version" json:"version"`
+}
+
+func typedFlow(db core.DB) error {
+	users := tabletheory.ModelOf[User](db)
+
+	user := User{PK: "TENANT#demo", SK: "USER#ada", Name: "Ada"}
+	if err := users.Create(&user); err != nil {
+		return err
+	}
+
+	got, err := users.Get(users.Key("TENANT#demo", "USER#ada"))
+	if err != nil {
+		return err
+	}
+
+	got.Name = "Ada Lovelace"
+	if err := users.Update(&got, "Name"); err != nil {
+		return err
+	}
+
+	_, err = users.Query().Where("SK", query.OpBeginsWith, "USER#").First()
+	return err
+}
+
+func main() {}

--- a/internal/theorydb/theorydb.go
+++ b/internal/theorydb/theorydb.go
@@ -324,7 +324,11 @@ func (db *DB) AutoMigrate(models ...any) error {
 	return nil
 }
 
-// AutoMigrateWithOptions performs enhanced auto-migration with data copy support
+// AutoMigrateWithOptions performs enhanced auto-migration with data copy support.
+//
+// Deprecation notice: use AutoMigrateWithTypedOptions when the concrete
+// schema.AutoMigrateOption type is available. This opts ...any compatibility
+// surface is planned for removal in v2.
 func (db *DB) AutoMigrateWithOptions(model any, opts ...any) error {
 	// Convert opts to the expected type
 	var options []schema.AutoMigrateOption
@@ -336,17 +340,22 @@ func (db *DB) AutoMigrateWithOptions(model any, opts ...any) error {
 		}
 	}
 
-	manager := schema.NewManager(db.session, db.registry)
-	return manager.AutoMigrateWithOptions(model, options...)
+	return db.AutoMigrateWithTypedOptions(model, options...)
 }
 
-// CreateTable creates a DynamoDB table for the given model
-func (db *DB) CreateTable(model any, opts ...any) error {
-	// Register model first
-	if err := db.registry.Register(model); err != nil {
-		return fmt.Errorf("failed to register model %T: %w", model, err)
-	}
+// AutoMigrateWithTypedOptions performs enhanced auto-migration with concrete
+// schema.AutoMigrateOption values.
+func (db *DB) AutoMigrateWithTypedOptions(model any, opts ...schema.AutoMigrateOption) error {
+	manager := schema.NewManager(db.session, db.registry)
+	return manager.AutoMigrateWithOptions(model, opts...)
+}
 
+// CreateTable creates a DynamoDB table for the given model.
+//
+// Deprecation notice: use CreateTableWithOptions when the concrete
+// schema.TableOption type is available. This opts ...any compatibility surface
+// is planned for removal in v2.
+func (db *DB) CreateTable(model any, opts ...any) error {
 	// Convert opts to the expected type
 	var options []schema.TableOption
 	for _, opt := range opts {
@@ -357,8 +366,18 @@ func (db *DB) CreateTable(model any, opts ...any) error {
 		}
 	}
 
+	return db.CreateTableWithOptions(model, options...)
+}
+
+// CreateTableWithOptions creates a DynamoDB table with concrete schema.TableOption values.
+func (db *DB) CreateTableWithOptions(model any, opts ...schema.TableOption) error {
+	// Register model first
+	if err := db.registry.Register(model); err != nil {
+		return fmt.Errorf("failed to register model %T: %w", model, err)
+	}
+
 	manager := schema.NewManager(db.session, db.registry)
-	return manager.CreateTable(model, options...)
+	return manager.CreateTable(model, opts...)
 }
 
 // EnsureTable checks if a table exists for the model and creates it if not

--- a/pkg/core/interfaces.go
+++ b/pkg/core/interfaces.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
 	"github.com/theory-cloud/tabletheory/pkg/model"
+	"github.com/theory-cloud/tabletheory/pkg/schema"
 	pkgTypes "github.com/theory-cloud/tabletheory/pkg/types"
 )
 
@@ -43,7 +44,10 @@ type ExtendedDB interface {
 	DB
 
 	// AutoMigrateWithOptions performs enhanced auto-migration with data copy support
-	// opts should be of type schema.AutoMigrateOption
+	//
+	// Deprecation notice: use TypedExtendedDB.AutoMigrateWithTypedOptions when the
+	// concrete option type is available. This opts ...any compatibility surface is
+	// planned for removal in v2.
 	AutoMigrateWithOptions(model any, opts ...any) error
 
 	// RegisterTypeConverter registers a custom converter for a specific Go type, allowing
@@ -51,7 +55,10 @@ type ExtendedDB interface {
 	RegisterTypeConverter(typ reflect.Type, converter pkgTypes.CustomConverter) error
 
 	// CreateTable creates a DynamoDB table for the given model
-	// opts should be of type schema.TableOption
+	//
+	// Deprecation notice: use TypedExtendedDB.CreateTableWithOptions when the
+	// concrete option type is available. This opts ...any compatibility surface is
+	// planned for removal in v2.
 	CreateTable(model any, opts ...any) error
 
 	// EnsureTable checks if a table exists for the model and creates it if not
@@ -83,6 +90,21 @@ type ExtendedDB interface {
 	// TransactWrite executes the provided function within a transaction builder context
 	// and automatically commits the accumulated operations.
 	TransactWrite(ctx context.Context, fn func(TransactionBuilder) error) error
+}
+
+// TypedExtendedDB is an additive extension interface for callers that want
+// concrete option types instead of the legacy opts ...any compatibility methods.
+// It is intentionally separate from ExtendedDB so existing mocks and custom
+// implementations remain source-compatible.
+type TypedExtendedDB interface {
+	ExtendedDB
+
+	// AutoMigrateWithTypedOptions performs enhanced auto-migration with
+	// schema.AutoMigrateOption values.
+	AutoMigrateWithTypedOptions(model any, opts ...schema.AutoMigrateOption) error
+
+	// CreateTableWithOptions creates a DynamoDB table with schema.TableOption values.
+	CreateTableWithOptions(model any, opts ...schema.TableOption) error
 }
 
 // TransactGetter is an additive extension interface for DynamoDB TransactGetItems

--- a/pkg/query/constants.go
+++ b/pkg/query/constants.go
@@ -1,6 +1,56 @@
 package query
 
+// Operator identifies a DynamoDB condition/filter operator accepted by TableTheory query builders.
+type Operator string
+
 const (
 	operationQuery = "Query"
 	operationScan  = "Scan"
 )
+
+const (
+	// OpEqual compares equality.
+	OpEqual Operator = "="
+	// OpNotEqual compares inequality.
+	OpNotEqual Operator = "<>"
+	// OpLessThan compares values lower than the operand.
+	OpLessThan Operator = "<"
+	// OpLessThanOrEqual compares values lower than or equal to the operand.
+	OpLessThanOrEqual Operator = "<="
+	// OpGreaterThan compares values greater than the operand.
+	OpGreaterThan Operator = ">"
+	// OpGreaterThanOrEqual compares values greater than or equal to the operand.
+	OpGreaterThanOrEqual Operator = ">="
+	// OpBetween compares a value against an inclusive lower/upper bound pair.
+	OpBetween Operator = "BETWEEN"
+	// OpIn compares membership in a bounded value list.
+	OpIn Operator = "IN"
+	// OpBeginsWith matches string/binary sort-key or filter prefixes.
+	OpBeginsWith Operator = "BEGINS_WITH"
+	// OpContains matches collection or substring containment.
+	OpContains Operator = "CONTAINS"
+	// OpExists checks that an attribute exists.
+	OpExists Operator = "ATTRIBUTE_EXISTS"
+	// OpNotExists checks that an attribute does not exist.
+	OpNotExists Operator = "ATTRIBUTE_NOT_EXISTS"
+)
+
+const (
+	// OpEQ is an alias for OpEqual.
+	OpEQ Operator = "EQ"
+	// OpNE is an alias for OpNotEqual.
+	OpNE Operator = "NE"
+	// OpLT is an alias for OpLessThan.
+	OpLT Operator = "LT"
+	// OpLE is an alias for OpLessThanOrEqual.
+	OpLE Operator = "LE"
+	// OpGT is an alias for OpGreaterThan.
+	OpGT Operator = "GT"
+	// OpGE is an alias for OpGreaterThanOrEqual.
+	OpGE Operator = "GE"
+)
+
+// Between returns the two-value operand shape expected by DynamoDB BETWEEN expressions.
+func Between(lo, hi any) []any {
+	return []any{lo, hi}
+}

--- a/pkg/query/operator_constants_test.go
+++ b/pkg/query/operator_constants_test.go
@@ -1,0 +1,15 @@
+package query_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/query"
+)
+
+func TestOperatorConstantsAreStringCompatible(t *testing.T) {
+	op := string(query.OpBeginsWith)
+	require.Equal(t, "BEGINS_WITH", op)
+	require.Equal(t, []any{"A", "Z"}, query.Between("A", "Z"))
+}

--- a/pkg/typed/typed.go
+++ b/pkg/typed/typed.go
@@ -1,0 +1,225 @@
+// Package typed provides additive generic wrappers around the stable TableTheory
+// core interfaces. The wrappers keep the existing runtime behavior while moving
+// common result/destination shapes into Go's type system at call sites.
+package typed
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/query"
+)
+
+// Model is a generic handle for one TableTheory model type.
+type Model[T any] struct {
+	db core.DB
+}
+
+// Query is a generic query builder for a TableTheory model type.
+type Query[T any] struct {
+	query core.Query
+}
+
+// Key is a primary-key value tied to a specific model type.
+type Key[T any] struct {
+	pair core.KeyPair
+}
+
+// ModelOf creates a generic handle for model type T from an existing TableTheory DB.
+func ModelOf[T any](db core.DB) Model[T] {
+	return Model[T]{db: db}
+}
+
+// NewKey creates a model-typed key without requiring a Model handle.
+func NewKey[T any](partitionKey any, sortKey ...any) Key[T] {
+	return Key[T]{pair: core.NewKeyPair(partitionKey, sortKey...)}
+}
+
+// Core returns the underlying untyped TableTheory key pair for interoperability.
+func (k Key[T]) Core() core.KeyPair {
+	return k.pair
+}
+
+// Key creates a model-typed key.
+func (m Model[T]) Key(partitionKey any, sortKey ...any) Key[T] {
+	return NewKey[T](partitionKey, sortKey...)
+}
+
+// Query returns a generic query builder using a zero-value model instance for metadata.
+func (m Model[T]) Query() Query[T] {
+	var zero T
+	return Query[T]{query: m.db.Model(&zero)}
+}
+
+// Item returns a generic query builder bound to item for create/update/delete operations.
+func (m Model[T]) Item(item *T) Query[T] {
+	return Query[T]{query: m.db.Model(item)}
+}
+
+// Create inserts item using the existing TableTheory create semantics.
+func (m Model[T]) Create(item *T) error {
+	return m.Item(item).Create()
+}
+
+// CreateOrUpdate upserts item using the existing TableTheory create-or-update semantics.
+func (m Model[T]) CreateOrUpdate(item *T) error {
+	return m.Item(item).CreateOrUpdate()
+}
+
+// Update updates item fields using the existing TableTheory update semantics.
+func (m Model[T]) Update(item *T, fields ...string) error {
+	return m.Item(item).Update(fields...)
+}
+
+// Delete deletes item using the existing TableTheory delete semantics.
+func (m Model[T]) Delete(item *T) error {
+	return m.Item(item).Delete()
+}
+
+// Get fetches one item by typed key. Missing items return ErrItemNotFound.
+func (m Model[T]) Get(key Key[T]) (T, error) {
+	items, err := m.BatchGet([]Key[T]{key})
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	if len(items) == 0 {
+		var zero T
+		return zero, theorydbErrors.ErrItemNotFound
+	}
+	return items[0], nil
+}
+
+// GetOrNil fetches one item by typed key and returns nil when it is absent.
+func (m Model[T]) GetOrNil(key Key[T]) (*T, error) {
+	item, err := m.Get(key)
+	if err != nil {
+		if errors.Is(err, theorydbErrors.ErrItemNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &item, nil
+}
+
+// BatchGet retrieves multiple items by typed keys.
+func (m Model[T]) BatchGet(keys []Key[T]) ([]T, error) {
+	var zero T
+	untypedKeys := make([]any, 0, len(keys))
+	for _, key := range keys {
+		untypedKeys = append(untypedKeys, key.Core())
+	}
+	var dest []T
+	if err := m.db.Model(&zero).BatchGet(untypedKeys, &dest); err != nil {
+		return nil, err
+	}
+	return dest, nil
+}
+
+// DeleteKey deletes one item by typed key.
+func (m Model[T]) DeleteKey(key Key[T]) error {
+	var zero T
+	return m.db.Model(&zero).BatchDelete([]any{key.Core()})
+}
+
+// Where adds a condition and preserves the generic query type.
+func (q Query[T]) Where(field string, op query.Operator, value any) Query[T] {
+	q.query = q.query.Where(field, string(op), value)
+	return q
+}
+
+// Between adds a BETWEEN condition with a two-argument value shape.
+func (q Query[T]) Between(field string, lo any, hi any) Query[T] {
+	return q.Where(field, query.OpBetween, query.Between(lo, hi))
+}
+
+// Filter adds a filter condition and preserves the generic query type.
+func (q Query[T]) Filter(field string, op query.Operator, value any) Query[T] {
+	q.query = q.query.Filter(field, string(op), value)
+	return q
+}
+
+// Index selects an index and preserves the generic query type.
+func (q Query[T]) Index(indexName string) Query[T] {
+	q.query = q.query.Index(indexName)
+	return q
+}
+
+// Limit sets a result limit and preserves the generic query type.
+func (q Query[T]) Limit(limit int) Query[T] {
+	q.query = q.query.Limit(limit)
+	return q
+}
+
+// First returns the first matching item as T.
+func (q Query[T]) First() (T, error) {
+	var dest T
+	if err := q.query.First(&dest); err != nil {
+		return dest, err
+	}
+	return dest, nil
+}
+
+// FirstOrNil returns the first matching item or nil when it is absent.
+func (q Query[T]) FirstOrNil() (*T, error) {
+	var dest T
+	found, err := query.FirstOrNil(q.query, &dest)
+	if err != nil || !found {
+		return nil, err
+	}
+	return &dest, nil
+}
+
+// All returns all matching items as []T.
+func (q Query[T]) All() ([]T, error) {
+	var dest []T
+	if err := q.query.All(&dest); err != nil {
+		return nil, err
+	}
+	return dest, nil
+}
+
+// Count returns the number of matching items without materializing them.
+func (q Query[T]) Count() (int64, error) {
+	return q.query.Count()
+}
+
+// Create inserts the query's bound item.
+func (q Query[T]) Create() error {
+	if q.query == nil {
+		return fmt.Errorf("typed query is not bound to a model")
+	}
+	return q.query.Create()
+}
+
+// CreateOrUpdate upserts the query's bound item.
+func (q Query[T]) CreateOrUpdate() error {
+	if q.query == nil {
+		return fmt.Errorf("typed query is not bound to a model")
+	}
+	return q.query.CreateOrUpdate()
+}
+
+// Update updates selected fields on the query's bound item.
+func (q Query[T]) Update(fields ...string) error {
+	if q.query == nil {
+		return fmt.Errorf("typed query is not bound to a model")
+	}
+	return q.query.Update(fields...)
+}
+
+// Delete deletes the query's bound item.
+func (q Query[T]) Delete() error {
+	if q.query == nil {
+		return fmt.Errorf("typed query is not bound to a model")
+	}
+	return q.query.Delete()
+}
+
+// Untyped exposes the underlying core.Query for compatibility with APIs not yet
+// wrapped by the generic layer.
+func (q Query[T]) Untyped() core.Query {
+	return q.query
+}

--- a/pkg/typed/typed_test.go
+++ b/pkg/typed/typed_test.go
@@ -1,0 +1,238 @@
+package typed_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/mocks"
+	"github.com/theory-cloud/tabletheory/pkg/query"
+	"github.com/theory-cloud/tabletheory/pkg/typed"
+)
+
+type typedUser struct {
+	PK   string `theorydb:"pk" json:"PK"`
+	SK   string `theorydb:"sk" json:"SK"`
+	Name string `json:"name"`
+}
+
+type typedOrder struct {
+	PK string `theorydb:"pk" json:"PK"`
+}
+
+func TestTypedQueryFirstAllAndOperators(t *testing.T) {
+	db := new(mocks.MockDB)
+	q := new(mocks.MockQuery)
+	db.On("Model", mock.Anything).Return(q)
+	q.On("Where", "SK", string(query.OpBeginsWith), "USER#").Return(q)
+	q.On("First", mock.Anything).Run(func(args mock.Arguments) {
+		dest, ok := args.Get(0).(*typedUser)
+		require.True(t, ok)
+		*dest = typedUser{PK: "TENANT#1", SK: "USER#1", Name: "Ada"}
+	}).Return(nil)
+	q.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		dest, ok := args.Get(0).(*[]typedUser)
+		require.True(t, ok)
+		*dest = []typedUser{{PK: "TENANT#1", SK: "USER#1", Name: "Ada"}}
+	}).Return(nil)
+
+	users := typed.ModelOf[typedUser](db)
+	first, err := users.Query().Where("SK", query.OpBeginsWith, "USER#").First()
+	require.NoError(t, err)
+	require.Equal(t, "Ada", first.Name)
+
+	all, err := users.Query().All()
+	require.NoError(t, err)
+	require.Equal(t, []typedUser{{PK: "TENANT#1", SK: "USER#1", Name: "Ada"}}, all)
+
+	db.AssertExpectations(t)
+	q.AssertExpectations(t)
+}
+
+func TestTypedKeysStayBoundToModelType(t *testing.T) {
+	userKey := typed.NewKey[typedUser]("TENANT#1", "USER#1")
+	require.Equal(t, core.KeyPair{PartitionKey: "TENANT#1", SortKey: "USER#1"}, userKey.Core())
+
+	// This assignment is intentionally absent because it would not compile:
+	// var _ typed.Key[typedUser] = typed.NewKey[typedOrder]("ORDER#1")
+	_ = typed.NewKey[typedOrder]("ORDER#1")
+}
+
+func TestTypedBatchGetUsesTypedKeyInput(t *testing.T) {
+	db := new(mocks.MockDB)
+	q := new(mocks.MockQuery)
+	db.On("Model", mock.Anything).Return(q)
+	q.On("BatchGet", []any{core.NewKeyPair("TENANT#1", "USER#1")}, mock.Anything).Run(func(args mock.Arguments) {
+		dest, ok := args.Get(1).(*[]typedUser)
+		require.True(t, ok)
+		*dest = []typedUser{{PK: "TENANT#1", SK: "USER#1", Name: "Ada"}}
+	}).Return(nil)
+
+	users := typed.ModelOf[typedUser](db)
+	got, err := users.BatchGet([]typed.Key[typedUser]{users.Key("TENANT#1", "USER#1")})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "Ada", got[0].Name)
+
+	db.AssertExpectations(t)
+	q.AssertExpectations(t)
+}
+
+func TestTypedModelCRUDDelegatesToBoundQuery(t *testing.T) {
+	db := new(mocks.MockDB)
+	q := new(mocks.MockQuery)
+	item := &typedUser{PK: "TENANT#1", SK: "USER#1", Name: "Ada"}
+
+	db.On("Model", item).Return(q).Times(4)
+	q.On("Create").Return(nil).Once()
+	q.On("CreateOrUpdate").Return(nil).Once()
+	q.On("Update", []string{"Name"}).Return(nil).Once()
+	q.On("Delete").Return(nil).Once()
+
+	users := typed.ModelOf[typedUser](db)
+	require.NoError(t, users.Create(item))
+	require.NoError(t, users.CreateOrUpdate(item))
+	require.NoError(t, users.Update(item, "Name"))
+	require.NoError(t, users.Delete(item))
+
+	db.AssertExpectations(t)
+	q.AssertExpectations(t)
+}
+
+func TestTypedQueryBuilderDelegatesAndExposesUntyped(t *testing.T) {
+	db := new(mocks.MockDB)
+	q := new(mocks.MockQuery)
+
+	db.On("Model", mock.Anything).Return(q)
+	q.On("Where", "SK", string(query.OpBetween), []any{"USER#1", "USER#9"}).Return(q)
+	q.On("Filter", "Name", string(query.OpContains), "Ada").Return(q)
+	q.On("Index", "gsi1").Return(q)
+	q.On("Limit", 2).Return(q)
+	q.On("Count").Return(int64(7), nil)
+
+	users := typed.ModelOf[typedUser](db)
+	built := users.Query().
+		Between("SK", "USER#1", "USER#9").
+		Filter("Name", query.OpContains, "Ada").
+		Index("gsi1").
+		Limit(2)
+
+	require.Same(t, q, built.Untyped())
+	count, err := built.Count()
+	require.NoError(t, err)
+	require.Equal(t, int64(7), count)
+
+	db.AssertExpectations(t)
+	q.AssertExpectations(t)
+}
+
+func TestTypedGetMissingErrorAndNilHelper(t *testing.T) {
+	db := new(mocks.MockDB)
+	q := new(mocks.MockQuery)
+
+	db.On("Model", mock.Anything).Return(q).Times(2)
+	q.On("BatchGet", []any{core.NewKeyPair("TENANT#1", "USER#404")}, mock.Anything).Return(nil).Times(2)
+
+	users := typed.ModelOf[typedUser](db)
+	key := users.Key("TENANT#1", "USER#404")
+
+	_, err := users.Get(key)
+	require.ErrorIs(t, err, theorydbErrors.ErrItemNotFound)
+
+	got, err := users.GetOrNil(key)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	db.AssertExpectations(t)
+	q.AssertExpectations(t)
+}
+
+func TestTypedGetAndDeleteKeyDelegateThroughTypedKeys(t *testing.T) {
+	db := new(mocks.MockDB)
+	q := new(mocks.MockQuery)
+	key := core.NewKeyPair("TENANT#1", "USER#1")
+
+	db.On("Model", mock.Anything).Return(q).Times(2)
+	q.On("BatchGet", []any{key}, mock.Anything).Run(func(args mock.Arguments) {
+		dest, ok := args.Get(1).(*[]typedUser)
+		require.True(t, ok)
+		*dest = []typedUser{{PK: "TENANT#1", SK: "USER#1", Name: "Ada"}}
+	}).Return(nil).Once()
+	q.On("BatchDelete", []any{key}).Return(nil).Once()
+
+	users := typed.ModelOf[typedUser](db)
+	got, err := users.Get(users.Key("TENANT#1", "USER#1"))
+	require.NoError(t, err)
+	require.Equal(t, "Ada", got.Name)
+	require.NoError(t, users.DeleteKey(users.Key("TENANT#1", "USER#1")))
+
+	db.AssertExpectations(t)
+	q.AssertExpectations(t)
+}
+
+func TestTypedUnboundQueryWriteMethodsFailEarly(t *testing.T) {
+	var q typed.Query[typedUser]
+
+	require.ErrorContains(t, q.Create(), "not bound")
+	require.ErrorContains(t, q.CreateOrUpdate(), "not bound")
+	require.ErrorContains(t, q.Update("Name"), "not bound")
+	require.ErrorContains(t, q.Delete(), "not bound")
+	require.Nil(t, q.Untyped())
+}
+
+func TestTypedQueryFirstOrNilSuccessAndMissing(t *testing.T) {
+	db := new(mocks.MockDB)
+	q := new(mocks.MockQuery)
+
+	db.On("Model", mock.Anything).Return(q).Times(2)
+	q.On("First", mock.Anything).Run(func(args mock.Arguments) {
+		dest, ok := args.Get(0).(*typedUser)
+		require.True(t, ok)
+		*dest = typedUser{PK: "TENANT#1", SK: "USER#1", Name: "Ada"}
+	}).Return(nil).Once()
+	q.On("First", mock.Anything).Return(theorydbErrors.ErrItemNotFound).Once()
+
+	users := typed.ModelOf[typedUser](db)
+	found, err := users.Query().FirstOrNil()
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	require.Equal(t, "Ada", found.Name)
+
+	missing, err := users.Query().FirstOrNil()
+	require.NoError(t, err)
+	require.Nil(t, missing)
+
+	db.AssertExpectations(t)
+	q.AssertExpectations(t)
+}
+
+func TestTypedQueryAndGetReturnUnderlyingErrors(t *testing.T) {
+	db := new(mocks.MockDB)
+	q := new(mocks.MockQuery)
+	boom := errors.New("boom")
+
+	db.On("Model", mock.Anything).Return(q).Times(4)
+	q.On("First", mock.Anything).Return(boom).Once()
+	q.On("All", mock.Anything).Return(boom).Once()
+	q.On("BatchGet", []any{core.NewKeyPair("TENANT#1", "USER#1")}, mock.Anything).Return(boom).Times(2)
+
+	users := typed.ModelOf[typedUser](db)
+	_, err := users.Query().First()
+	require.ErrorIs(t, err, boom)
+
+	_, err = users.Query().All()
+	require.ErrorIs(t, err, boom)
+
+	_, err = users.Get(users.Key("TENANT#1", "USER#1"))
+	require.ErrorIs(t, err, boom)
+
+	_, err = users.GetOrNil(users.Key("TENANT#1", "USER#1"))
+	require.ErrorIs(t, err, boom)
+
+	db.AssertExpectations(t)
+	q.AssertExpectations(t)
+}

--- a/py/docs/api-reference.md
+++ b/py/docs/api-reference.md
@@ -6,7 +6,7 @@
 ## Imports
 
 ```python
-from tabletheory_py import ModelDefinition, Table, theorydb_field
+from tabletheory_py import DynamoDBClientProtocol, ModelDefinition, Role, Table, theorydb_field
 from tabletheory_py import SortKeyCondition
 from tabletheory_py import unmarshal_stream_record
 from tabletheory_py import (
@@ -25,7 +25,14 @@ from tabletheory_py.mocks import FakeDynamoDBClient, FakeKmsClient
 
 ### `theorydb_field(...)`
 
-Declares attribute metadata for dataclass fields (roles, omitempty, encryption, defaults, converters, etc.).
+Declares attribute metadata for dataclass fields (roles, omitempty, encryption, defaults, converters, etc.). Role strings remain supported; new code can use `Role` constants for typo-resistant type checking.
+
+```python
+@dataclass(frozen=True)
+class User:
+    pk: str = theorydb_field(name='PK', roles=[Role.PK])
+    sk: str = theorydb_field(name='SK', roles=[Role.SK])
+```
 
 ### `ModelDefinition.from_dataclass(dataclass_type, table_name=...)`
 
@@ -35,9 +42,7 @@ Builds a model definition from a dataclass and a table name.
 
 ### `Table(model, *, client=None, table_name=None, kms_key_arn=None, kms_client=None, rand_bytes=None, now=None)`
 
-Primary entrypoint for operations. `client` is a boto3-compatible DynamoDB client; when omitted, `Table` constructs one
-with `boto3.client("dynamodb")`. If any model attribute is encrypted, construction fails closed unless `kms_key_arn` is
-provided.
+Primary entrypoint for operations. `client` is typed as `DynamoDBClientProtocol` (a boto3-compatible DynamoDB client protocol with `query`, `scan`, `get_item`, `put_item`, batch, transaction, delete, and update methods); when omitted, `Table` constructs one with `boto3.client("dynamodb")`. If any model attribute is encrypted, construction fails closed unless `kms_key_arn` is provided.
 
 ### CRUD
 

--- a/py/src/theorydb_py/__init__.py
+++ b/py/src/theorydb_py/__init__.py
@@ -28,6 +28,7 @@ from .model import (
     ModelDefinition,
     ModelDefinitionError,
     Projection,
+    Role,
     WritePolicy,
     gsi,
     lsi,
@@ -62,6 +63,7 @@ if TYPE_CHECKING:
     from .multiaccount import AccountConfig, MultiAccountSessions
     from .optimizer import QueryOptimizer, QueryPlan, QueryShape, ScanShape
     from .protection import ConcurrencyLimiter, SimpleLimiter
+    from .protocols import DynamoDBClientProtocol
     from .release_state import transition_release_state, validate_deploy_authority_metadata
     from .runtime import (
         DEFAULT_LAMBDA_TIMEOUT_BUFFER_SECONDS,
@@ -151,10 +153,11 @@ def __getattr__(name: str) -> Any:
         from . import schema
 
         return getattr(schema, name)
-    if name == "Table":
+    if name in {"DynamoDBClientProtocol", "Table"}:
+        from .protocols import DynamoDBClientProtocol
         from .table import Table
 
-        return Table
+        return {"DynamoDBClientProtocol": DynamoDBClientProtocol, "Table": Table}[name]
     if name in {
         "AggregateResult",
         "GroupByQuery",
@@ -258,6 +261,7 @@ __all__ = [
     "create_lambda_boto3_config",
     "create_table",
     "delete_table",
+    "DynamoDBClientProtocol",
     "TheorydbPyError",
     "describe_table",
     "group_by",
@@ -278,6 +282,7 @@ __all__ = [
     "ModelDefinitionError",
     "NotFoundError",
     "Projection",
+    "Role",
     "ProtectedFieldMutationError",
     "RejectedDeployAuthorityEvidenceError",
     "FilterCondition",

--- a/py/src/theorydb_py/model.py
+++ b/py/src/theorydb_py/model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import MISSING, dataclass, field, fields, is_dataclass
+from enum import StrEnum
 from typing import Any, Protocol, cast, get_type_hints, overload
 
 from .attr_types import infer_storage_type, validate_json_storage_type
@@ -10,6 +11,24 @@ from .errors import ValidationError
 
 class ModelDefinitionError(ValueError):
     pass
+
+
+class Role(StrEnum):
+    PK = "pk"
+    SK = "sk"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+    VERSION = "version"
+    TTL = "ttl"
+
+
+RoleLike = str | Role
+
+
+def _normalize_role(role: RoleLike) -> str:
+    if isinstance(role, Role):
+        return role.value
+    return role
 
 
 class AttributeConverter(Protocol):
@@ -111,7 +130,7 @@ def _resolve_write_policy(
 def theorydb_field(
     *,
     name: str | None = None,
-    roles: Sequence[str] | None = None,
+    roles: Sequence[RoleLike] | None = None,
     omitempty: bool = False,
     set_: bool = False,
     json: bool = False,
@@ -127,7 +146,7 @@ def theorydb_field(
 def theorydb_field(
     *,
     name: str | None = None,
-    roles: Sequence[str] | None = None,
+    roles: Sequence[RoleLike] | None = None,
     omitempty: bool = False,
     set_: bool = False,
     json: bool = False,
@@ -144,7 +163,7 @@ def theorydb_field(
 def theorydb_field(
     *,
     name: str | None = None,
-    roles: Sequence[str] | None = None,
+    roles: Sequence[RoleLike] | None = None,
     omitempty: bool = False,
     set_: bool = False,
     json: bool = False,
@@ -160,7 +179,7 @@ def theorydb_field(
 def theorydb_field(
     *,
     name: str | None = None,
-    roles: Sequence[str] | None = None,
+    roles: Sequence[RoleLike] | None = None,
     omitempty: bool = False,
     set_: bool = False,
     json: bool = False,
@@ -186,7 +205,7 @@ def theorydb_field(
     if name is not None:
         theorydb["name"] = name
     if roles is not None:
-        theorydb["roles"] = list(roles)
+        theorydb["roles"] = [_normalize_role(role) for role in roles]
 
     return field(default=default, default_factory=default_factory, metadata={"theorydb": theorydb})
 

--- a/py/src/theorydb_py/protocols.py
+++ b/py/src/theorydb_py/protocols.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+
+class DynamoDBClientProtocol(Protocol):
+    def query(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
+    def scan(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
+    def batch_get_item(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
+    def batch_write_item(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
+    def transact_get_items(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
+    def transact_write_items(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
+    def put_item(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
+    def get_item(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
+    def delete_item(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
+    def update_item(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass

--- a/py/src/theorydb_py/table.py
+++ b/py/src/theorydb_py/table.py
@@ -26,6 +26,7 @@ from .errors import (
     ValidationError,
 )
 from .model import AttributeDefinition, ModelDefinition
+from .protocols import DynamoDBClientProtocol as DynamoDBClientProtocol
 from .query import (
     FilterCondition,
     FilterExpression,
@@ -119,7 +120,7 @@ class Table[T]:
         self,
         model: ModelDefinition[T],
         *,
-        client: Any | None = None,
+        client: DynamoDBClientProtocol | None = None,
         table_name: str | None = None,
         kms_key_arn: str | None = None,
         kms_client: Any | None = None,
@@ -133,7 +134,9 @@ class Table[T]:
 
         self._model = model
         self._table_name = table_name
-        self._client: Any = client or boto3.client("dynamodb")
+        self._client: DynamoDBClientProtocol = client or cast(
+            DynamoDBClientProtocol, boto3.client("dynamodb")
+        )
         self._kms_key_arn = (kms_key_arn or "").strip() or None
         self._kms_client: Any | None = kms_client
         self._rand_bytes = rand_bytes or os.urandom
@@ -159,7 +162,7 @@ class Table[T]:
             return self
         return Table(
             self._model,
-            client=client,
+            client=cast(DynamoDBClientProtocol, client),
             table_name=self._table_name,
             kms_key_arn=self._kms_key_arn,
             kms_client=self._kms_client,

--- a/py/tests/types/typed_api_mypy.py
+++ b/py/tests/types/typed_api_mypy.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from theorydb_py.model import ModelDefinition, Role, theorydb_field
+from theorydb_py.table import DynamoDBClientProtocol, Table
+
+
+@dataclass(frozen=True)
+class User:
+    pk: str = theorydb_field(name="PK", roles=[Role.PK])
+    sk: str = theorydb_field(name="SK", roles=[Role.SK])
+    ttl: int = theorydb_field(name="ttl", roles=[Role.TTL], default=0)
+
+
+class FakeDynamoDBClient:
+    def query(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def scan(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def batch_get_item(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def batch_write_item(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def transact_get_items(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def put_item(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def get_item(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def delete_item(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def update_item(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+
+def type_assertions(client: DynamoDBClientProtocol) -> None:
+    model = ModelDefinition.from_dataclass(User, table_name="users")
+    Table(model, client=client)
+    Table(model, client=FakeDynamoDBClient())
+
+    # These ignores must remain used: Role typos and non-DynamoDB clients should fail type checking.
+    theorydb_field(roles=[Role.PKK])  # type: ignore[attr-defined]
+    Table(model, client=object())  # type: ignore[arg-type]
+
+
+__all__ = ["FakeDynamoDBClient", "User", "type_assertions"]

--- a/py/tests/unit/test_model_definition.py
+++ b/py/tests/unit/test_model_definition.py
@@ -8,6 +8,7 @@ from theorydb_py.model import (
     ModelDefinition,
     ModelDefinitionError,
     Projection,
+    Role,
     WritePolicy,
     gsi,
     lsi,
@@ -17,10 +18,10 @@ from theorydb_py.model import (
 
 @dataclass(frozen=True)
 class User:
-    pk: str = theorydb_field(name="PK", roles=["pk"])
-    sk: str = theorydb_field(name="SK", roles=["sk"])
+    pk: str = theorydb_field(name="PK", roles=[Role.PK])
+    sk: str = theorydb_field(name="SK", roles=[Role.SK])
     email_hash: str = theorydb_field(name="emailHash", omitempty=True)
-    created_at: str = theorydb_field(name="createdAt", roles=["created_at"])
+    created_at: str = theorydb_field(name="createdAt", roles=[Role.CREATED_AT])
     tags: set[str] = theorydb_field(name="tags", set_=True, omitempty=True, default_factory=set)
     payload: dict[str, int] = theorydb_field(name="payload", json=True, omitempty=True, default_factory=dict)
     blob: bytes = theorydb_field(name="blob", binary=True, omitempty=True, default=b"")
@@ -50,6 +51,20 @@ def test_model_definition_extracts_keys_attributes_and_indexes() -> None:
     assert len(model.indexes) == 2
     assert model.indexes[0].type == "GSI" and model.indexes[0].partition == "emailHash"
     assert model.indexes[1].type == "LSI" and model.indexes[1].partition == "PK"
+
+
+def test_model_definition_accepts_role_constants_and_strings() -> None:
+    @dataclass(frozen=True)
+    class MixedRoles:
+        pk: str = theorydb_field(roles=[Role.PK])
+        sk: str = theorydb_field(roles=["sk"])
+        ttl: int = theorydb_field(roles=[Role.TTL], default=0)
+
+    model = ModelDefinition.from_dataclass(MixedRoles)
+
+    assert model.pk.roles == ("pk",)
+    assert model.sk is not None and model.sk.roles == ("sk",)
+    assert model.attributes["ttl"].roles == ("ttl",)
 
 
 def test_model_definition_rejects_missing_pk() -> None:

--- a/py/tests/unit/test_protocols.py
+++ b/py/tests/unit/test_protocols.py
@@ -1,0 +1,22 @@
+from theorydb_py.protocols import DynamoDBClientProtocol
+
+
+class _ProtocolStub(DynamoDBClientProtocol):
+    pass
+
+
+def test_dynamodb_client_protocol_methods_are_typing_only() -> None:
+    stub = _ProtocolStub()
+    for method_name in (
+        "query",
+        "scan",
+        "batch_get_item",
+        "batch_write_item",
+        "transact_get_items",
+        "transact_write_items",
+        "put_item",
+        "get_item",
+        "delete_item",
+        "update_item",
+    ):
+        assert getattr(stub, method_name)() is None

--- a/tabletheory.go
+++ b/tabletheory.go
@@ -17,6 +17,7 @@ import (
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	"github.com/theory-cloud/tabletheory/pkg/schema"
 	"github.com/theory-cloud/tabletheory/pkg/session"
+	"github.com/theory-cloud/tabletheory/pkg/typed"
 )
 
 type (
@@ -34,6 +35,7 @@ type (
 	AutoMigrateOption = schema.AutoMigrateOption
 	BatchGetOptions   = core.BatchGetOptions
 	KeyPair           = core.KeyPair
+	TypedExtendedDB   = core.TypedExtendedDB
 )
 
 // Re-export AutoMigrate options for convenience.
@@ -67,6 +69,14 @@ func NewBasic(config session.Config) (core.DB, error) {
 
 func NewKeyPair(partitionKey any, sortKey ...any) core.KeyPair {
 	return internaltheorydb.NewKeyPair(partitionKey, sortKey...)
+}
+
+func ModelOf[T any](db core.DB) typed.Model[T] {
+	return typed.ModelOf[T](db)
+}
+
+func NewTypedKey[T any](partitionKey any, sortKey ...any) typed.Key[T] {
+	return typed.NewKey[T](partitionKey, sortKey...)
 }
 
 func DefaultBatchGetOptions() *core.BatchGetOptions {

--- a/ts/docs/api-reference.md
+++ b/ts/docs/api-reference.md
@@ -13,12 +13,14 @@ import {
   createLambdaDynamoDBClient,
   createLambdaTimeoutSignal,
   defineModel,
+  unsafeOperator,
   withLambdaTimeout,
   type BatchGetResult,
   type BatchWriteResult,
   type EncryptionProvider,
   type LambdaContextLike,
   type Model,
+  type ModelItem,
   type Page,
   type SendOptions,
   type TransactAction,
@@ -42,8 +44,21 @@ Defines a model with explicit attribute names and roles.
 - `indexes`: optional GSI/LSI definitions with explicit key attributes
 - `write_policy`: optional write-once/protected-attribute policy
 
-`defineModel` returns a runtime model descriptor. It does not currently infer a schema-specific TypeScript item type for
-`TheorydbClient`; client item payloads are still `Record<string, unknown>`.
+`defineModel<const S>(...)` returns a runtime model descriptor whose item type is inferred from literal schema attributes. Required attributes remain required; `optional`, `omit_empty`, and lifecycle-managed roles such as `created_at`, `updated_at`, `version`, and `ttl` are optional in the inferred call-site type.
+
+```ts
+const User = defineModel({
+  name: 'User',
+  table: { name: 'users' },
+  keys: { partition: { attribute: 'PK', type: 'S' } },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'age', type: 'N' },
+  ],
+});
+
+type UserItem = ModelItem<typeof User>; // { PK: string; age: number }
+```
 
 See [Core Patterns](./core-patterns.md) for canonical model definitions.
 
@@ -72,6 +87,21 @@ Options:
 ### `register(...models: Model[]): this`
 
 Registers one or more model definitions and returns the same client.
+
+### `model(model: Model)` / `model(modelName: string)`
+
+Returns a repository handle for one model. Passing a model descriptor preserves the inferred item type; string lookup remains available and intentionally returns the existing untyped `Record<string, unknown>` boundary.
+
+```ts
+const db = new TheorydbClient(ddb);
+const users = db.model(User);
+
+await users.create({ PK: 'USER#1', age: 42 });
+const got = await users.get({ PK: 'USER#1' }); // UserItem
+await users.update({ ...got, age: 43 }, ['age']);
+
+await db.model('User').create({ stringLookup: 'stays untyped' });
+```
 
 ### `withEncryption(provider: EncryptionProvider): this`
 
@@ -170,12 +200,13 @@ Key, cursor, and page methods:
 - `consistentRead(enabled = true): this` (rejected for GSIs)
 - `limit(n: number): this`
 - `projection(fields: string[]): this`
+- `filter(field, op, ...values): this`, where `op` is a known operator literal (`'='`, `'BETWEEN'`, `'BEGINS_WITH'`, etc.) or `unsafeOperator(value)` for explicit runtime-validation escape hatches
 - `cursor(encoded: string): this`
-- `page(): Promise<Page>`
-- `pages(): AsyncGenerator<Page>`
-- `items(): AsyncGenerator<Record<string, unknown>>`
-- `all(): Promise<Array<Record<string, unknown>>>`
-- `pageWithRetry(options?): Promise<Page>`
+- `page(): Promise<Page<TItem>>` for typed repository handles, otherwise `Promise<Page<Record<string, unknown>>>`
+- `pages(): AsyncGenerator<Page<TItem>>`
+- `items(): AsyncGenerator<TItem>`
+- `all(): Promise<TItem[]>`
+- `pageWithRetry(options?): Promise<Page<TItem>>`
 - `describe(): BuilderShape`
 
 Prefer `pages()` or `items()` for large result sets. They fetch one DynamoDB page at a time and stop fetching when the

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -27,7 +27,7 @@ import {
 } from './batch.js';
 import { mapDynamoError } from './dynamo-error.js';
 import { hasTheorydbErrorCode, TheorydbError } from './errors.js';
-import type { Model } from './model.js';
+import type { Model, ModelItem } from './model.js';
 import type { SendOptions } from './send-options.js';
 import {
   isEmpty,
@@ -69,6 +69,82 @@ export interface TheorydbClientOptions {
    * Use 'string' to receive canonical DynamoDB decimal strings for exact reads.
    */
   numberUnmarshalMode?: NumberUnmarshalMode;
+}
+
+type ModelKey<TItem extends Record<string, unknown>> = Partial<TItem>;
+type ModelField<TItem extends Record<string, unknown>> = Extract<
+  keyof TItem,
+  string
+>;
+
+export class ModelRepository<
+  TItem extends Record<string, unknown> = Record<string, unknown>,
+> {
+  constructor(
+    private readonly client: TheorydbClient,
+    private readonly modelDef: Model<TItem>,
+  ) {}
+
+  create(item: TItem, opts: { ifNotExists?: boolean } = {}): Promise<void> {
+    return this.client.create(this.modelDef.name, item, opts);
+  }
+
+  save(item: TItem): Promise<void> {
+    return this.client.save(this.modelDef.name, item);
+  }
+
+  async get(key: ModelKey<TItem>): Promise<TItem> {
+    return (await this.client.get(this.modelDef.name, key)) as TItem;
+  }
+
+  async getOrNull(key: ModelKey<TItem>): Promise<TItem | null> {
+    return (await this.client.getOrNull(
+      this.modelDef.name,
+      key,
+    )) as TItem | null;
+  }
+
+  update(
+    item: TItem,
+    fields: readonly ModelField<TItem>[],
+    opts: WritePolicyOptions = {},
+  ): Promise<void> {
+    return this.client.update(this.modelDef.name, item, [...fields], opts);
+  }
+
+  delete(key: ModelKey<TItem>): Promise<void> {
+    return this.client.delete(this.modelDef.name, key);
+  }
+
+  async batchGet(
+    keys: Array<ModelKey<TItem>>,
+    opts: RetryOptions & { consistentRead?: boolean } = {},
+  ): Promise<BatchGetResult<TItem>> {
+    const result = await this.client.batchGet(this.modelDef.name, keys, opts);
+    return result as BatchGetResult<TItem>;
+  }
+
+  batchWrite(
+    req: {
+      puts?: TItem[];
+      deletes?: Array<ModelKey<TItem>>;
+    },
+    opts: RetryOptions = {},
+  ): Promise<BatchWriteResult> {
+    return this.client.batchWrite(this.modelDef.name, req, opts);
+  }
+
+  query(): QueryBuilder<TItem> {
+    return this.client.query(this.modelDef.name) as QueryBuilder<TItem>;
+  }
+
+  scan(): ScanBuilder<TItem> {
+    return this.client.scan(this.modelDef.name) as ScanBuilder<TItem>;
+  }
+
+  updateBuilder(key: ModelKey<TItem>): UpdateBuilder {
+    return this.client.updateBuilder(this.modelDef.name, key);
+  }
 }
 
 export class TheorydbClient {
@@ -122,6 +198,16 @@ export class TheorydbClient {
       this.models.set(model.name, model);
     }
     return this;
+  }
+
+  model<M extends Model>(model: M): ModelRepository<ModelItem<M>>;
+  model(modelName: string): ModelRepository<Record<string, unknown>>;
+  model(modelOrName: string | Model): ModelRepository<Record<string, unknown>> {
+    const model =
+      typeof modelOrName === 'string'
+        ? this.requireModel(modelOrName)
+        : this.register(modelOrName).requireModel(modelOrName.name);
+    return new ModelRepository(this, model);
   }
 
   private requireModel(name: string): Model {

--- a/ts/src/model.ts
+++ b/ts/src/model.ts
@@ -32,7 +32,7 @@ export interface AttributeSchema {
   json?: boolean;
   binary?: boolean;
   format?: string;
-  roles?: string[];
+  roles?: readonly string[];
   encryption?: unknown;
   converter?: ValueConverter;
 }
@@ -47,7 +47,7 @@ export interface IndexSchema {
 
 export interface WritePolicySchema {
   mode?: 'mutable' | 'write_once';
-  protected_attributes?: string[];
+  protected_attributes?: readonly string[];
 }
 
 export interface WritePolicy {
@@ -64,8 +64,8 @@ export interface ModelSchema {
     sort?: KeySchema;
   };
   write_policy?: WritePolicySchema;
-  attributes: AttributeSchema[];
-  indexes?: IndexSchema[];
+  attributes: readonly AttributeSchema[];
+  indexes?: readonly IndexSchema[];
 }
 
 export interface ModelRoles {
@@ -77,7 +77,9 @@ export interface ModelRoles {
   ttl?: string;
 }
 
-export interface Model {
+export interface Model<
+  TItem extends Record<string, unknown> = Record<string, unknown>,
+> {
   readonly name: string;
   readonly tableName: string;
   readonly schema: Readonly<ModelSchema>;
@@ -85,7 +87,77 @@ export interface Model {
   readonly indexes: ReadonlyMap<string, Readonly<IndexSchema>>;
   readonly roles: Readonly<ModelRoles>;
   readonly writePolicy: Readonly<WritePolicy>;
+  readonly __itemType?: TItem;
 }
+
+type AttributeValueFor<A extends AttributeSchema> = A['type'] extends 'S'
+  ? string
+  : A['type'] extends 'N'
+    ? number
+    : A['type'] extends 'B'
+      ? Uint8Array
+      : A['type'] extends 'BOOL'
+        ? boolean
+        : A['type'] extends 'NULL'
+          ? null
+          : A['type'] extends 'SS'
+            ? string[]
+            : A['type'] extends 'NS'
+              ? number[]
+              : A['type'] extends 'BS'
+                ? Uint8Array[]
+                : A['type'] extends 'L'
+                  ? unknown[]
+                  : A['type'] extends 'M'
+                    ? Record<string, unknown>
+                    : unknown;
+
+type AttributeHasRole<
+  A extends AttributeSchema,
+  R extends string,
+> = A['roles'] extends readonly string[]
+  ? R extends A['roles'][number]
+    ? true
+    : false
+  : false;
+
+type IsOptionalAttribute<A extends AttributeSchema> = A extends {
+  optional: true;
+}
+  ? true
+  : A extends { omit_empty: true }
+    ? true
+    : AttributeHasRole<A, 'created_at'> extends true
+      ? true
+      : AttributeHasRole<A, 'updated_at'> extends true
+        ? true
+        : AttributeHasRole<A, 'version'> extends true
+          ? true
+          : AttributeHasRole<A, 'ttl'> extends true
+            ? true
+            : false;
+
+type AttributeName<A extends AttributeSchema> = A['attribute'] extends string
+  ? A['attribute']
+  : never;
+
+type RequiredAttributes<S extends ModelSchema> = {
+  [A in S['attributes'][number] as IsOptionalAttribute<A> extends true
+    ? never
+    : AttributeName<A>]: AttributeValueFor<A>;
+};
+
+type OptionalAttributes<S extends ModelSchema> = {
+  [A in S['attributes'][number] as IsOptionalAttribute<A> extends true
+    ? AttributeName<A>
+    : never]?: AttributeValueFor<A>;
+};
+
+export type InferModelItem<S extends ModelSchema> = RequiredAttributes<S> &
+  OptionalAttributes<S>;
+
+export type ModelItem<M extends Model> =
+  M extends Model<infer TItem> ? TItem : Record<string, unknown>;
 
 function isSupportedJsonStorageType(type: ScalarType): boolean {
   return (
@@ -98,7 +170,9 @@ function isSupportedJsonStorageType(type: ScalarType): boolean {
   );
 }
 
-export function defineModel(schema: ModelSchema): Model {
+export function defineModel<const S extends ModelSchema>(
+  schema: S,
+): Model<InferModelItem<S>> {
   validateModelSchema(schema);
 
   const attributes = new Map<string, AttributeSchema>();

--- a/ts/src/query-types.ts
+++ b/ts/src/query-types.ts
@@ -1,0 +1,57 @@
+declare const operatorEscapeBrand: unique symbol;
+
+export type KnownOperator =
+  | '='
+  | '!='
+  | '<>'
+  | '<'
+  | '<='
+  | '>'
+  | '>='
+  | 'BETWEEN'
+  | 'IN'
+  | 'BEGINS_WITH'
+  | 'CONTAINS'
+  | 'EXISTS'
+  | 'NOT_EXISTS'
+  | 'ATTRIBUTE_EXISTS'
+  | 'ATTRIBUTE_NOT_EXISTS'
+  | 'EQ'
+  | 'NE'
+  | 'LT'
+  | 'LE'
+  | 'GT'
+  | 'GE'
+  | 'between'
+  | 'in'
+  | 'begins_with'
+  | 'contains'
+  | 'exists'
+  | 'not_exists'
+  | 'attribute_exists'
+  | 'attribute_not_exists';
+
+export type OperatorEscape = string & {
+  readonly [operatorEscapeBrand]: true;
+};
+
+export type QueryOperator = KnownOperator | OperatorEscape;
+
+export function unsafeOperator(operator: string): OperatorEscape {
+  return operator as OperatorEscape;
+}
+
+export interface Page<T = Record<string, unknown>> {
+  items: T[];
+  cursor?: string;
+}
+
+export interface QueryRetryOptions<T = Record<string, unknown>> {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+  retryOnEmpty?: boolean;
+  retryOnError?: boolean;
+  verify?: (page: Page<T>) => boolean;
+}

--- a/ts/src/query.ts
+++ b/ts/src/query.ts
@@ -39,25 +39,19 @@ import { mapConcurrent } from './query-concurrency.js';
 import { itemIterator, pageIterator } from './query-iterators.js';
 import { countAllPages } from './query-count.js';
 import type { SendOptions } from './send-options.js';
-
-export interface Page<T = Record<string, unknown>> {
-  items: T[];
-  cursor?: string;
-}
-
-export interface QueryRetryOptions {
-  maxAttempts?: number;
-  baseDelayMs?: number;
-  maxDelayMs?: number;
-  backoffFactor?: number;
-  retryOnEmpty?: boolean;
-  retryOnError?: boolean;
-  verify?: (page: Page) => boolean;
-}
+import type { Page, QueryOperator, QueryRetryOptions } from './query-types.js';
+export { unsafeOperator } from './query-types.js';
+export type {
+  KnownOperator,
+  OperatorEscape,
+  Page,
+  QueryOperator,
+  QueryRetryOptions,
+} from './query-types.js';
 
 export interface FilterGroupBuilder {
-  filter(field: string, op: string, ...values: unknown[]): this;
-  orFilter(field: string, op: string, ...values: unknown[]): this;
+  filter(field: string, op: QueryOperator, ...values: unknown[]): this;
+  orFilter(field: string, op: QueryOperator, ...values: unknown[]): this;
   filterGroup(fn: (b: FilterGroupBuilder) => void): this;
   orFilterGroup(fn: (b: FilterGroupBuilder) => void): this;
 }
@@ -88,12 +82,12 @@ class FilterExpressionBuilder implements FilterGroupBuilder {
       } satisfies FilterExpressionBuilder['state']);
   }
 
-  filter(field: string, op: string, ...values: unknown[]): this {
+  filter(field: string, op: QueryOperator, ...values: unknown[]): this {
     this.addCondition('AND', field, op, values);
     return this;
   }
 
-  orFilter(field: string, op: string, ...values: unknown[]): this {
+  orFilter(field: string, op: QueryOperator, ...values: unknown[]): this {
     this.addCondition('OR', field, op, values);
     return this;
   }
@@ -134,7 +128,7 @@ class FilterExpressionBuilder implements FilterGroupBuilder {
   private addCondition(
     logicalOp: 'AND' | 'OR',
     field: string,
-    op: string,
+    op: QueryOperator,
     values: unknown[],
   ): void {
     const schema = this.model.attributes.get(field);
@@ -299,7 +293,9 @@ function singleValue(values: unknown[], op: string): unknown {
   return values[0];
 }
 
-export class QueryBuilder {
+export class QueryBuilder<
+  TItem extends Record<string, unknown> = Record<string, unknown>,
+> {
   private indexName?: string;
   private pkValue?: unknown;
   private skCondition?: {
@@ -348,12 +344,12 @@ export class QueryBuilder {
     return this;
   }
 
-  filter(field: string, op: string, ...values: unknown[]): this {
+  filter(field: string, op: QueryOperator, ...values: unknown[]): this {
     this.filters.filter(field, op, ...values);
     return this;
   }
 
-  orFilter(field: string, op: string, ...values: unknown[]): this {
+  orFilter(field: string, op: QueryOperator, ...values: unknown[]): this {
     this.filters.orFilter(field, op, ...values);
     return this;
   }
@@ -386,7 +382,7 @@ export class QueryBuilder {
     return this;
   }
 
-  async page(): Promise<Page> {
+  async page(): Promise<Page<TItem>> {
     const { pkName, pkSchema, skName, skSchema, index } =
       this.resolveKeySchema();
     if (this.pkValue === undefined)
@@ -546,7 +542,7 @@ export class QueryBuilder {
       cursor = encodeCursor(c);
     }
 
-    const page: Page = { items };
+    const page: Page<TItem> = { items: items as TItem[] };
     if (cursor) page.cursor = cursor;
     return page;
   }
@@ -696,10 +692,10 @@ export class QueryBuilder {
     return out;
   }
 
-  async all(): Promise<Array<Record<string, unknown>>> {
+  async all(): Promise<TItem[]> {
     const original = this.cursorToken;
     try {
-      const out: Array<Record<string, unknown>> = [];
+      const out: TItem[] = [];
       let cursor = original;
 
       for (;;) {
@@ -716,7 +712,7 @@ export class QueryBuilder {
     }
   }
 
-  pages(): AsyncGenerator<Page<Record<string, unknown>>> {
+  pages(): AsyncGenerator<Page<TItem>> {
     return pageIterator(
       () => this.cursorToken,
       (cursor) => {
@@ -726,7 +722,7 @@ export class QueryBuilder {
     );
   }
 
-  items(): AsyncGenerator<Record<string, unknown>> {
+  items(): AsyncGenerator<TItem> {
     return itemIterator(this.pages());
   }
 
@@ -782,7 +778,7 @@ export class QueryBuilder {
    * Client-side aggregation: the returned group query calls `all()` during `execute()` and keeps groups in memory.
    * Use only for bounded result sets; use native `count()` for count-only reads.
    */
-  groupBy(field: string): GroupByQuery<Record<string, unknown>> {
+  groupBy(field: string): GroupByQuery<TItem> {
     return new GroupByQuery(() => this.all(), field);
   }
 
@@ -807,7 +803,9 @@ export class QueryBuilder {
     };
   }
 
-  async pageWithRetry(opts: QueryRetryOptions = {}): Promise<Page> {
+  async pageWithRetry(
+    opts: QueryRetryOptions<TItem> = {},
+  ): Promise<Page<TItem>> {
     const maxAttempts = opts.maxAttempts ?? 5;
     if (!Number.isInteger(maxAttempts) || maxAttempts <= 0) {
       throw new TheorydbError(
@@ -823,7 +821,7 @@ export class QueryBuilder {
     const maxDelay = opts.maxDelayMs ?? 5_000;
     const backoff = opts.backoffFactor ?? 2;
 
-    let lastPage: Page | undefined;
+    let lastPage: Page<TItem> | undefined;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         const page = await this.page();
@@ -924,7 +922,9 @@ export class QueryBuilder {
   }
 }
 
-export class ScanBuilder {
+export class ScanBuilder<
+  TItem extends Record<string, unknown> = Record<string, unknown>,
+> {
   private indexName?: string;
   private limitCount?: number;
   private projectionFields?: string[];
@@ -964,12 +964,12 @@ export class ScanBuilder {
     return this;
   }
 
-  filter(field: string, op: string, ...values: unknown[]): this {
+  filter(field: string, op: QueryOperator, ...values: unknown[]): this {
     this.filters.filter(field, op, ...values);
     return this;
   }
 
-  orFilter(field: string, op: string, ...values: unknown[]): this {
+  orFilter(field: string, op: QueryOperator, ...values: unknown[]): this {
     this.filters.orFilter(field, op, ...values);
     return this;
   }
@@ -1016,7 +1016,7 @@ export class ScanBuilder {
   async scanAllSegments(
     totalSegments: number,
     opts: { concurrency?: number } = {},
-  ): Promise<Array<Record<string, unknown>>> {
+  ): Promise<TItem[]> {
     const index = this.indexName
       ? this.model.indexes.get(this.indexName)
       : undefined;
@@ -1124,8 +1124,8 @@ export class ScanBuilder {
       },
     );
 
-    const out: Array<Record<string, unknown>> = [];
-    for (const r of results) out.push(...r);
+    const out: TItem[] = [];
+    for (const r of results) out.push(...(r as TItem[]));
     return out;
   }
 
@@ -1223,10 +1223,10 @@ export class ScanBuilder {
     return out;
   }
 
-  async all(): Promise<Array<Record<string, unknown>>> {
+  async all(): Promise<TItem[]> {
     const original = this.cursorToken;
     try {
-      const out: Array<Record<string, unknown>> = [];
+      const out: TItem[] = [];
       let cursor = original;
 
       for (;;) {
@@ -1243,7 +1243,7 @@ export class ScanBuilder {
     }
   }
 
-  pages(): AsyncGenerator<Page<Record<string, unknown>>> {
+  pages(): AsyncGenerator<Page<TItem>> {
     return pageIterator(
       () => this.cursorToken,
       (cursor) => {
@@ -1253,7 +1253,7 @@ export class ScanBuilder {
     );
   }
 
-  items(): AsyncGenerator<Record<string, unknown>> {
+  items(): AsyncGenerator<TItem> {
     return itemIterator(this.pages());
   }
 
@@ -1309,7 +1309,7 @@ export class ScanBuilder {
    * Client-side aggregation: the returned group query calls `all()` during `execute()` and keeps groups in memory.
    * Use only for bounded result sets; use native `count()` for count-only reads.
    */
-  groupBy(field: string): GroupByQuery<Record<string, unknown>> {
+  groupBy(field: string): GroupByQuery<TItem> {
     return new GroupByQuery(() => this.all(), field);
   }
 
@@ -1337,7 +1337,7 @@ export class ScanBuilder {
     };
   }
 
-  async page(): Promise<Page> {
+  async page(): Promise<Page<TItem>> {
     const index = this.indexName
       ? this.model.indexes.get(this.indexName)
       : undefined;
@@ -1446,12 +1446,14 @@ export class ScanBuilder {
       cursor = encodeCursor(c);
     }
 
-    const page: Page = { items };
+    const page: Page<TItem> = { items: items as TItem[] };
     if (cursor) page.cursor = cursor;
     return page;
   }
 
-  async pageWithRetry(opts: QueryRetryOptions = {}): Promise<Page> {
+  async pageWithRetry(
+    opts: QueryRetryOptions<TItem> = {},
+  ): Promise<Page<TItem>> {
     const maxAttempts = opts.maxAttempts ?? 5;
     if (!Number.isInteger(maxAttempts) || maxAttempts <= 0) {
       throw new TheorydbError(
@@ -1467,7 +1469,7 @@ export class ScanBuilder {
     const maxDelay = opts.maxDelayMs ?? 5_000;
     const backoff = opts.backoffFactor ?? 2;
 
-    let lastPage: Page | undefined;
+    let lastPage: Page<TItem> | undefined;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         const page = await this.page();

--- a/ts/src/update-builder.ts
+++ b/ts/src/update-builder.ts
@@ -25,6 +25,7 @@ import {
   assertMutableWritePolicy,
   assertProtectedFieldsCanMutate,
 } from './write-policy.js';
+import type { QueryOperator } from './query-types.js';
 
 export type ReturnValuesOption =
   | 'NONE'
@@ -47,7 +48,7 @@ type UpdateOp =
 type ConditionOp = {
   logicOp: 'AND' | 'OR';
   field: string;
-  operator: string;
+  operator: QueryOperator;
   value?: unknown;
 };
 
@@ -70,11 +71,11 @@ class ConditionExpressionBuilder {
 
   constructor(private readonly model: Model) {}
 
-  and(field: string, op: string, value?: unknown): void {
+  and(field: string, op: QueryOperator, value?: unknown): void {
     this.addCondition('AND', field, op, value);
   }
 
-  or(field: string, op: string, value?: unknown): void {
+  or(field: string, op: QueryOperator, value?: unknown): void {
     this.addCondition('OR', field, op, value);
   }
 
@@ -94,7 +95,7 @@ class ConditionExpressionBuilder {
   private addCondition(
     logicalOp: 'AND' | 'OR',
     field: string,
-    op: string,
+    op: QueryOperator,
     value?: unknown,
   ): void {
     const schema = this.model.attributes.get(field);
@@ -345,12 +346,12 @@ export class UpdateBuilder {
     return this;
   }
 
-  condition(field: string, operator: string, value?: unknown): this {
+  condition(field: string, operator: QueryOperator, value?: unknown): this {
     this.conditionOps.push({ logicOp: 'AND', field, operator, value });
     return this;
   }
 
-  orCondition(field: string, operator: string, value?: unknown): this {
+  orCondition(field: string, operator: QueryOperator, value?: unknown): this {
     this.conditionOps.push({ logicOp: 'OR', field, operator, value });
     return this;
   }

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -1,6 +1,7 @@
 await import('./unit/basic.test.js');
 await import('./unit/errors.test.js');
 await import('./unit/model.test.js');
+await import('./unit/typed-api.test.js');
 await import('./unit/dms.test.js');
 await import('./unit/key-contract.test.js');
 await import('./unit/cursor.test.js');

--- a/ts/test/unit/query-builder.test.ts
+++ b/ts/test/unit/query-builder.test.ts
@@ -10,6 +10,7 @@ import { encodeCursor } from '../../src/cursor.js';
 import { TheorydbClient } from '../../src/client.js';
 import { TheorydbError } from '../../src/errors.js';
 import { defineModel } from '../../src/model.js';
+import { unsafeOperator } from '../../src/query.js';
 
 class StubDdb {
   calls = 0;
@@ -414,7 +415,10 @@ const User = defineModel({
   );
   assert.throws(
     () =>
-      client.query('User').partitionKey('A').filter('emailHash', 'LIKE', 'x'),
+      client
+        .query('User')
+        .partitionKey('A')
+        .filter('emailHash', unsafeOperator('LIKE'), 'x'),
     (e) => e instanceof TheorydbError && e.code === 'ErrInvalidOperator',
   );
 }

--- a/ts/test/unit/typed-api.test.ts
+++ b/ts/test/unit/typed-api.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+
+import { PutItemCommand, type DynamoDBClient } from '@aws-sdk/client-dynamodb';
+
+import { TheorydbClient } from '../../src/client.js';
+import { defineModel, type ModelItem } from '../../src/model.js';
+import { unsafeOperator } from '../../src/query.js';
+
+const TypedUser = defineModel({
+  name: 'TypedUser',
+  table: { name: 'typed_users' },
+  keys: {
+    partition: { attribute: 'PK', type: 'S' },
+    sort: { attribute: 'SK', type: 'S' },
+  },
+  attributes: [
+    { attribute: 'PK', type: 'S', roles: ['pk'] },
+    { attribute: 'SK', type: 'S', roles: ['sk'] },
+    { attribute: 'age', type: 'N' },
+    { attribute: 'nickname', type: 'S', optional: true },
+    { attribute: 'version', type: 'N', roles: ['version'] },
+  ],
+});
+
+type TypedUserItem = ModelItem<typeof TypedUser>;
+
+class StubDdb {
+  sent: unknown[] = [];
+
+  async send(cmd: unknown): Promise<unknown> {
+    this.sent.push(cmd);
+    return {};
+  }
+}
+
+const goodItem: TypedUserItem = { PK: 'TENANT#1', SK: 'USER#1', age: 42 };
+assert.equal(goodItem.age, 42);
+
+{
+  const ddb = new StubDdb();
+  const users = new TheorydbClient(ddb as unknown as DynamoDBClient).model(
+    TypedUser,
+  );
+  await users.create({ PK: 'TENANT#1', SK: 'USER#1', age: 42 });
+  const cmd = ddb.sent[0];
+  assert.ok(cmd instanceof PutItemCommand);
+  assert.equal(cmd.input.TableName, 'typed_users');
+}
+
+async function typeAssertions(client: TheorydbClient): Promise<void> {
+  const users = client.model(TypedUser);
+  await users.create({ PK: 'TENANT#1', SK: 'USER#1', age: 42 });
+  await users.update({ PK: 'TENANT#1', SK: 'USER#1', age: 43 }, ['age']);
+
+  const item = await users.get({ PK: 'TENANT#1', SK: 'USER#1' });
+  item.age.toFixed();
+  item.nickname?.toUpperCase();
+
+  await users.query().partitionKey('TENANT#1').filter('age', '>', 21).page();
+  await users
+    .query()
+    .partitionKey('TENANT#1')
+    .filter('age', unsafeOperator('CUSTOM_RUNTIME_OPERATOR'), 21)
+    .page();
+
+  const untyped = client.model('TypedUser');
+  await untyped.create({ intentionally: 'string lookup stays untyped' });
+
+  // @ts-expect-error missing required SK and age fields
+  await users.create({ PK: 'TENANT#1' });
+  // @ts-expect-error age is inferred as a number
+  await users.create({ PK: 'TENANT#1', SK: 'USER#1', age: '42' });
+  // @ts-expect-error unknown fields are rejected for typed model handles
+  await users.create({ PK: 'TENANT#1', SK: 'USER#1', age: 42, nope: true });
+  // @ts-expect-error update field names are tied to the inferred item shape
+  await users.update({ PK: 'TENANT#1', SK: 'USER#1', age: 43 }, ['missing']);
+  // @ts-expect-error unknown operator literals require unsafeOperator(...)
+  users.query().partitionKey('TENANT#1').filter('age', 'BOGUS', 21);
+}
+
+void typeAssertions;

--- a/ts/test/unit/update-builder.test.ts
+++ b/ts/test/unit/update-builder.test.ts
@@ -9,6 +9,7 @@ import { TheorydbClient } from '../../src/client.js';
 import { encryptAttributeValue } from '../../src/encryption.js';
 import { hasTheorydbErrorCode, TheorydbError } from '../../src/errors.js';
 import { defineModel } from '../../src/model.js';
+import { unsafeOperator } from '../../src/query.js';
 import {
   createDeterministicEncryptionProvider,
   createMockDynamoDBClient,
@@ -796,7 +797,7 @@ import {
       client
         .updateBuilder('T', { PK: 'A' })
         .set('name', 'x')
-        .condition('count', 'bogus', 1)
+        .condition('count', unsafeOperator('bogus'), 1)
         .execute(),
     (e) => e instanceof TheorydbError && e.code === 'ErrInvalidOperator',
   );


### PR DESCRIPTION
## Summary

References THE-2384, THE-2385, THE-2387, THE-2388, THE-2389, THE-2391, THE-2392, THE-2393.

- Adds additive Go typed API surfaces: exported `query.Op*` operator constants, `query.Between(lo, hi)`, `pkg/typed` generic model/query/key wrappers, root `ModelOf`, and concrete typed option methods via `core.TypedExtendedDB` / `*DB`.
- Adds TypeScript type inference for `defineModel<const S>`, typed `db.model(Model)` repository handles, typed query/scan/update operator unions, and an explicit `unsafeOperator()` escape hatch while keeping string model lookup/untyped paths.
- Adds Python `Role` constants, a typed DynamoDB client protocol boundary for `Table(client=...)`, and mypy proof fixtures while preserving string roles and existing client construction.

## Compatibility / security

- Additive and backward compatible: existing untyped Go `db.Model(...)`, string operators, TypeScript string model lookup, Python string roles, and legacy Go `opts ...any` option paths remain supported.
- No DMS/release-lane/v2 capstone work, no cloud mutation, no secrets, and no agent-material edits.

## Validation

- `git diff --check` — PASS (exit 0; no output)
- `make contract-tests` — PASS (exit 0; final output `contract-tests: PASS`; TS P0/P1/P2 contract runners pass; Python contract phase `39 passed, 2 skipped`; cross-runtime interop Go/TS/Py pass)
- `make test-unit` — PASS (exit 0)
- `make rubric` — PASS (exit 0; `Status: PASS (pass=36 fail=0 blocked=0)`; subtree verifier PASS)
- `cd ts && npm run check` — PASS (exit 0; prettier, eslint, typecheck, ESM/CJS build, unit tests `21 pass`)
- `uv --directory py run pytest -q tests/unit` — PASS (exit 0; `267 passed in 2.29s`)
- `uv --directory py run mypy src tests/types/typed_api_mypy.py` — PASS (exit 0; `Success: no issues found in 56 source files`)
- `cd py && python -m unittest` — drift observed, not used as proof (`Ran 0 tests`; exit 5); authoritative Python proof is pytest/uv above.

## Notes

- Go deprecation markers intentionally use prose “Deprecation notice” rather than `// Deprecated:` on compatibility methods, to avoid creating in-repo staticcheck SA1019 usage debt before v2 removal work.
- TypeScript runtime validation is unchanged; unknown operator literals now require `unsafeOperator(...)` at compile time when using typed APIs.
