### PR TITLE
feat(testkit): add stateful consumer testing fakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 ### Features
 
+* **go:** add `NewWithClient` and a state-backed `pkg/testing/fakedb` consumer test fake
+* **contract:** validate the Go state-backed fake against the P0 contract corpus
+* **ts:** add a stateful DynamoDB `send()` fake to the public testkit
+* **py:** add a stateful DynamoDB testkit fake and top-level re-exports
 * add TTL-aware schema provisioning across Go, TypeScript, and Python helpers
 * add CDK archival construct for DynamoDB TTL expirations to S3 Glacier lifecycle storage
 

--- a/contract-tests/runners/go/contract_test.go
+++ b/contract-tests/runners/go/contract_test.go
@@ -19,6 +19,11 @@ func TestContract_P0(t *testing.T) {
 	runContractScenarios(t, filepath.Join("contract-tests", "scenarios", "p0"))
 }
 
+func TestContract_P0_Fake(t *testing.T) {
+	t.Helper()
+	runFakeContractScenarios(t, filepath.Join("contract-tests", "scenarios", "p0"))
+}
+
 func TestContract_P1(t *testing.T) {
 	t.Helper()
 	runContractScenarios(t, filepath.Join("contract-tests", "scenarios", "p1"))
@@ -78,6 +83,48 @@ func runContractScenarios(t *testing.T, scenarioRelDir string) {
 			require.NoError(t, err)
 
 			r, err := runner.New(drv)
+			require.NoError(t, err)
+
+			if missing := scenario.MissingCapabilities(s.RequiresCapabilities, drv.Capabilities()); len(missing) > 0 {
+				t.Skipf("scenario requires unsupported capabilities: %v", missing)
+			}
+
+			r.RunScenario(t, ctx, s, models)
+		})
+	}
+}
+
+func runFakeContractScenarios(t *testing.T, scenarioRelDir string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	root, err := runner.RepoRootFromModuleDir()
+	require.NoError(t, err)
+
+	models, err := spec.LoadModelsDir(filepath.Join(root, "contract-tests", "dms", "v0.1", "models"))
+	require.NoError(t, err)
+
+	scenarioDir := filepath.Join(root, scenarioRelDir)
+	files, err := filepath.Glob(filepath.Join(scenarioDir, "*.yml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	for _, path := range files {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			s, err := scenario.LoadFile(path)
+			require.NoError(t, err)
+
+			drv, fake, err := driver.NewFakeTheorydbDriver(driver.Options{
+				Encryption: driver.EncryptionOptions{
+					Provider: s.Encryption.Provider,
+					Seed:     s.Encryption.Seed,
+				},
+			})
+			require.NoError(t, err)
+
+			r, err := runner.NewWithDynamoDBAPI(drv, fake)
 			require.NoError(t, err)
 
 			if missing := scenario.MissingCapabilities(s.RequiresCapabilities, drv.Capabilities()); len(missing) > 0 {

--- a/contract-tests/runners/go/internal/driver/driver.go
+++ b/contract-tests/runners/go/internal/driver/driver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/theory-cloud/tabletheory/pkg/model"
 	"github.com/theory-cloud/tabletheory/pkg/releasestate"
 	"github.com/theory-cloud/tabletheory/pkg/session"
+	"github.com/theory-cloud/tabletheory/pkg/testing/fakedb"
 )
 
 type ErrorCode string
@@ -242,6 +243,35 @@ func NewTheorydbDriver(options ...Options) (*TheorydbDriver, error) {
 	}
 
 	return &TheorydbDriver{db: db, deterministicEncryption: deterministicEncryption}, nil
+}
+
+func NewFakeTheorydbDriver(options ...Options) (*TheorydbDriver, *fakedb.Fake, error) {
+	cfg := session.Config{
+		Region: "us-east-1",
+	}
+	deterministicEncryption := false
+	if len(options) > 0 && options[0].Encryption.Provider != "" {
+		kmsClient, rng, err := deterministicEncryptionForOptions(options[0].Encryption)
+		if err != nil {
+			return nil, nil, err
+		}
+		cfg.KMSKeyARN = "arn:aws:kms:us-east-1:111111111111:key/contract-deterministic"
+		cfg.KMSClient = kmsClient
+		cfg.EncryptionRand = rng
+		deterministicEncryption = true
+	}
+
+	fake := fakedb.New()
+	db, err := tabletheory.NewWithClient(cfg, fake)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := db.RegisterTypeConverter(reflect.TypeOf(DecimalString("")), decimalStringConverter{}); err != nil {
+		return nil, nil, err
+	}
+
+	return &TheorydbDriver{db: db, deterministicEncryption: deterministicEncryption}, fake, nil
 }
 
 func (d *TheorydbDriver) Create(ctx context.Context, model string, item map[string]any, ifNotExists bool) error {

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -26,10 +26,11 @@ import (
 	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/scenario"
 	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/spec"
 	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/session"
 )
 
 type Runner struct {
-	ddb    *dynamodb.Client
+	ddb    session.DynamoDBAPI
 	driver driver.Driver
 	vars   map[string]any
 }
@@ -59,6 +60,17 @@ func New(driver driver.Driver) (*Runner, error) {
 		o.BaseEndpoint = aws.String(endpoint)
 	})
 
+	return &Runner{
+		ddb:    ddb,
+		driver: driver,
+		vars:   make(map[string]any),
+	}, nil
+}
+
+func NewWithDynamoDBAPI(driver driver.Driver, ddb session.DynamoDBAPI) (*Runner, error) {
+	if ddb == nil {
+		return nil, fmt.Errorf("dynamodb api is required")
+	}
 	return &Runner{
 		ddb:    ddb,
 		driver: driver,

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -12,7 +12,7 @@ This guide explains how to write unit and integration tests for applications usi
 - TypeScript: runtime-specific testing guide is staged alongside this document in the shared TableTheory subtree
 - Python: runtime-specific testing guide is staged alongside this document in the shared TableTheory subtree
 
-## Unit Testing with Mocks
+## Go unit testing with mocks and state-backed fakes
 
 To write unit tests without connecting to DynamoDB, use the `core.DB` interface and the provided mocks.
 
@@ -103,6 +103,44 @@ func TestEncryptedWrites(t *testing.T) {
 }
 ```
 
+### 4. State-backed fake client (Go)
+
+For consumer tests that should exercise TableTheory write/query behavior without Docker, construct a real `DB` over the
+deterministic in-memory fake:
+
+```go
+import (
+    "testing"
+
+    "github.com/theory-cloud/tabletheory"
+    "github.com/theory-cloud/tabletheory/pkg/session"
+    "github.com/theory-cloud/tabletheory/pkg/testing/fakedb"
+)
+
+func TestServiceWritesAndQueries(t *testing.T) {
+    fake := fakedb.New()
+    db, err := tabletheory.NewWithClient(session.Config{Region: "us-east-1"}, fake)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if err := db.CreateTable(&User{}); err != nil {
+        t.Fatal(err)
+    }
+
+    if err := db.Model(&User{PK: "USER#1", SK: "PROFILE", Email: "a@example.com"}).Create(); err != nil {
+        t.Fatal(err)
+    }
+
+    // Exercise consumer code using db. Use fake.Items("users") for direct assertions when useful.
+}
+```
+
+`NewWithClient` accepts any implementation of the public `tabletheory.DynamoDBAPI` seam. `pkg/testing/fakedb` honors
+TableTheory keys, conditional writes, optimistic-lock version increments, TTL attributes, batches, transactions, and basic
+query/scan filters. It is a deterministic local testing aid, not a DynamoDB replacement; behavior beyond the
+scenario-validated fake lane should still be covered with DynamoDB Local integration tests.
+
 ## TypeScript unit testing
 
 Use `@theory-cloud/tabletheory-ts/testkit` for a strict AWS SDK v3 `send()` mock and deterministic helpers:
@@ -123,6 +161,19 @@ const db = new TheorydbClient(mock.client, {
 });
 ```
 
+For stateful write-then-query tests, use the TypeScript stateful fake:
+
+```ts
+import { TheorydbClient } from "@theory-cloud/tabletheory-ts";
+import { createStatefulDynamoDBClient } from "@theory-cloud/tabletheory-ts/testkit";
+
+const { client, fake } = createStatefulDynamoDBClient();
+const db = new TheorydbClient(client);
+
+// Register models, write through db, then query through db.
+// fake.items("users") returns a deterministic snapshot for direct assertions.
+```
+
 ## Python unit testing
 
 Use `theorydb_py.mocks` for strict fakes and deterministic encryption nonces:
@@ -135,6 +186,18 @@ fake_ddb = FakeDynamoDBClient()
 fake_kms = FakeKmsClient(plaintext_key=b"\x00" * 32, ciphertext_blob=b"edk")
 
 table = Table(model, client=fake_ddb, kms_key_arn="arn:aws:kms:...", kms_client=fake_kms, rand_bytes=lambda n: b"\x01" * n)
+```
+
+For stateful Python tests that should exercise TableTheory query/write behavior without scripting every command:
+
+```python
+from tabletheory_py import StatefulDynamoDBClient, Table
+
+fake_ddb = StatefulDynamoDBClient()
+table = Table(model, client=fake_ddb)
+
+# table.put(...), table.query(...), table.update(...)
+# fake_ddb.items("notes") returns a deterministic snapshot for direct assertions.
 ```
 
 ## Integration Testing

--- a/internal/theorydb/query_executor.go
+++ b/internal/theorydb/query_executor.go
@@ -418,8 +418,8 @@ type pagePaginator[Output any] interface {
 }
 
 type readPagerSpec struct {
-	buildCountPager func(*dynamodb.Client, *core.CompiledQuery) (func() bool, countPageFunc)
-	buildItemPager  func(*dynamodb.Client, *core.CompiledQuery) (func() bool, itemPageFunc)
+	buildCountPager func(session.DynamoDBAPI, *core.CompiledQuery) (func() bool, countPageFunc)
+	buildItemPager  func(session.DynamoDBAPI, *core.CompiledQuery) (func() bool, itemPageFunc)
 	nilErr          string
 	operation       string
 }
@@ -429,14 +429,14 @@ func newReadPagerSpec[Input any, Output any, P pagePaginator[Output]](
 	operation string,
 	buildInput func(*core.CompiledQuery) *Input,
 	configureCountInput func(*Input),
-	newPaginator func(*dynamodb.Client, *Input) P,
+	newPaginator func(session.DynamoDBAPI, *Input) P,
 	extractCounts func(*Output) (int32, int32),
 	extractItems func(*Output) []map[string]types.AttributeValue,
 ) readPagerSpec {
 	return readPagerSpec{
 		nilErr:    nilErr,
 		operation: operation,
-		buildCountPager: func(client *dynamodb.Client, input *core.CompiledQuery) (func() bool, countPageFunc) {
+		buildCountPager: func(client session.DynamoDBAPI, input *core.CompiledQuery) (func() bool, countPageFunc) {
 			countInput := buildInput(input)
 			configureCountInput(countInput)
 
@@ -451,7 +451,7 @@ func newReadPagerSpec[Input any, Output any, P pagePaginator[Output]](
 				return count, scannedCount, nil
 			}
 		},
-		buildItemPager: func(client *dynamodb.Client, input *core.CompiledQuery) (func() bool, itemPageFunc) {
+		buildItemPager: func(client session.DynamoDBAPI, input *core.CompiledQuery) (func() bool, itemPageFunc) {
 			itemInput := buildInput(input)
 
 			paginator := newPaginator(client, itemInput)
@@ -472,10 +472,10 @@ func (qe *queryExecutor) executeReadSpec(input *core.CompiledQuery, dest any, sp
 		dest,
 		spec.nilErr,
 		spec.operation,
-		func(client *dynamodb.Client) (func() bool, countPageFunc) {
+		func(client session.DynamoDBAPI) (func() bool, countPageFunc) {
 			return spec.buildCountPager(client, input)
 		},
-		func(client *dynamodb.Client) (func() bool, itemPageFunc) {
+		func(client session.DynamoDBAPI) (func() bool, itemPageFunc) {
 			return spec.buildItemPager(client, input)
 		},
 	)
@@ -489,7 +489,7 @@ type singlePageResult struct {
 }
 
 type singlePageSpec struct {
-	execute   func(context.Context, *dynamodb.Client, *core.CompiledQuery) (singlePageResult, error)
+	execute   func(context.Context, session.DynamoDBAPI, *core.CompiledQuery) (singlePageResult, error)
 	nilErr    string
 	operation string
 }
@@ -500,7 +500,7 @@ func (qe *queryExecutor) executeReadWithPaginationSpec(input *core.CompiledQuery
 		dest,
 		spec.nilErr,
 		spec.operation,
-		func(client *dynamodb.Client, ctx context.Context) (singlePageResult, error) {
+		func(client session.DynamoDBAPI, ctx context.Context) (singlePageResult, error) {
 			return spec.execute(ctx, client, input)
 		},
 	)
@@ -534,11 +534,11 @@ func configureScanCountInput(scanInput *dynamodb.ScanInput) {
 	scanInput.ProjectionExpression = nil
 }
 
-func newQueryPaginator(client *dynamodb.Client, queryInput *dynamodb.QueryInput) *dynamodb.QueryPaginator {
+func newQueryPaginator(client session.DynamoDBAPI, queryInput *dynamodb.QueryInput) *dynamodb.QueryPaginator {
 	return dynamodb.NewQueryPaginator(client, queryInput)
 }
 
-func newScanPaginator(client *dynamodb.Client, scanInput *dynamodb.ScanInput) *dynamodb.ScanPaginator {
+func newScanPaginator(client session.DynamoDBAPI, scanInput *dynamodb.ScanInput) *dynamodb.ScanPaginator {
 	return dynamodb.NewScanPaginator(client, scanInput)
 }
 
@@ -572,7 +572,7 @@ func newSinglePageResult(
 	}
 }
 
-func executeQuerySinglePage(ctx context.Context, client *dynamodb.Client, input *core.CompiledQuery) (singlePageResult, error) {
+func executeQuerySinglePage(ctx context.Context, client session.DynamoDBAPI, input *core.CompiledQuery) (singlePageResult, error) {
 	out, err := client.Query(ctx, buildDynamoQueryInput(input))
 	if err != nil {
 		return singlePageResult{}, fmt.Errorf("failed to execute query: %w", err)
@@ -580,7 +580,7 @@ func executeQuerySinglePage(ctx context.Context, client *dynamodb.Client, input 
 	return newSinglePageResult(out.Items, out.Count, out.ScannedCount, out.LastEvaluatedKey), nil
 }
 
-func executeScanSinglePage(ctx context.Context, client *dynamodb.Client, input *core.CompiledQuery) (singlePageResult, error) {
+func executeScanSinglePage(ctx context.Context, client session.DynamoDBAPI, input *core.CompiledQuery) (singlePageResult, error) {
 	out, err := client.Scan(ctx, buildDynamoScanInput(input))
 	if err != nil {
 		return singlePageResult{}, fmt.Errorf("failed to execute scan: %w", err)
@@ -620,7 +620,7 @@ var scanSinglePageSpec = singlePageSpec{
 	execute:   executeScanSinglePage,
 }
 
-func (qe *queryExecutor) readClient(input *core.CompiledQuery, nilErr string, operation string) (*dynamodb.Client, error) {
+func (qe *queryExecutor) readClient(input *core.CompiledQuery, nilErr string, operation string) (session.DynamoDBAPI, error) {
 	if input == nil {
 		return nil, errors.New(nilErr)
 	}
@@ -631,7 +631,7 @@ func (qe *queryExecutor) readClient(input *core.CompiledQuery, nilErr string, op
 		return nil, err
 	}
 
-	client, err := qe.session().Client()
+	client, err := qe.session().API()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client for %s: %w", operation, err)
 	}
@@ -643,8 +643,8 @@ func (qe *queryExecutor) executeRead(
 	dest any,
 	nilErr string,
 	operation string,
-	buildCountPager func(*dynamodb.Client) (func() bool, countPageFunc),
-	buildItemPager func(*dynamodb.Client) (func() bool, itemPageFunc),
+	buildCountPager func(session.DynamoDBAPI) (func() bool, countPageFunc),
+	buildItemPager func(session.DynamoDBAPI) (func() bool, itemPageFunc),
 ) error {
 	client, err := qe.readClient(input, nilErr, operation)
 	if err != nil {
@@ -675,7 +675,7 @@ func (qe *queryExecutor) executeReadWithPagination(
 	dest any,
 	nilErr string,
 	operation string,
-	execute func(*dynamodb.Client, context.Context) (singlePageResult, error),
+	execute func(session.DynamoDBAPI, context.Context) (singlePageResult, error),
 ) (singlePageResult, error) {
 	client, err := qe.readClient(input, nilErr, operation)
 	if err != nil {
@@ -750,7 +750,7 @@ func (qe *queryExecutor) ExecuteGetItem(input *core.CompiledQuery, key map[strin
 		return err
 	}
 
-	client, err := qe.session().Client()
+	client, err := qe.session().API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for get item: %w", err)
 	}
@@ -808,7 +808,7 @@ func (qe *queryExecutor) ExecutePutItem(input *core.CompiledQuery, item map[stri
 		return err
 	}
 
-	client, err := qe.session().Client()
+	client, err := qe.session().API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for put item: %w", err)
 	}
@@ -895,7 +895,7 @@ func (qe *queryExecutor) ExecuteUpdateItem(input *core.CompiledQuery, key map[st
 		return err
 	}
 
-	client, err := qe.session().Client()
+	client, err := qe.session().API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for update item: %w", err)
 	}
@@ -930,7 +930,7 @@ func (qe *queryExecutor) ExecuteUpdateItemWithResult(input *core.CompiledQuery, 
 		return nil, err
 	}
 
-	client, err := qe.session().Client()
+	client, err := qe.session().API()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client for update item: %w", err)
 	}
@@ -971,7 +971,7 @@ func (qe *queryExecutor) ExecuteDeleteItem(input *core.CompiledQuery, key map[st
 		return err
 	}
 
-	client, err := qe.session().Client()
+	client, err := qe.session().API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for delete item: %w", err)
 	}
@@ -1016,7 +1016,7 @@ func (qe *queryExecutor) ExecuteBatchGet(input *query.CompiledBatchGet, opts *co
 		return nil, err
 	}
 
-	client, err := qe.session().Client()
+	client, err := qe.session().API()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client for batch get: %w", err)
 	}
@@ -1038,7 +1038,7 @@ func normalizeBatchGetOptions(opts *core.BatchGetOptions) *core.BatchGetOptions 
 }
 
 func (qe *queryExecutor) executeBatchGetWithRetry(
-	client *dynamodb.Client,
+	client session.DynamoDBAPI,
 	requestItems map[string]types.KeysAndAttributes,
 	tableName string,
 	opts *core.BatchGetOptions,
@@ -1186,7 +1186,7 @@ func (qe *queryExecutor) ExecuteBatchWriteItemRaw(tableName string, writeRequest
 		return nil, fmt.Errorf("batch write supports maximum 25 items per request, got %d", len(writeRequests))
 	}
 
-	client, err := qe.session().Client()
+	client, err := qe.session().API()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client for batch write: %w", err)
 	}

--- a/internal/theorydb/theorydb.go
+++ b/internal/theorydb/theorydb.go
@@ -134,7 +134,21 @@ func New(config session.Config) (core.ExtendedDB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
+	return newWithSession(config, sess)
+}
 
+// NewWithClient creates a TableTheory instance backed by an injected DynamoDB
+// API implementation. This is intended for deterministic consumer tests and
+// local fakes; production callers should continue to use New.
+func NewWithClient(config session.Config, client session.DynamoDBAPI) (core.ExtendedDB, error) {
+	sess, err := session.NewSessionWithClient(&config, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create session with client: %w", err)
+	}
+	return newWithSession(config, sess)
+}
+
+func newWithSession(config session.Config, sess *session.Session) (core.ExtendedDB, error) {
 	converter := pkgTypes.NewConverter()
 	marshalerFactory := marshal.NewMarshalerFactory(marshal.DefaultConfig()).WithConverter(converter)
 	if config.Now != nil {

--- a/pkg/schema/automigrate.go
+++ b/pkg/schema/automigrate.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/theory-cloud/tabletheory/internal/numutil"
 	"github.com/theory-cloud/tabletheory/pkg/model"
+	"github.com/theory-cloud/tabletheory/pkg/session"
 )
 
 // AutoMigrateOptions holds configuration for AutoMigrate operations
@@ -187,7 +188,7 @@ func (m *Manager) createBackup(ctx context.Context, sourceTable, backupName stri
 		BackupName: &backupName,
 	}
 
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for backup creation: %w", err)
 	}
@@ -204,7 +205,7 @@ func (m *Manager) createBackup(ctx context.Context, sourceTable, backupName stri
 // copyTable creates a copy of a table
 func (m *Manager) copyTable(ctx context.Context, sourceTable, targetTable string) error {
 	// Get source table description
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for table description: %w", err)
 	}
@@ -308,7 +309,7 @@ func (m *Manager) copyData(opts *AutoMigrateOptions, sourceMetadata, targetMetad
 	ctx := opts.Context
 
 	// Get client once for the entire operation
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for data copy: %w", err)
 	}
@@ -347,7 +348,7 @@ func (m *Manager) copyData(opts *AutoMigrateOptions, sourceMetadata, targetMetad
 }
 
 // processItems processes and writes items to the target table
-func (m *Manager) processItems(ctx context.Context, client *dynamodb.Client, items []map[string]types.AttributeValue,
+func (m *Manager) processItems(ctx context.Context, client session.DynamoDBAPI, items []map[string]types.AttributeValue,
 	targetTable string,
 	transformFunc TransformFunc,
 	sourceMetadata, targetMetadata *model.Metadata,
@@ -367,7 +368,7 @@ func (m *Manager) processItems(ctx context.Context, client *dynamodb.Client, ite
 
 // copyTableData copies all data from source to target table
 func (m *Manager) copyTableData(ctx context.Context, sourceTable, targetTable string, batchSize int) error {
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for table data copy: %w", err)
 	}
@@ -409,7 +410,7 @@ func resolveDataCopyBatchSize(batchSize int) int {
 
 func scanTablePage(
 	ctx context.Context,
-	client *dynamodb.Client,
+	client session.DynamoDBAPI,
 	sourceTable string,
 	batchSize int,
 	lastEvaluatedKey map[string]types.AttributeValue,
@@ -432,7 +433,7 @@ func scanTablePage(
 
 func writeItemsToTable(
 	ctx context.Context,
-	client *dynamodb.Client,
+	client session.DynamoDBAPI,
 	targetTable string,
 	items []map[string]types.AttributeValue,
 	maxBatchSize int,
@@ -486,7 +487,7 @@ func buildPutWriteRequestsWithTransform(
 
 func writeRequestsBatched(
 	ctx context.Context,
-	client *dynamodb.Client,
+	client session.DynamoDBAPI,
 	tableName string,
 	writeRequests []types.WriteRequest,
 	maxBatchSize int,
@@ -524,7 +525,7 @@ func writeRequestsBatched(
 
 func batchWriteWithRetries(
 	ctx context.Context,
-	client *dynamodb.Client,
+	client session.DynamoDBAPI,
 	tableName string,
 	writeRequests []types.WriteRequest,
 	maxRetries int,
@@ -592,7 +593,7 @@ func sleepWithBackoff(ctx context.Context, retryCount int) error {
 
 func putWriteRequestsIndividually(
 	ctx context.Context,
-	client *dynamodb.Client,
+	client session.DynamoDBAPI,
 	tableName string,
 	remainingRequests []types.WriteRequest,
 ) error {

--- a/pkg/schema/manager.go
+++ b/pkg/schema/manager.go
@@ -102,7 +102,7 @@ func (m *Manager) CreateTable(model any, opts ...TableOption) error {
 
 	// Create table
 	ctx := context.Background()
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for table creation: %w", err)
 	}
@@ -267,7 +267,7 @@ func (m *Manager) buildIndexes(metadata *model.Metadata) ([]types.GlobalSecondar
 // waitForTableActive waits for a table to become active
 func (m *Manager) waitForTableActive(tableName string) error {
 	ctx := context.Background()
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for table waiter: %w", err)
 	}
@@ -289,7 +289,7 @@ func (m *Manager) waitForTableActive(tableName string) error {
 // TableExists checks if a table exists
 func (m *Manager) TableExists(tableName string) (bool, error) {
 	ctx := context.Background()
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return false, fmt.Errorf("failed to get client for table exists check: %w", err)
 	}
@@ -312,7 +312,7 @@ func (m *Manager) TableExists(tableName string) (bool, error) {
 // DeleteTable deletes a DynamoDB table
 func (m *Manager) DeleteTable(tableName string) error {
 	ctx := context.Background()
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for table deletion: %w", err)
 	}
@@ -340,7 +340,7 @@ func (m *Manager) DescribeTable(model any) (*types.TableDescription, error) {
 	}
 
 	ctx := context.Background()
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client for table description: %w", err)
 	}
@@ -383,7 +383,7 @@ func (m *Manager) UpdateTable(model any, opts ...TableOption) error {
 	}
 
 	ctx := context.Background()
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for table update: %w", err)
 	}

--- a/pkg/schema/ttl.go
+++ b/pkg/schema/ttl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
 	"github.com/theory-cloud/tabletheory/pkg/model"
+	"github.com/theory-cloud/tabletheory/pkg/session"
 )
 
 // EnableTTL enables DynamoDB TTL for the ttl-tagged field on an existing model table.
@@ -23,7 +24,7 @@ func (m *Manager) EnableTTL(modelValue any) error {
 	}
 
 	ctx := context.Background()
-	client, err := m.session.Client()
+	client, err := m.session.API()
 	if err != nil {
 		return fmt.Errorf("failed to get client for ttl update: %w", err)
 	}
@@ -31,7 +32,7 @@ func (m *Manager) EnableTTL(modelValue any) error {
 	return m.syncModelTTL(ctx, client, metadata)
 }
 
-func (m *Manager) syncModelTTL(ctx context.Context, client *dynamodb.Client, metadata *model.Metadata) error {
+func (m *Manager) syncModelTTL(ctx context.Context, client session.DynamoDBAPI, metadata *model.Metadata) error {
 	if metadata == nil || metadata.TTLField == nil {
 		return nil
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -45,6 +45,32 @@ type KMSClient interface {
 	Decrypt(ctx context.Context, params *kms.DecryptInput, optFns ...func(*kms.Options)) (*kms.DecryptOutput, error)
 }
 
+// DynamoDBAPI is the DynamoDB client seam TableTheory uses internally.
+//
+// It is intentionally the AWS SDK v2 operation shape, so tests can inject a
+// deterministic local fake while production callers continue to use
+// *dynamodb.Client through NewSession/New.
+type DynamoDBAPI interface {
+	CreateTable(ctx context.Context, params *dynamodb.CreateTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error)
+	CreateBackup(ctx context.Context, params *dynamodb.CreateBackupInput, optFns ...func(*dynamodb.Options)) (*dynamodb.CreateBackupOutput, error)
+	DescribeTable(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
+	DeleteTable(ctx context.Context, params *dynamodb.DeleteTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteTableOutput, error)
+	ListTables(ctx context.Context, params *dynamodb.ListTablesInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error)
+	UpdateTable(ctx context.Context, params *dynamodb.UpdateTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error)
+	UpdateTimeToLive(ctx context.Context, params *dynamodb.UpdateTimeToLiveInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateTimeToLiveOutput, error)
+
+	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
+	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+	Scan(ctx context.Context, params *dynamodb.ScanInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+	BatchGetItem(ctx context.Context, params *dynamodb.BatchGetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchGetItemOutput, error)
+	BatchWriteItem(ctx context.Context, params *dynamodb.BatchWriteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error)
+	TransactWriteItems(ctx context.Context, params *dynamodb.TransactWriteItemsInput, optFns ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error)
+	TransactGetItems(ctx context.Context, params *dynamodb.TransactGetItemsInput, optFns ...func(*dynamodb.Options)) (*dynamodb.TransactGetItemsOutput, error)
+}
+
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
 	return &Config{
@@ -61,6 +87,7 @@ func DefaultConfig() *Config {
 type Session struct {
 	config    *Config
 	client    *dynamodb.Client
+	api       DynamoDBAPI
 	awsConfig aws.Config
 }
 
@@ -149,6 +176,31 @@ func NewSession(cfg *Config) (*Session, error) {
 		config:    cfg,
 		awsConfig: awsConfig,
 		client:    client,
+		api:       client,
+	}, nil
+}
+
+// NewSessionWithClient creates a session backed by an injected DynamoDBAPI.
+// It does not create a DynamoDB client or contact AWS for DynamoDB setup. If
+// encrypted fields are used without Config.KMSClient, the normal KMS behavior
+// still applies via AWSConfig().
+func NewSessionWithClient(cfg *Config, client DynamoDBAPI) (*Session, error) {
+	if client == nil {
+		return nil, fmt.Errorf("DynamoDB client is nil")
+	}
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
+	region := cfg.Region
+	if region == "" {
+		region = "us-east-1"
+	}
+	return &Session{
+		config: cfg,
+		api:    client,
+		awsConfig: aws.Config{
+			Region: region,
+		},
 	}, nil
 }
 
@@ -161,6 +213,20 @@ func (s *Session) Client() (*dynamodb.Client, error) {
 		return nil, fmt.Errorf("DynamoDB client is nil")
 	}
 	return s.client, nil
+}
+
+// API returns the configured DynamoDB operation seam.
+func (s *Session) API() (DynamoDBAPI, error) {
+	if s == nil {
+		return nil, fmt.Errorf("session is nil")
+	}
+	if s.api == nil {
+		if s.client == nil {
+			return nil, fmt.Errorf("DynamoDB client is nil")
+		}
+		return s.client, nil
+	}
+	return s.api, nil
 }
 
 // Config returns the session configuration

--- a/pkg/testing/fakedb/fakedb.go
+++ b/pkg/testing/fakedb/fakedb.go
@@ -1,0 +1,1447 @@
+// Package fakedb provides a deterministic, state-backed DynamoDBAPI fake for
+// consumer tests.
+//
+// The fake is a local testing aid. It is intentionally bounded to TableTheory's
+// scenario-validated behavior and should not be treated as a DynamoDB emulator.
+package fakedb
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/theory-cloud/tabletheory/pkg/session"
+)
+
+var _ session.DynamoDBAPI = (*Fake)(nil)
+
+// Fake is an in-memory implementation of the TableTheory DynamoDBAPI seam.
+type Fake struct {
+	tables map[string]*tableState
+	mu     sync.RWMutex
+}
+
+type tableState struct {
+	indexes map[string]indexState
+	items   map[string]map[string]types.AttributeValue
+	name    string
+	pk      string
+	sk      string
+	ttlAttr string
+}
+
+type indexState struct {
+	pk string
+	sk string
+}
+
+// New returns an empty in-memory DynamoDB fake.
+func New() *Fake {
+	return &Fake{tables: make(map[string]*tableState)}
+}
+
+// Reset removes all fake tables and items.
+func (f *Fake) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.tables = make(map[string]*tableState)
+}
+
+// Seed stores items in a table, creating a PK/SK shaped table when needed.
+func (f *Fake) Seed(tableName string, items ...map[string]types.AttributeValue) error {
+	if tableName == "" {
+		return errors.New("table name is required")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	table := f.tableOrDefaultLocked(tableName)
+	for _, item := range items {
+		key, err := table.itemKey(item)
+		if err != nil {
+			return err
+		}
+		table.items[key] = cloneItem(item)
+	}
+	return nil
+}
+
+// Items returns a deterministic snapshot of the table's stored items.
+func (f *Fake) Items(tableName string) []map[string]types.AttributeValue {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	table := f.tables[tableName]
+	if table == nil {
+		return nil
+	}
+	items := make([]map[string]types.AttributeValue, 0, len(table.items))
+	for _, item := range table.items {
+		items = append(items, cloneItem(item))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return itemSortKey(table, items[i]) < itemSortKey(table, items[j])
+	})
+	return items
+}
+
+func (f *Fake) CreateTable(_ context.Context, params *dynamodb.CreateTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error) {
+	if params == nil || params.TableName == nil || aws.ToString(params.TableName) == "" {
+		return nil, errors.New("CreateTable requires TableName")
+	}
+	name := aws.ToString(params.TableName)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, exists := f.tables[name]; exists {
+		return nil, &types.ResourceInUseException{Message: aws.String("table already exists")}
+	}
+	table := &tableState{
+		name:    name,
+		indexes: make(map[string]indexState),
+		items:   make(map[string]map[string]types.AttributeValue),
+	}
+	applyKeySchema(table, params.KeySchema)
+	for _, gsi := range params.GlobalSecondaryIndexes {
+		if gsi.IndexName == nil {
+			continue
+		}
+		table.indexes[aws.ToString(gsi.IndexName)] = indexFromSchema(gsi.KeySchema)
+	}
+	for _, lsi := range params.LocalSecondaryIndexes {
+		if lsi.IndexName == nil {
+			continue
+		}
+		table.indexes[aws.ToString(lsi.IndexName)] = indexFromSchema(lsi.KeySchema)
+	}
+	if table.pk == "" {
+		table.pk = "PK"
+	}
+	f.tables[name] = table
+	return &dynamodb.CreateTableOutput{TableDescription: tableDescription(table)}, nil
+}
+
+func (f *Fake) CreateBackup(_ context.Context, params *dynamodb.CreateBackupInput, _ ...func(*dynamodb.Options)) (*dynamodb.CreateBackupOutput, error) {
+	if params == nil || params.TableName == nil {
+		return nil, errors.New("CreateBackup requires TableName")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if _, err := f.requiredTableLocked(aws.ToString(params.TableName)); err != nil {
+		return nil, err
+	}
+	return &dynamodb.CreateBackupOutput{
+		BackupDetails: &types.BackupDetails{
+			BackupArn:    aws.String("arn:aws:dynamodb:local:000000000000:table/" + aws.ToString(params.TableName) + "/backup/" + aws.ToString(params.BackupName)),
+			BackupName:   params.BackupName,
+			BackupStatus: types.BackupStatusAvailable,
+			BackupType:   types.BackupTypeUser,
+		},
+	}, nil
+}
+
+func (f *Fake) DescribeTable(_ context.Context, params *dynamodb.DescribeTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+	tableName := tableNameFrom(params)
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	table := f.tables[tableName]
+	if table == nil {
+		return nil, resourceNotFound(tableName)
+	}
+	return &dynamodb.DescribeTableOutput{Table: tableDescription(table)}, nil
+}
+
+func (f *Fake) DeleteTable(_ context.Context, params *dynamodb.DeleteTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteTableOutput, error) {
+	tableName := tableNameFrom(params)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	table := f.tables[tableName]
+	if table == nil {
+		return nil, resourceNotFound(tableName)
+	}
+	delete(f.tables, tableName)
+	return &dynamodb.DeleteTableOutput{TableDescription: tableDescription(table)}, nil
+}
+
+func (f *Fake) ListTables(_ context.Context, params *dynamodb.ListTablesInput, _ ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	names := make([]string, 0, len(f.tables))
+	for name := range f.tables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if params != nil && params.Limit != nil && *params.Limit > 0 && int(*params.Limit) < len(names) {
+		names = names[:int(*params.Limit)]
+	}
+	return &dynamodb.ListTablesOutput{TableNames: names}, nil
+}
+
+func (f *Fake) UpdateTable(_ context.Context, params *dynamodb.UpdateTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error) {
+	if params == nil || params.TableName == nil {
+		return nil, errors.New("UpdateTable requires TableName")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	table, err := f.requiredTableLocked(aws.ToString(params.TableName))
+	if err != nil {
+		return nil, err
+	}
+	for _, gsiUpdate := range params.GlobalSecondaryIndexUpdates {
+		if gsiUpdate.Create == nil || gsiUpdate.Create.IndexName == nil {
+			continue
+		}
+		table.indexes[aws.ToString(gsiUpdate.Create.IndexName)] = indexFromSchema(gsiUpdate.Create.KeySchema)
+	}
+	return &dynamodb.UpdateTableOutput{TableDescription: tableDescription(table)}, nil
+}
+
+func (f *Fake) UpdateTimeToLive(_ context.Context, params *dynamodb.UpdateTimeToLiveInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateTimeToLiveOutput, error) {
+	tableName := tableNameFrom(params)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	table := f.tables[tableName]
+	if table == nil {
+		return nil, resourceNotFound(tableName)
+	}
+	if params.TimeToLiveSpecification != nil && params.TimeToLiveSpecification.AttributeName != nil {
+		table.ttlAttr = aws.ToString(params.TimeToLiveSpecification.AttributeName)
+	}
+	return &dynamodb.UpdateTimeToLiveOutput{TimeToLiveSpecification: params.TimeToLiveSpecification}, nil
+}
+
+func (f *Fake) GetItem(_ context.Context, params *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	if params == nil {
+		return nil, errors.New("GetItemInput is required")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	table, err := f.requiredTableLocked(aws.ToString(params.TableName))
+	if err != nil {
+		return nil, err
+	}
+	key, err := table.keyFromKeyMap(params.Key)
+	if err != nil {
+		return nil, err
+	}
+	item := cloneItem(table.items[key])
+	if len(item) > 0 {
+		item = projectItem(item, params.ProjectionExpression, params.ExpressionAttributeNames)
+	}
+	return &dynamodb.GetItemOutput{Item: item}, nil
+}
+
+func (f *Fake) PutItem(_ context.Context, params *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	if params == nil {
+		return nil, errors.New("PutItemInput is required")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	table := f.tableOrDefaultLocked(aws.ToString(params.TableName))
+	key, err := table.itemKey(params.Item)
+	if err != nil {
+		return nil, err
+	}
+	existing := table.items[key]
+	if !evalCondition(params.ConditionExpression, existing, params.ExpressionAttributeNames, params.ExpressionAttributeValues) {
+		return nil, conditionalFailed()
+	}
+	table.items[key] = cloneItem(params.Item)
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+func (f *Fake) DeleteItem(_ context.Context, params *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	if params == nil {
+		return nil, errors.New("DeleteItemInput is required")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	table, err := f.requiredTableLocked(aws.ToString(params.TableName))
+	if err != nil {
+		return nil, err
+	}
+	key, err := table.keyFromKeyMap(params.Key)
+	if err != nil {
+		return nil, err
+	}
+	existing := table.items[key]
+	if !evalCondition(params.ConditionExpression, existing, params.ExpressionAttributeNames, params.ExpressionAttributeValues) {
+		return nil, conditionalFailed()
+	}
+	delete(table.items, key)
+	return &dynamodb.DeleteItemOutput{}, nil
+}
+
+func (f *Fake) UpdateItem(_ context.Context, params *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	if params == nil {
+		return nil, errors.New("UpdateItemInput is required")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	table := f.tableOrDefaultLocked(aws.ToString(params.TableName))
+	key, err := table.keyFromKeyMap(params.Key)
+	if err != nil {
+		return nil, err
+	}
+	item := cloneItem(table.items[key])
+	if !evalCondition(params.ConditionExpression, item, params.ExpressionAttributeNames, params.ExpressionAttributeValues) {
+		return nil, conditionalFailed()
+	}
+	if item == nil {
+		item = cloneItem(params.Key)
+	}
+	if err := applyUpdateExpression(item, params.UpdateExpression, params.ExpressionAttributeNames, params.ExpressionAttributeValues); err != nil {
+		return nil, err
+	}
+	table.items[key] = item
+	out := &dynamodb.UpdateItemOutput{}
+	if params.ReturnValues == types.ReturnValueAllNew || params.ReturnValues == types.ReturnValueUpdatedNew {
+		out.Attributes = cloneItem(item)
+	}
+	return out, nil
+}
+
+func (f *Fake) Query(_ context.Context, params *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	if params == nil {
+		return nil, errors.New("QueryInput is required")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	table, err := f.requiredTableLocked(aws.ToString(params.TableName))
+	if err != nil {
+		return nil, err
+	}
+	items := f.readItemsLocked(table, readInput{
+		indexName:                 aws.ToString(params.IndexName),
+		keyConditionExpression:    params.KeyConditionExpression,
+		filterExpression:          params.FilterExpression,
+		projectionExpression:      params.ProjectionExpression,
+		expressionAttributeNames:  params.ExpressionAttributeNames,
+		expressionAttributeValues: params.ExpressionAttributeValues,
+		limit:                     params.Limit,
+		exclusiveStartKey:         params.ExclusiveStartKey,
+		scanIndexForward:          params.ScanIndexForward,
+		selectMode:                string(params.Select),
+	})
+	return &dynamodb.QueryOutput{
+		Items:            items.items,
+		Count:            safeInt32(len(items.items)),
+		ScannedCount:     safeInt32(items.scanned),
+		LastEvaluatedKey: items.lastKey,
+	}, nil
+}
+
+func (f *Fake) Scan(_ context.Context, params *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+	if params == nil {
+		return nil, errors.New("ScanInput is required")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	table, err := f.requiredTableLocked(aws.ToString(params.TableName))
+	if err != nil {
+		return nil, err
+	}
+	items := f.readItemsLocked(table, readInput{
+		indexName:                 aws.ToString(params.IndexName),
+		filterExpression:          params.FilterExpression,
+		projectionExpression:      params.ProjectionExpression,
+		expressionAttributeNames:  params.ExpressionAttributeNames,
+		expressionAttributeValues: params.ExpressionAttributeValues,
+		limit:                     params.Limit,
+		exclusiveStartKey:         params.ExclusiveStartKey,
+		selectMode:                string(params.Select),
+	})
+	return &dynamodb.ScanOutput{
+		Items:            items.items,
+		Count:            safeInt32(len(items.items)),
+		ScannedCount:     safeInt32(items.scanned),
+		LastEvaluatedKey: items.lastKey,
+	}, nil
+}
+
+func (f *Fake) BatchGetItem(_ context.Context, params *dynamodb.BatchGetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.BatchGetItemOutput, error) {
+	if params == nil {
+		return nil, errors.New("BatchGetItemInput is required")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	responses := make(map[string][]map[string]types.AttributeValue, len(params.RequestItems))
+	for tableName, request := range params.RequestItems {
+		table, err := f.requiredTableLocked(tableName)
+		if err != nil {
+			return nil, err
+		}
+		for _, keyMap := range request.Keys {
+			key, err := table.keyFromKeyMap(keyMap)
+			if err != nil {
+				return nil, err
+			}
+			if item := table.items[key]; len(item) > 0 {
+				responses[tableName] = append(responses[tableName], projectItem(cloneItem(item), request.ProjectionExpression, request.ExpressionAttributeNames))
+			}
+		}
+	}
+	return &dynamodb.BatchGetItemOutput{Responses: responses}, nil
+}
+
+func (f *Fake) BatchWriteItem(_ context.Context, params *dynamodb.BatchWriteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error) {
+	if params == nil {
+		return nil, errors.New("BatchWriteItemInput is required")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for tableName, writes := range params.RequestItems {
+		table := f.tableOrDefaultLocked(tableName)
+		for _, write := range writes {
+			if write.PutRequest != nil {
+				key, err := table.itemKey(write.PutRequest.Item)
+				if err != nil {
+					return nil, err
+				}
+				table.items[key] = cloneItem(write.PutRequest.Item)
+			}
+			if write.DeleteRequest != nil {
+				key, err := table.keyFromKeyMap(write.DeleteRequest.Key)
+				if err != nil {
+					return nil, err
+				}
+				delete(table.items, key)
+			}
+		}
+	}
+	return &dynamodb.BatchWriteItemOutput{}, nil
+}
+
+func (f *Fake) TransactGetItems(_ context.Context, params *dynamodb.TransactGetItemsInput, _ ...func(*dynamodb.Options)) (*dynamodb.TransactGetItemsOutput, error) {
+	if params == nil {
+		return nil, errors.New("TransactGetItemsInput is required")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	responses := make([]types.ItemResponse, 0, len(params.TransactItems))
+	for _, op := range params.TransactItems {
+		if op.Get == nil {
+			responses = append(responses, types.ItemResponse{})
+			continue
+		}
+		table, err := f.requiredTableLocked(aws.ToString(op.Get.TableName))
+		if err != nil {
+			return nil, err
+		}
+		key, err := table.keyFromKeyMap(op.Get.Key)
+		if err != nil {
+			return nil, err
+		}
+		item := projectItem(cloneItem(table.items[key]), op.Get.ProjectionExpression, op.Get.ExpressionAttributeNames)
+		responses = append(responses, types.ItemResponse{Item: item})
+	}
+	return &dynamodb.TransactGetItemsOutput{Responses: responses}, nil
+}
+
+func (f *Fake) TransactWriteItems(_ context.Context, params *dynamodb.TransactWriteItemsInput, _ ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error) {
+	if params == nil {
+		return nil, errors.New("TransactWriteItemsInput is required")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	snapshot := f.cloneTablesLocked()
+	for i, op := range params.TransactItems {
+		if err := applyTransactWrite(snapshot, op); err != nil {
+			return nil, transactionCanceled(i, err)
+		}
+	}
+	f.tables = snapshot
+	return &dynamodb.TransactWriteItemsOutput{}, nil
+}
+
+type readInput struct {
+	indexName                 string
+	keyConditionExpression    *string
+	filterExpression          *string
+	projectionExpression      *string
+	expressionAttributeNames  map[string]string
+	expressionAttributeValues map[string]types.AttributeValue
+	limit                     *int32
+	exclusiveStartKey         map[string]types.AttributeValue
+	scanIndexForward          *bool
+	selectMode                string
+}
+
+type readOutput struct {
+	lastKey map[string]types.AttributeValue
+	items   []map[string]types.AttributeValue
+	scanned int
+}
+
+const maxDynamoDBCount = int64(1<<31 - 1)
+
+func safeInt32(n int) int32 {
+	if int64(n) > maxDynamoDBCount {
+		return int32(maxDynamoDBCount)
+	}
+	return int32(n) // #nosec G115 -- n is bounded above by maxDynamoDBCount before conversion.
+}
+
+func (f *Fake) readItemsLocked(table *tableState, input readInput) readOutput {
+	items := collectReadItems(table, input)
+	sortReadItems(table, input, items)
+	items = applyExclusiveStartKey(table, input, items)
+	scanned := len(items)
+
+	lastKey, items := limitReadItems(table, input, items)
+	if strings.EqualFold(input.selectMode, string(types.SelectCount)) {
+		return readOutput{items: nil, lastKey: lastKey, scanned: scanned}
+	}
+	for i := range items {
+		items[i] = projectItem(items[i], input.projectionExpression, input.expressionAttributeNames)
+	}
+	return readOutput{items: items, lastKey: lastKey, scanned: scanned}
+}
+
+func collectReadItems(table *tableState, input readInput) []map[string]types.AttributeValue {
+	items := make([]map[string]types.AttributeValue, 0, len(table.items))
+	for _, item := range table.items {
+		if !evalCondition(input.keyConditionExpression, item, input.expressionAttributeNames, input.expressionAttributeValues) {
+			continue
+		}
+		if !evalCondition(input.filterExpression, item, input.expressionAttributeNames, input.expressionAttributeValues) {
+			continue
+		}
+		items = append(items, cloneItem(item))
+	}
+	return items
+}
+
+func sortReadItems(table *tableState, input readInput, items []map[string]types.AttributeValue) {
+	sortAttr := table.sk
+	if idx, ok := table.indexes[input.indexName]; ok && idx.sk != "" {
+		sortAttr = idx.sk
+	}
+	sort.Slice(items, func(i, j int) bool {
+		cmp := compareAV(items[i][sortAttr], items[j][sortAttr])
+		if cmp == 0 {
+			return itemSortKey(table, items[i]) < itemSortKey(table, items[j])
+		}
+		return cmp < 0
+	})
+	if input.scanIndexForward != nil && !aws.ToBool(input.scanIndexForward) {
+		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+			items[i], items[j] = items[j], items[i]
+		}
+	}
+}
+
+func applyExclusiveStartKey(table *tableState, input readInput, items []map[string]types.AttributeValue) []map[string]types.AttributeValue {
+	if len(input.exclusiveStartKey) > 0 {
+		startKey, err := table.keyFromKeyMap(input.exclusiveStartKey)
+		if err == nil {
+			for i, item := range items {
+				if itemSortKey(table, item) == startKey {
+					items = items[i+1:]
+					break
+				}
+			}
+		}
+	}
+	return items
+}
+
+func limitReadItems(table *tableState, input readInput, items []map[string]types.AttributeValue) (map[string]types.AttributeValue, []map[string]types.AttributeValue) {
+	limit := 0
+	if input.limit != nil && *input.limit > 0 {
+		limit = int(*input.limit)
+	}
+	var lastKey map[string]types.AttributeValue
+	if limit > 0 && len(items) > limit {
+		lastKey = table.keyMap(items[limit-1])
+		items = items[:limit]
+	}
+	return lastKey, items
+}
+
+func applyTransactWrite(tables map[string]*tableState, op types.TransactWriteItem) error {
+	switch {
+	case op.Put != nil:
+		return applyTransactPut(tables, op.Put)
+	case op.Update != nil:
+		return applyTransactUpdate(tables, op.Update)
+	case op.Delete != nil:
+		return applyTransactDelete(tables, op.Delete)
+	case op.ConditionCheck != nil:
+		return applyTransactConditionCheck(tables, op.ConditionCheck)
+	}
+	return nil
+}
+
+func applyTransactPut(tables map[string]*tableState, op *types.Put) error {
+	table := tableOrDefault(tables, aws.ToString(op.TableName))
+	key, err := table.itemKey(op.Item)
+	if err != nil {
+		return err
+	}
+	existing := table.items[key]
+	if !evalCondition(op.ConditionExpression, existing, op.ExpressionAttributeNames, op.ExpressionAttributeValues) {
+		return conditionalFailed()
+	}
+	table.items[key] = cloneItem(op.Item)
+	return nil
+}
+
+func applyTransactUpdate(tables map[string]*tableState, op *types.Update) error {
+	table := tableOrDefault(tables, aws.ToString(op.TableName))
+	key, err := table.keyFromKeyMap(op.Key)
+	if err != nil {
+		return err
+	}
+	item := cloneItem(table.items[key])
+	if !evalCondition(op.ConditionExpression, item, op.ExpressionAttributeNames, op.ExpressionAttributeValues) {
+		return conditionalFailed()
+	}
+	if item == nil {
+		item = cloneItem(op.Key)
+	}
+	if err := applyUpdateExpression(item, op.UpdateExpression, op.ExpressionAttributeNames, op.ExpressionAttributeValues); err != nil {
+		return err
+	}
+	table.items[key] = item
+	return nil
+}
+
+func applyTransactDelete(tables map[string]*tableState, op *types.Delete) error {
+	table, err := requiredTable(tables, aws.ToString(op.TableName))
+	if err != nil {
+		return err
+	}
+	key, err := table.keyFromKeyMap(op.Key)
+	if err != nil {
+		return err
+	}
+	existing := table.items[key]
+	if !evalCondition(op.ConditionExpression, existing, op.ExpressionAttributeNames, op.ExpressionAttributeValues) {
+		return conditionalFailed()
+	}
+	delete(table.items, key)
+	return nil
+}
+
+func applyTransactConditionCheck(tables map[string]*tableState, op *types.ConditionCheck) error {
+	table, err := requiredTable(tables, aws.ToString(op.TableName))
+	if err != nil {
+		return err
+	}
+	key, err := table.keyFromKeyMap(op.Key)
+	if err != nil {
+		return err
+	}
+	if !evalCondition(op.ConditionExpression, table.items[key], op.ExpressionAttributeNames, op.ExpressionAttributeValues) {
+		return conditionalFailed()
+	}
+	return nil
+}
+
+func (f *Fake) tableOrDefaultLocked(name string) *tableState {
+	return tableOrDefault(f.tables, name)
+}
+
+func tableOrDefault(tables map[string]*tableState, name string) *tableState {
+	if name == "" {
+		name = "default"
+	}
+	if table := tables[name]; table != nil {
+		return table
+	}
+	table := &tableState{
+		name:    name,
+		pk:      "PK",
+		sk:      "SK",
+		indexes: make(map[string]indexState),
+		items:   make(map[string]map[string]types.AttributeValue),
+	}
+	tables[name] = table
+	return table
+}
+
+func (f *Fake) requiredTableLocked(name string) (*tableState, error) {
+	return requiredTable(f.tables, name)
+}
+
+func requiredTable(tables map[string]*tableState, name string) (*tableState, error) {
+	table := tables[name]
+	if table == nil {
+		return nil, resourceNotFound(name)
+	}
+	return table, nil
+}
+
+func (f *Fake) cloneTablesLocked() map[string]*tableState {
+	out := make(map[string]*tableState, len(f.tables))
+	for name, table := range f.tables {
+		cloned := &tableState{
+			name:    table.name,
+			pk:      table.pk,
+			sk:      table.sk,
+			ttlAttr: table.ttlAttr,
+			indexes: make(map[string]indexState, len(table.indexes)),
+			items:   make(map[string]map[string]types.AttributeValue, len(table.items)),
+		}
+		for k, v := range table.indexes {
+			cloned.indexes[k] = v
+		}
+		for k, item := range table.items {
+			cloned.items[k] = cloneItem(item)
+		}
+		out[name] = cloned
+	}
+	return out
+}
+
+func applyKeySchema(table *tableState, schema []types.KeySchemaElement) {
+	for _, key := range schema {
+		switch key.KeyType {
+		case types.KeyTypeHash:
+			table.pk = aws.ToString(key.AttributeName)
+		case types.KeyTypeRange:
+			table.sk = aws.ToString(key.AttributeName)
+		}
+	}
+}
+
+func indexFromSchema(schema []types.KeySchemaElement) indexState {
+	var index indexState
+	for _, key := range schema {
+		switch key.KeyType {
+		case types.KeyTypeHash:
+			index.pk = aws.ToString(key.AttributeName)
+		case types.KeyTypeRange:
+			index.sk = aws.ToString(key.AttributeName)
+		}
+	}
+	return index
+}
+
+func tableDescription(table *tableState) *types.TableDescription {
+	if table == nil {
+		return nil
+	}
+	return &types.TableDescription{
+		TableName:   aws.String(table.name),
+		TableStatus: types.TableStatusActive,
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String(table.pk), KeyType: types.KeyTypeHash},
+			{AttributeName: aws.String(table.sk), KeyType: types.KeyTypeRange},
+		},
+		ItemCount: aws.Int64(int64(len(table.items))),
+	}
+}
+
+func tableNameFrom(input any) string {
+	switch v := input.(type) {
+	case *dynamodb.DescribeTableInput:
+		return aws.ToString(v.TableName)
+	case *dynamodb.DeleteTableInput:
+		return aws.ToString(v.TableName)
+	case *dynamodb.UpdateTimeToLiveInput:
+		return aws.ToString(v.TableName)
+	default:
+		return ""
+	}
+}
+
+func (t *tableState) keyFromKeyMap(key map[string]types.AttributeValue) (string, error) {
+	if len(key) == 0 {
+		return "", errors.New("key is required")
+	}
+	item := map[string]types.AttributeValue{t.pk: key[t.pk]}
+	if t.sk != "" {
+		item[t.sk] = key[t.sk]
+	}
+	return t.itemKey(item)
+}
+
+func (t *tableState) itemKey(item map[string]types.AttributeValue) (string, error) {
+	if t.pk == "" {
+		t.pk = "PK"
+	}
+	pk := item[t.pk]
+	if pk == nil {
+		return "", fmt.Errorf("missing partition key %s", t.pk)
+	}
+	key := avKeyComponent(pk)
+	if t.sk != "" {
+		sk := item[t.sk]
+		if sk == nil {
+			return "", fmt.Errorf("missing sort key %s", t.sk)
+		}
+		key += "|" + avKeyComponent(sk)
+	}
+	return key, nil
+}
+
+func (t *tableState) keyMap(item map[string]types.AttributeValue) map[string]types.AttributeValue {
+	key := map[string]types.AttributeValue{t.pk: cloneAV(item[t.pk])}
+	if t.sk != "" {
+		key[t.sk] = cloneAV(item[t.sk])
+	}
+	return key
+}
+
+func itemSortKey(table *tableState, item map[string]types.AttributeValue) string {
+	key, err := table.itemKey(item)
+	if err != nil {
+		return ""
+	}
+	return key
+}
+
+func evalCondition(expr *string, item map[string]types.AttributeValue, names map[string]string, values map[string]types.AttributeValue) bool {
+	if expr == nil || strings.TrimSpace(*expr) == "" {
+		return true
+	}
+	return evalExpr(strings.TrimSpace(*expr), item, names, values)
+}
+
+func evalExpr(expr string, item map[string]types.AttributeValue, names map[string]string, values map[string]types.AttributeValue) bool {
+	expr = trimOuterParens(strings.TrimSpace(expr))
+	if expr == "" {
+		return true
+	}
+	if result, ok := evalLogicalExpr(expr, item, names, values); ok {
+		return result
+	}
+	if result, ok := evalFunctionExpr(expr, item, names, values); ok {
+		return result
+	}
+	if result, ok := evalRangeOrMembershipExpr(expr, item, names, values); ok {
+		return result
+	}
+	if result, ok := evalComparisonExpr(expr, item, names, values); ok {
+		return result
+	}
+	return false
+}
+
+func evalLogicalExpr(expr string, item map[string]types.AttributeValue, names map[string]string, values map[string]types.AttributeValue) (bool, bool) {
+	if parts := splitLogical(expr, "OR"); len(parts) > 1 {
+		for _, part := range parts {
+			if evalExpr(part, item, names, values) {
+				return true, true
+			}
+		}
+		return false, true
+	}
+	if parts := splitLogical(expr, "AND"); len(parts) > 1 {
+		for _, part := range parts {
+			if !evalExpr(part, item, names, values) {
+				return false, true
+			}
+		}
+		return true, true
+	}
+	return false, false
+}
+
+func evalFunctionExpr(expr string, item map[string]types.AttributeValue, names map[string]string, values map[string]types.AttributeValue) (bool, bool) {
+	lower := strings.ToLower(expr)
+	if strings.HasPrefix(lower, "attribute_not_exists(") && strings.HasSuffix(expr, ")") {
+		attr := resolveName(expr[len("attribute_not_exists("):len(expr)-1], names)
+		return item == nil || item[attr] == nil, true
+	}
+	if strings.HasPrefix(lower, "attribute_exists(") && strings.HasSuffix(expr, ")") {
+		attr := resolveName(expr[len("attribute_exists("):len(expr)-1], names)
+		return item != nil && item[attr] != nil, true
+	}
+	if strings.HasPrefix(lower, "begins_with(") && strings.HasSuffix(expr, ")") {
+		return evalTwoArgFunction(expr, "begins_with", item, names, values, strings.HasPrefix), true
+	}
+	if strings.HasPrefix(lower, "contains(") && strings.HasSuffix(expr, ")") {
+		args := splitCSV(expr[len("contains(") : len(expr)-1])
+		if len(args) != 2 {
+			return false, true
+		}
+		return containsAV(item[resolveName(args[0], names)], values[strings.TrimSpace(args[1])]), true
+	}
+	return false, false
+}
+
+func evalTwoArgFunction(
+	expr string,
+	name string,
+	item map[string]types.AttributeValue,
+	names map[string]string,
+	values map[string]types.AttributeValue,
+	match func(string, string) bool,
+) bool {
+	args := splitCSV(expr[len(name)+1 : len(expr)-1])
+	if len(args) != 2 {
+		return false
+	}
+	have := stringValue(item[resolveName(args[0], names)])
+	want := stringValue(values[strings.TrimSpace(args[1])])
+	return match(have, want)
+}
+
+func evalRangeOrMembershipExpr(expr string, item map[string]types.AttributeValue, names map[string]string, values map[string]types.AttributeValue) (bool, bool) {
+	if attr, lo, hi, ok := parseBetween(expr); ok {
+		have := item[resolveName(attr, names)]
+		return compareAV(have, values[lo]) >= 0 && compareAV(have, values[hi]) <= 0, true
+	}
+	if attr, valueRefs, ok := parseIn(expr); ok {
+		have := item[resolveName(attr, names)]
+		for _, ref := range valueRefs {
+			if compareAV(have, values[ref]) == 0 {
+				return true, true
+			}
+		}
+		return false, true
+	}
+	return false, false
+}
+
+func evalComparisonExpr(expr string, item map[string]types.AttributeValue, names map[string]string, values map[string]types.AttributeValue) (bool, bool) {
+	for _, op := range []string{"<>", ">=", "<=", "=", ">", "<"} {
+		left, right, ok := splitComparison(expr, op)
+		if !ok {
+			continue
+		}
+		cmp := compareAV(item[resolveName(left, names)], values[strings.TrimSpace(right)])
+		return compareByOperator(cmp, op), true
+	}
+	return false, false
+}
+
+func compareByOperator(cmp int, op string) bool {
+	switch op {
+	case "=":
+		return cmp == 0
+	case "<>":
+		return cmp != 0
+	case ">":
+		return cmp > 0
+	case ">=":
+		return cmp >= 0
+	case "<":
+		return cmp < 0
+	case "<=":
+		return cmp <= 0
+	default:
+		return false
+	}
+}
+
+func splitLogical(expr, op string) []string {
+	target := " " + op + " "
+	var parts []string
+	depth := 0
+	between := false
+	start := 0
+	upper := strings.ToUpper(expr)
+	for i := 0; i < len(expr); i++ {
+		switch expr[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		}
+		if depth != 0 {
+			continue
+		}
+		if strings.HasPrefix(upper[i:], " BETWEEN ") {
+			between = true
+			continue
+		}
+		if strings.HasPrefix(upper[i:], target) {
+			if between && op == "AND" {
+				between = false
+				i += len(target) - 1
+				continue
+			}
+			parts = append(parts, strings.TrimSpace(expr[start:i]))
+			start = i + len(target)
+			i += len(target) - 1
+		}
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	parts = append(parts, strings.TrimSpace(expr[start:]))
+	return parts
+}
+
+func trimOuterParens(expr string) string {
+	for strings.HasPrefix(expr, "(") && strings.HasSuffix(expr, ")") && parensBalanced(expr[1:len(expr)-1]) {
+		expr = strings.TrimSpace(expr[1 : len(expr)-1])
+	}
+	return expr
+}
+
+func parensBalanced(expr string) bool {
+	depth := 0
+	for i := 0; i < len(expr); i++ {
+		switch expr[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return false
+			}
+		}
+	}
+	return depth == 0
+}
+
+func splitComparison(expr, op string) (string, string, bool) {
+	idx := strings.Index(expr, " "+op+" ")
+	if idx < 0 {
+		return "", "", false
+	}
+	return strings.TrimSpace(expr[:idx]), strings.TrimSpace(expr[idx+len(op)+2:]), true
+}
+
+func parseBetween(expr string) (string, string, string, bool) {
+	parts := strings.Split(expr, " BETWEEN ")
+	if len(parts) != 2 {
+		return "", "", "", false
+	}
+	bounds := strings.Split(parts[1], " AND ")
+	if len(bounds) != 2 {
+		return "", "", "", false
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(bounds[0]), strings.TrimSpace(bounds[1]), true
+}
+
+func parseIn(expr string) (string, []string, bool) {
+	idx := strings.Index(strings.ToUpper(expr), " IN ")
+	if idx < 0 {
+		return "", nil, false
+	}
+	attr := strings.TrimSpace(expr[:idx])
+	rest := strings.TrimSpace(expr[idx+4:])
+	if !strings.HasPrefix(rest, "(") || !strings.HasSuffix(rest, ")") {
+		return "", nil, false
+	}
+	values := splitCSV(rest[1 : len(rest)-1])
+	for i := range values {
+		values[i] = strings.TrimSpace(values[i])
+	}
+	return attr, values, true
+}
+
+func applyUpdateExpression(item map[string]types.AttributeValue, expr *string, names map[string]string, values map[string]types.AttributeValue) error {
+	if expr == nil || strings.TrimSpace(*expr) == "" {
+		return nil
+	}
+	sections := updateSections(*expr)
+	for action, body := range sections {
+		if err := applyUpdateSection(item, action, body, names, values); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyUpdateSection(item map[string]types.AttributeValue, action, body string, names map[string]string, values map[string]types.AttributeValue) error {
+	switch action {
+	case "SET":
+		return applySetSection(item, body, names, values)
+	case "ADD":
+		return applyAddSection(item, body, names, values)
+	case "REMOVE":
+		applyRemoveSection(item, body, names)
+	case "DELETE":
+		applyDeleteSection(item, body, names)
+	}
+	return nil
+}
+
+func applySetSection(item map[string]types.AttributeValue, body string, names map[string]string, values map[string]types.AttributeValue) error {
+	for _, assignment := range splitCSV(body) {
+		left, right, ok := strings.Cut(assignment, "=")
+		if !ok {
+			return fmt.Errorf("invalid SET assignment %q", assignment)
+		}
+		attr := resolveName(left, names)
+		value, err := evalUpdateValue(strings.TrimSpace(right), item, names, values)
+		if err != nil {
+			return err
+		}
+		item[attr] = value
+	}
+	return nil
+}
+
+func applyAddSection(item map[string]types.AttributeValue, body string, names map[string]string, values map[string]types.AttributeValue) error {
+	for _, addition := range splitCSV(body) {
+		fields := strings.Fields(addition)
+		if len(fields) != 2 {
+			return fmt.Errorf("invalid ADD expression %q", addition)
+		}
+		attr := resolveName(fields[0], names)
+		item[attr] = addAV(item[attr], values[fields[1]])
+	}
+	return nil
+}
+
+func applyRemoveSection(item map[string]types.AttributeValue, body string, names map[string]string) {
+	for _, attrExpr := range splitCSV(body) {
+		delete(item, resolveName(attrExpr, names))
+	}
+}
+
+func applyDeleteSection(item map[string]types.AttributeValue, body string, names map[string]string) {
+	for _, deleteExpr := range splitCSV(body) {
+		fields := strings.Fields(deleteExpr)
+		if len(fields) > 0 {
+			delete(item, resolveName(fields[0], names))
+		}
+	}
+}
+
+var updateKeywordRE = regexp.MustCompile(`\b(SET|ADD|REMOVE|DELETE)\b`)
+
+func updateSections(expr string) map[string]string {
+	matches := updateKeywordRE.FindAllStringIndex(expr, -1)
+	out := make(map[string]string, len(matches))
+	for i, match := range matches {
+		action := expr[match[0]:match[1]]
+		start := match[1]
+		end := len(expr)
+		if i+1 < len(matches) {
+			end = matches[i+1][0]
+		}
+		out[action] = strings.TrimSpace(expr[start:end])
+	}
+	return out
+}
+
+func evalUpdateValue(expr string, item map[string]types.AttributeValue, names map[string]string, values map[string]types.AttributeValue) (types.AttributeValue, error) {
+	if strings.Contains(expr, " + ") {
+		parts := strings.Split(expr, " + ")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid addition expression %q", expr)
+		}
+		left, err := evalUpdateValue(strings.TrimSpace(parts[0]), item, names, values)
+		if err != nil {
+			return nil, err
+		}
+		right, err := evalUpdateValue(strings.TrimSpace(parts[1]), item, names, values)
+		if err != nil {
+			return nil, err
+		}
+		return addAV(left, right), nil
+	}
+	if strings.HasPrefix(strings.ToLower(expr), "if_not_exists(") && strings.HasSuffix(expr, ")") {
+		args := splitCSV(expr[len("if_not_exists(") : len(expr)-1])
+		if len(args) != 2 {
+			return nil, fmt.Errorf("invalid if_not_exists expression %q", expr)
+		}
+		attr := resolveName(args[0], names)
+		if item[attr] != nil {
+			return cloneAV(item[attr]), nil
+		}
+		return evalUpdateValue(strings.TrimSpace(args[1]), item, names, values)
+	}
+	if strings.HasPrefix(expr, ":") {
+		return cloneAV(values[expr]), nil
+	}
+	return cloneAV(item[resolveName(expr, names)]), nil
+}
+
+func splitCSV(s string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, strings.TrimSpace(s[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	last := strings.TrimSpace(s[start:])
+	if last != "" {
+		parts = append(parts, last)
+	}
+	return parts
+}
+
+func resolveName(token string, names map[string]string) string {
+	token = strings.TrimSpace(token)
+	if resolved, ok := names[token]; ok {
+		return resolved
+	}
+	return token
+}
+
+func projectItem(item map[string]types.AttributeValue, projection *string, names map[string]string) map[string]types.AttributeValue {
+	if len(item) == 0 {
+		return item
+	}
+	if projection == nil || strings.TrimSpace(*projection) == "" {
+		return cloneItem(item)
+	}
+	out := make(map[string]types.AttributeValue)
+	for _, token := range splitCSV(*projection) {
+		attr := resolveName(token, names)
+		if av := item[attr]; av != nil {
+			out[attr] = cloneAV(av)
+		}
+	}
+	return out
+}
+
+func compareAV(left, right types.AttributeValue) int {
+	if cmp, ok := compareNilAV(left, right); ok {
+		return cmp
+	}
+	switch l := left.(type) {
+	case *types.AttributeValueMemberS:
+		return compareStringMember(l, right)
+	case *types.AttributeValueMemberN:
+		return compareNumberMember(l, right)
+	case *types.AttributeValueMemberB:
+		return compareBinaryMember(l, right)
+	case *types.AttributeValueMemberBOOL:
+		return compareBoolMember(l, right)
+	default:
+		if reflect.DeepEqual(left, right) {
+			return 0
+		}
+		return strings.Compare(avKeyComponent(left), avKeyComponent(right))
+	}
+}
+
+func compareNilAV(left, right types.AttributeValue) (int, bool) {
+	if left == nil && right == nil {
+		return 0, true
+	}
+	if left == nil {
+		return -1, true
+	}
+	if right == nil {
+		return 1, true
+	}
+	return 0, false
+}
+
+func compareStringMember(left *types.AttributeValueMemberS, right types.AttributeValue) int {
+	rightString, ok := right.(*types.AttributeValueMemberS)
+	if !ok {
+		return strings.Compare(avKeyComponent(left), avKeyComponent(right))
+	}
+	return strings.Compare(left.Value, rightString.Value)
+}
+
+func compareNumberMember(left *types.AttributeValueMemberN, right types.AttributeValue) int {
+	rightNumber, ok := right.(*types.AttributeValueMemberN)
+	if !ok {
+		return strings.Compare(avKeyComponent(left), avKeyComponent(right))
+	}
+	leftRat, leftOK := new(big.Rat).SetString(left.Value)
+	rightRat, rightOK := new(big.Rat).SetString(rightNumber.Value)
+	if !leftOK || !rightOK {
+		return strings.Compare(left.Value, rightNumber.Value)
+	}
+	return leftRat.Cmp(rightRat)
+}
+
+func compareBinaryMember(left *types.AttributeValueMemberB, right types.AttributeValue) int {
+	rightBinary, ok := right.(*types.AttributeValueMemberB)
+	if !ok {
+		return strings.Compare(avKeyComponent(left), avKeyComponent(right))
+	}
+	return bytes.Compare(left.Value, rightBinary.Value)
+}
+
+func compareBoolMember(left *types.AttributeValueMemberBOOL, right types.AttributeValue) int {
+	rightBool, ok := right.(*types.AttributeValueMemberBOOL)
+	if !ok {
+		return strings.Compare(avKeyComponent(left), avKeyComponent(right))
+	}
+	if left.Value == rightBool.Value {
+		return 0
+	}
+	if !left.Value {
+		return -1
+	}
+	return 1
+}
+
+func stringValue(av types.AttributeValue) string {
+	switch v := av.(type) {
+	case *types.AttributeValueMemberS:
+		return v.Value
+	case *types.AttributeValueMemberN:
+		return v.Value
+	case *types.AttributeValueMemberB:
+		return string(v.Value)
+	default:
+		return avKeyComponent(av)
+	}
+}
+
+func containsAV(container, needle types.AttributeValue) bool {
+	switch v := container.(type) {
+	case *types.AttributeValueMemberS:
+		return strings.Contains(v.Value, stringValue(needle))
+	case *types.AttributeValueMemberSS:
+		want := stringValue(needle)
+		for _, value := range v.Value {
+			if value == want {
+				return true
+			}
+		}
+	case *types.AttributeValueMemberNS:
+		want := stringValue(needle)
+		for _, value := range v.Value {
+			if value == want {
+				return true
+			}
+		}
+	case *types.AttributeValueMemberL:
+		for _, value := range v.Value {
+			if compareAV(value, needle) == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func addAV(left, right types.AttributeValue) types.AttributeValue {
+	if left == nil {
+		return cloneAV(right)
+	}
+	ln, lok := left.(*types.AttributeValueMemberN)
+	rn, rok := right.(*types.AttributeValueMemberN)
+	if lok && rok {
+		return &types.AttributeValueMemberN{Value: addNumberStrings(ln.Value, rn.Value)}
+	}
+	return cloneAV(right)
+}
+
+func addNumberStrings(left, right string) string {
+	l, lok := new(big.Rat).SetString(left)
+	r, rok := new(big.Rat).SetString(right)
+	if !lok || !rok {
+		li, lerr := strconv.ParseInt(left, 10, 64)
+		ri, rerr := strconv.ParseInt(right, 10, 64)
+		if lerr != nil || rerr != nil {
+			return right
+		}
+		return strconv.FormatInt(li+ri, 10)
+	}
+	l.Add(l, r)
+	if l.IsInt() {
+		return l.Num().String()
+	}
+	out := l.FloatString(10)
+	return strings.TrimRight(strings.TrimRight(out, "0"), ".")
+}
+
+func avKeyComponent(av types.AttributeValue) string {
+	switch v := av.(type) {
+	case *types.AttributeValueMemberS:
+		return "S:" + v.Value
+	case *types.AttributeValueMemberN:
+		return "N:" + v.Value
+	case *types.AttributeValueMemberB:
+		return "B:" + string(v.Value)
+	case *types.AttributeValueMemberBOOL:
+		return fmt.Sprintf("BOOL:%t", v.Value)
+	default:
+		return fmt.Sprintf("%T:%v", av, av)
+	}
+}
+
+func cloneItem(item map[string]types.AttributeValue) map[string]types.AttributeValue {
+	if item == nil {
+		return nil
+	}
+	out := make(map[string]types.AttributeValue, len(item))
+	for key, value := range item {
+		out[key] = cloneAV(value)
+	}
+	return out
+}
+
+func cloneAV(av types.AttributeValue) types.AttributeValue {
+	switch v := av.(type) {
+	case *types.AttributeValueMemberS:
+		return &types.AttributeValueMemberS{Value: v.Value}
+	case *types.AttributeValueMemberN:
+		return &types.AttributeValueMemberN{Value: v.Value}
+	case *types.AttributeValueMemberB:
+		return &types.AttributeValueMemberB{Value: append([]byte(nil), v.Value...)}
+	case *types.AttributeValueMemberBOOL:
+		return &types.AttributeValueMemberBOOL{Value: v.Value}
+	case *types.AttributeValueMemberNULL:
+		return &types.AttributeValueMemberNULL{Value: v.Value}
+	case *types.AttributeValueMemberSS:
+		return &types.AttributeValueMemberSS{Value: append([]string(nil), v.Value...)}
+	case *types.AttributeValueMemberNS:
+		return &types.AttributeValueMemberNS{Value: append([]string(nil), v.Value...)}
+	case *types.AttributeValueMemberBS:
+		out := make([][]byte, len(v.Value))
+		for i := range v.Value {
+			out[i] = append([]byte(nil), v.Value[i]...)
+		}
+		return &types.AttributeValueMemberBS{Value: out}
+	case *types.AttributeValueMemberL:
+		out := make([]types.AttributeValue, len(v.Value))
+		for i := range v.Value {
+			out[i] = cloneAV(v.Value[i])
+		}
+		return &types.AttributeValueMemberL{Value: out}
+	case *types.AttributeValueMemberM:
+		return &types.AttributeValueMemberM{Value: cloneItem(v.Value)}
+	default:
+		return av
+	}
+}
+
+func resourceNotFound(tableName string) error {
+	return &types.ResourceNotFoundException{Message: aws.String(fmt.Sprintf("table not found: %s", tableName))}
+}
+
+func conditionalFailed() error {
+	return &types.ConditionalCheckFailedException{Message: aws.String("conditional request failed")}
+}
+
+func transactionCanceled(index int, err error) error {
+	if err == nil {
+		return nil
+	}
+	code := "ConditionalCheckFailed"
+	message := err.Error()
+	return &types.TransactionCanceledException{
+		Message: aws.String("transaction canceled"),
+		CancellationReasons: []types.CancellationReason{
+			{
+				Code:    aws.String(code),
+				Message: aws.String(fmt.Sprintf("operation %d: %s", index, message)),
+			},
+		},
+	}
+}

--- a/pkg/testing/fakedb/fakedb_internal_test.go
+++ b/pkg/testing/fakedb/fakedb_internal_test.go
@@ -1,0 +1,172 @@
+package fakedb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpressionAndAttributeHelpers(t *testing.T) {
+	item := map[string]types.AttributeValue{
+		"blob":    &types.AttributeValueMemberB{Value: []byte("abc")},
+		"blobSet": &types.AttributeValueMemberBS{Value: [][]byte{[]byte("abc")}},
+		"flag":    &types.AttributeValueMemberBOOL{Value: true},
+		"list": &types.AttributeValueMemberL{Value: []types.AttributeValue{
+			&types.AttributeValueMemberS{Value: "needle"},
+		}},
+		"meta": &types.AttributeValueMemberM{Value: map[string]types.AttributeValue{
+			"k": &types.AttributeValueMemberS{Value: "v"},
+		}},
+		"name":    &types.AttributeValueMemberS{Value: "one"},
+		"nothing": &types.AttributeValueMemberNULL{Value: true},
+		"nums":    &types.AttributeValueMemberNS{Value: []string{"7"}},
+		"score":   &types.AttributeValueMemberN{Value: "7"},
+		"tags":    &types.AttributeValueMemberSS{Value: []string{"blue"}},
+	}
+	names := map[string]string{
+		"#blob":    "blob",
+		"#blobSet": "blobSet",
+		"#flag":    "flag",
+		"#list":    "list",
+		"#missing": "missing",
+		"#name":    "name",
+		"#nums":    "nums",
+		"#score":   "score",
+		"#tags":    "tags",
+	}
+	values := map[string]types.AttributeValue{
+		":blob":    &types.AttributeValueMemberB{Value: []byte("abc")},
+		":flag":    &types.AttributeValueMemberBOOL{Value: true},
+		":max":     &types.AttributeValueMemberN{Value: "9"},
+		":min":     &types.AttributeValueMemberN{Value: "1"},
+		":needle":  &types.AttributeValueMemberS{Value: "needle"},
+		":notName": &types.AttributeValueMemberS{Value: "two"},
+		":num":     &types.AttributeValueMemberN{Value: "7"},
+		":score":   &types.AttributeValueMemberN{Value: "7"},
+		":tag":     &types.AttributeValueMemberS{Value: "blue"},
+		":value":   &types.AttributeValueMemberS{Value: "one"},
+	}
+
+	for _, expr := range []string{
+		"(#score >= :score AND (#name = :value OR #name = :notName))",
+		"#score <> :min",
+		"#score < :max",
+		"#score <= :score",
+		"#score > :min",
+		"#name IN (:value, :notName)",
+		"attribute_exists(#name)",
+		"attribute_not_exists(#missing)",
+		"begins_with(#name, :value)",
+		"contains(#tags, :tag)",
+		"contains(#nums, :num)",
+		"contains(#list, :needle)",
+		"#blob = :blob",
+		"#flag = :flag",
+	} {
+		require.True(t, evalExpr(expr, item, names, values), expr)
+	}
+	require.False(t, evalExpr("contains(#blobSet, :blob)", item, names, values))
+	require.False(t, evalExpr("contains(#list)", item, names, values))
+	require.False(t, evalExpr("#name IN :value", item, names, values))
+	require.False(t, evalExpr("#score BETWEEN :min", item, names, values))
+	require.False(t, evalExpr("#name XOR :value", item, names, values))
+}
+
+func TestUpdateAndCloneHelpers(t *testing.T) {
+	item := map[string]types.AttributeValue{
+		"count": &types.AttributeValueMemberN{Value: "1"},
+		"drop":  &types.AttributeValueMemberS{Value: "x"},
+		"name":  &types.AttributeValueMemberS{Value: "one"},
+		"set":   &types.AttributeValueMemberSS{Value: []string{"a"}},
+	}
+	names := map[string]string{
+		"#count": "count",
+		"#drop":  "drop",
+		"#name":  "name",
+		"#set":   "set",
+	}
+	values := map[string]types.AttributeValue{
+		":fallback": &types.AttributeValueMemberS{Value: "fallback"},
+		":inc":      &types.AttributeValueMemberN{Value: "2"},
+		":set":      &types.AttributeValueMemberSS{Value: []string{"a"}},
+	}
+
+	err := applyUpdateExpression(
+		item,
+		aws.String("SET #name = if_not_exists(#name, :fallback), #count = #count + :inc REMOVE #drop DELETE #set :set"),
+		names,
+		values,
+	)
+	require.NoError(t, err)
+	require.Equal(t, &types.AttributeValueMemberS{Value: "one"}, item["name"])
+	require.Equal(t, &types.AttributeValueMemberN{Value: "3"}, item["count"])
+	require.Nil(t, item["drop"])
+	require.Nil(t, item["set"])
+
+	err = applyUpdateExpression(item, aws.String("SET #name"), names, values)
+	require.Error(t, err)
+	_, err = evalUpdateValue("#count + :inc + :fallback", item, names, values)
+	require.Error(t, err)
+	require.Equal(t, "2", addNumberStrings("bad", "2"))
+
+	cloned := cloneAV(&types.AttributeValueMemberM{Value: map[string]types.AttributeValue{
+		"bs":   &types.AttributeValueMemberBS{Value: [][]byte{[]byte("x")}},
+		"bool": &types.AttributeValueMemberBOOL{Value: false},
+		"list": &types.AttributeValueMemberL{Value: []types.AttributeValue{
+			&types.AttributeValueMemberNULL{Value: true},
+		}},
+	}})
+	require.NotNil(t, cloned)
+	require.Equal(t, 0, compareAV(nil, nil))
+	require.Equal(t, -1, compareAV(nil, &types.AttributeValueMemberS{Value: "x"}))
+	require.Equal(t, 1, compareAV(&types.AttributeValueMemberS{Value: "x"}, nil))
+	require.Equal(t, 0, compareAV(&types.AttributeValueMemberB{Value: []byte("a")}, &types.AttributeValueMemberB{Value: []byte("a")}))
+	require.Equal(t, -1, compareAV(&types.AttributeValueMemberBOOL{Value: false}, &types.AttributeValueMemberBOOL{Value: true}))
+	require.NotEmpty(t, avKeyComponent(cloned))
+	require.True(t, parensBalanced("(#a AND (#b))"))
+	require.False(t, parensBalanced("(#a"))
+}
+
+func TestErrorBranchesAndScalarHelpers(t *testing.T) {
+	ctx := context.Background()
+	fake := New()
+	_, err := fake.CreateTable(ctx, nil)
+	require.Error(t, err)
+	_, err = fake.CreateBackup(ctx, &dynamodb.CreateBackupInput{TableName: aws.String("missing")})
+	require.Error(t, err)
+	_, err = fake.UpdateTable(ctx, nil)
+	require.Error(t, err)
+	_, err = fake.UpdateTimeToLive(ctx, &dynamodb.UpdateTimeToLiveInput{TableName: aws.String("missing")})
+	require.Error(t, err)
+	_, err = fake.Query(ctx, nil)
+	require.Error(t, err)
+	_, err = fake.Scan(ctx, nil)
+	require.Error(t, err)
+	_, err = fake.BatchGetItem(ctx, nil)
+	require.Error(t, err)
+	_, err = fake.BatchWriteItem(ctx, nil)
+	require.Error(t, err)
+
+	require.Equal(t, int32(maxDynamoDBCount), safeInt32(int(maxDynamoDBCount)+1))
+	tables := map[string]*tableState{}
+	require.Same(t, tableOrDefault(tables, ""), tableOrDefault(tables, "default"))
+	require.NotNil(t, tableDescription(&tableState{name: "pk_only", pk: "PK"}))
+
+	require.NotZero(t, compareAV(&types.AttributeValueMemberS{Value: "x"}, &types.AttributeValueMemberN{Value: "1"}))
+	require.NotZero(t, compareAV(&types.AttributeValueMemberN{Value: "bad"}, &types.AttributeValueMemberN{Value: "1"}))
+	require.NotZero(t, compareAV(&types.AttributeValueMemberB{Value: []byte("b")}, &types.AttributeValueMemberB{Value: []byte("a")}))
+	require.Zero(t, compareAV(&types.AttributeValueMemberBOOL{Value: true}, &types.AttributeValueMemberBOOL{Value: true}))
+	require.Zero(t, compareAV(&types.AttributeValueMemberNULL{Value: true}, &types.AttributeValueMemberNULL{Value: true}))
+	require.NotEmpty(t, stringValue(&types.AttributeValueMemberBOOL{Value: true}))
+	require.Equal(t, &types.AttributeValueMemberS{Value: "fallback"}, addAV(nil, &types.AttributeValueMemberS{Value: "fallback"}))
+	require.Equal(t, &types.AttributeValueMemberS{Value: "right"}, addAV(&types.AttributeValueMemberS{Value: "left"}, &types.AttributeValueMemberS{Value: "right"}))
+	require.NotEmpty(t, avKeyComponent(&types.AttributeValueMemberBOOL{Value: true}))
+	require.NotEmpty(t, avKeyComponent(&types.AttributeValueMemberNULL{Value: true}))
+	require.NotEmpty(t, avKeyComponent(&types.AttributeValueMemberSS{Value: []string{"a"}}))
+	require.NotEmpty(t, avKeyComponent(&types.AttributeValueMemberL{Value: []types.AttributeValue{&types.AttributeValueMemberS{Value: "a"}}}))
+	require.Nil(t, cloneAV(nil))
+}

--- a/pkg/testing/fakedb/fakedb_test.go
+++ b/pkg/testing/fakedb/fakedb_test.go
@@ -1,10 +1,14 @@
 package fakedb_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/theory-cloud/tabletheory"
@@ -82,4 +86,277 @@ func TestNewWithClientUsesStatefulFake(t *testing.T) {
 func TestNewWithClientRejectsNilClient(t *testing.T) {
 	_, err := tabletheory.NewWithClient(session.Config{}, nil)
 	require.ErrorContains(t, err, "DynamoDB client is nil")
+}
+
+func TestFakeSupportsAdminBatchScanAndTransactions(t *testing.T) {
+	ctx := context.Background()
+	fake := fakedb.New()
+	tableName := "stateful_fake"
+
+	_, err := fake.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("PK"), KeyType: types.KeyTypeHash},
+			{AttributeName: aws.String("SK"), KeyType: types.KeyTypeRange},
+		},
+		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+			{
+				IndexName: aws.String("gsi1"),
+				KeySchema: []types.KeySchemaElement{
+					{AttributeName: aws.String("GPK"), KeyType: types.KeyTypeHash},
+					{AttributeName: aws.String("GSK"), KeyType: types.KeyTypeRange},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = fake.CreateTable(ctx, &dynamodb.CreateTableInput{TableName: aws.String(tableName)})
+	require.ErrorAs(t, err, new(*types.ResourceInUseException))
+
+	_, err = fake.UpdateTimeToLive(ctx, &dynamodb.UpdateTimeToLiveInput{
+		TableName: aws.String(tableName),
+		TimeToLiveSpecification: &types.TimeToLiveSpecification{
+			AttributeName: aws.String("ttl"),
+			Enabled:       aws.Bool(true),
+		},
+	})
+	require.NoError(t, err)
+
+	backup, err := fake.CreateBackup(ctx, &dynamodb.CreateBackupInput{
+		TableName:  aws.String(tableName),
+		BackupName: aws.String("unit"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.BackupStatusAvailable, backup.BackupDetails.BackupStatus)
+
+	_, err = fake.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName: aws.String(tableName),
+		GlobalSecondaryIndexUpdates: []types.GlobalSecondaryIndexUpdate{
+			{
+				Create: &types.CreateGlobalSecondaryIndexAction{
+					IndexName: aws.String("gsi2"),
+					KeySchema: []types.KeySchemaElement{
+						{AttributeName: aws.String("AltPK"), KeyType: types.KeyTypeHash},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, fake.Seed(tableName,
+		fakeItem("USER#1", "A", "one", "10", "blue", "G#1", "001"),
+		fakeItem("USER#1", "B", "two", "20", "green", "G#1", "002"),
+		fakeItem("USER#2", "A", "three", "30", "blue", "G#2", "001"),
+	))
+	require.Len(t, fake.Items(tableName), 3)
+
+	tables, err := fake.ListTables(ctx, &dynamodb.ListTablesInput{Limit: aws.Int32(1)})
+	require.NoError(t, err)
+	require.Equal(t, []string{tableName}, tables.TableNames)
+
+	got, err := fake.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:            aws.String(tableName),
+		Key:                  fakeKey("USER#1", "A"),
+		ProjectionExpression: aws.String("PK, #n"),
+		ExpressionAttributeNames: map[string]string{
+			"#n": "name",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, avS("one"), got.Item["name"])
+	require.Nil(t, got.Item["score"])
+
+	scanned, err := fake.Scan(ctx, &dynamodb.ScanInput{
+		TableName:        aws.String(tableName),
+		FilterExpression: aws.String("contains(#tags, :tag) OR #score BETWEEN :lo AND :hi"),
+		ExpressionAttributeNames: map[string]string{
+			"#score": "score",
+			"#tags":  "tags",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":hi":  avN("25"),
+			":lo":  avN("15"),
+			":tag": avS("blue"),
+		},
+		Limit: aws.Int32(2),
+	})
+	require.NoError(t, err)
+	require.Len(t, scanned.Items, 2)
+	require.NotEmpty(t, scanned.LastEvaluatedKey)
+
+	counted, err := fake.Scan(ctx, &dynamodb.ScanInput{
+		TableName: aws.String(tableName),
+		Select:    types.SelectCount,
+	})
+	require.NoError(t, err)
+	require.Empty(t, counted.Items)
+	require.Equal(t, int32(3), counted.ScannedCount)
+
+	gsiPage, err := fake.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		IndexName:              aws.String("gsi1"),
+		KeyConditionExpression: aws.String("#gpk = :gpk AND #gsk >= :min"),
+		ExpressionAttributeNames: map[string]string{
+			"#gpk": "GPK",
+			"#gsk": "GSK",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":gpk": avS("G#1"),
+			":min": avS("001"),
+		},
+		ScanIndexForward: aws.Bool(false),
+		Limit:            aws.Int32(1),
+	})
+	require.NoError(t, err)
+	require.Equal(t, avS("B"), gsiPage.Items[0]["SK"])
+	require.NotEmpty(t, gsiPage.LastEvaluatedKey)
+
+	nextGSIPage, err := fake.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		IndexName:              aws.String("gsi1"),
+		KeyConditionExpression: aws.String("#gpk = :gpk AND #gsk >= :min"),
+		ExpressionAttributeNames: map[string]string{
+			"#gpk": "GPK",
+			"#gsk": "GSK",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":gpk": avS("G#1"),
+			":min": avS("001"),
+		},
+		ExclusiveStartKey: gsiPage.LastEvaluatedKey,
+		ScanIndexForward:  aws.Bool(false),
+	})
+	require.NoError(t, err)
+	require.Equal(t, avS("A"), nextGSIPage.Items[0]["SK"])
+
+	_, err = fake.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			tableName: {
+				{PutRequest: &types.PutRequest{Item: fakeItem("USER#1", "C", "four", "40", "red", "G#1", "003")}},
+				{DeleteRequest: &types.DeleteRequest{Key: fakeKey("USER#1", "B")}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	batch, err := fake.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]types.KeysAndAttributes{
+			tableName: {
+				Keys: []map[string]types.AttributeValue{
+					fakeKey("USER#1", "A"),
+					fakeKey("USER#1", "C"),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, batch.Responses[tableName], 2)
+
+	updated, err := fake.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(tableName),
+		Key:       fakeKey("USER#1", "C"),
+		UpdateExpression: aws.String(
+			"SET #note = if_not_exists(#note, :note), #score = #score + :inc REMOVE #tags DELETE #unused :unused",
+		),
+		ExpressionAttributeNames: map[string]string{
+			"#note":   "note",
+			"#score":  "score",
+			"#tags":   "tags",
+			"#unused": "unused",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":inc":    avN("2"),
+			":note":   avS("seeded"),
+			":unused": avS("unused"),
+		},
+		ReturnValues: types.ReturnValueAllNew,
+	})
+	require.NoError(t, err)
+	require.Equal(t, avN("42"), updated.Attributes["score"])
+	require.Equal(t, avS("seeded"), updated.Attributes["note"])
+	require.Nil(t, updated.Attributes["tags"])
+
+	transactRead, err := fake.TransactGetItems(ctx, &dynamodb.TransactGetItemsInput{
+		TransactItems: []types.TransactGetItem{
+			{Get: &types.Get{TableName: aws.String(tableName), Key: fakeKey("USER#1", "C")}},
+			{Get: &types.Get{TableName: aws.String(tableName), Key: fakeKey("MISSING", "A")}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, transactRead.Responses, 2)
+	require.NotNil(t, transactRead.Responses[0].Item)
+	require.Nil(t, transactRead.Responses[1].Item)
+
+	_, err = fake.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+		TransactItems: []types.TransactWriteItem{
+			{Put: &types.Put{TableName: aws.String(tableName), Item: fakeItem("TX#1", "A", "tx", "1", "tx", "G#9", "001")}},
+			{ConditionCheck: &types.ConditionCheck{
+				TableName:           aws.String(tableName),
+				Key:                 fakeKey("USER#1", "C"),
+				ConditionExpression: aws.String("attribute_exists(PK)"),
+			}},
+			{Update: &types.Update{
+				TableName:                 aws.String(tableName),
+				Key:                       fakeKey("TX#1", "A"),
+				UpdateExpression:          aws.String("ADD #score :inc"),
+				ExpressionAttributeNames:  map[string]string{"#score": "score"},
+				ExpressionAttributeValues: map[string]types.AttributeValue{":inc": avN("1")},
+			}},
+			{Delete: &types.Delete{TableName: aws.String(tableName), Key: fakeKey("USER#2", "A")}},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = fake.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+		TransactItems: []types.TransactWriteItem{
+			{ConditionCheck: &types.ConditionCheck{
+				TableName:           aws.String(tableName),
+				Key:                 fakeKey("USER#1", "C"),
+				ConditionExpression: aws.String("attribute_not_exists(PK)"),
+			}},
+		},
+	})
+	require.ErrorAs(t, err, new(*types.TransactionCanceledException))
+
+	_, err = fake.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName:           aws.String(tableName),
+		Key:                 fakeKey("USER#1", "A"),
+		ConditionExpression: aws.String("attribute_exists(PK)"),
+	})
+	require.NoError(t, err)
+
+	_, err = fake.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String(tableName)})
+	require.NoError(t, err)
+	_, err = fake.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String(tableName)})
+	require.ErrorAs(t, err, new(*types.ResourceNotFoundException))
+
+	fake.Reset()
+	require.Empty(t, fake.Items(tableName))
+}
+
+func fakeItem(pk, sk, name, score, tag, gpk, gsk string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK":    avS(pk),
+		"SK":    avS(sk),
+		"GPK":   avS(gpk),
+		"GSK":   avS(gsk),
+		"name":  avS(name),
+		"score": avN(score),
+		"tags":  &types.AttributeValueMemberSS{Value: []string{tag}},
+		"ttl":   avN("1700000000"),
+	}
+}
+
+func fakeKey(pk, sk string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{"PK": avS(pk), "SK": avS(sk)}
+}
+
+func avS(value string) types.AttributeValue {
+	return &types.AttributeValueMemberS{Value: value}
+}
+
+func avN(value string) types.AttributeValue {
+	return &types.AttributeValueMemberN{Value: value}
 }

--- a/pkg/testing/fakedb/fakedb_test.go
+++ b/pkg/testing/fakedb/fakedb_test.go
@@ -1,0 +1,85 @@
+package fakedb_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory"
+	theorydberrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/session"
+	"github.com/theory-cloud/tabletheory/pkg/testing/fakedb"
+)
+
+type fakeUser struct {
+	CreatedAt time.Time `theorydb:"created_at" json:"createdAt"`
+	UpdatedAt time.Time `theorydb:"updated_at" json:"updatedAt"`
+	PK        string    `theorydb:"pk" json:"PK"`
+	SK        string    `theorydb:"sk" json:"SK"`
+	EmailHash string    `json:"emailHash"`
+	Nickname  string    `json:"nickname,omitempty"`
+	Version   int64     `theorydb:"version" json:"version"`
+	TTL       int64     `theorydb:"ttl,omitempty" json:"ttl,omitempty"`
+}
+
+func (fakeUser) TableName() string { return "fake_users" }
+
+func TestNewWithClientUsesStatefulFake(t *testing.T) {
+	now := time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
+	fake := fakedb.New()
+	db, err := tabletheory.NewWithClient(session.Config{
+		Region: "us-east-1",
+		Now:    func() time.Time { return now },
+	}, fake)
+	require.NoError(t, err)
+
+	require.NoError(t, db.CreateTable(&fakeUser{}))
+	require.NoError(t, db.Model(&fakeUser{
+		PK:        "USER#1",
+		SK:        "PROFILE",
+		EmailHash: "test@example",
+		Nickname:  "one",
+		TTL:       1_700_000_000,
+	}).Create())
+
+	var queried []fakeUser
+	err = db.Model(&fakeUser{}).
+		Where("PK", "=", "USER#1").
+		Where("SK", "begins_with", "PRO").
+		Filter("emailHash", "=", "test@example").
+		All(&queried)
+	require.NoError(t, err)
+	require.Len(t, queried, 1)
+	require.Equal(t, "one", queried[0].Nickname)
+	require.Equal(t, int64(1_700_000_000), queried[0].TTL)
+	require.Equal(t, now, queried[0].CreatedAt)
+	require.Equal(t, int64(0), queried[0].Version)
+
+	require.NoError(t, db.Model(&fakeUser{
+		PK:       "USER#1",
+		SK:       "PROFILE",
+		Nickname: "two",
+		Version:  0,
+	}).Update("nickname"))
+
+	err = db.Model(&fakeUser{
+		PK:       "USER#1",
+		SK:       "PROFILE",
+		Nickname: "stale",
+		Version:  0,
+	}).Update("nickname")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, theorydberrors.ErrVersionConflict) || errors.Is(err, theorydberrors.ErrConditionFailed))
+
+	var got fakeUser
+	require.NoError(t, db.Model(&fakeUser{}).Where("PK", "=", "USER#1").Where("SK", "=", "PROFILE").First(&got))
+	require.Equal(t, "two", got.Nickname)
+	require.Equal(t, int64(1), got.Version)
+}
+
+func TestNewWithClientRejectsNilClient(t *testing.T) {
+	_, err := tabletheory.NewWithClient(session.Config{}, nil)
+	require.ErrorContains(t, err, "DynamoDB client is nil")
+}

--- a/pkg/transaction/builder.go
+++ b/pkg/transaction/builder.go
@@ -822,7 +822,7 @@ func (b *Builder) executeWithRetry(ctx context.Context, input *dynamodb.Transact
 			if b.session == nil {
 				return errors.New("dynamodb session is not configured")
 			}
-			client, err := b.session.Client()
+			client, err := b.session.API()
 			if err != nil {
 				return err
 			}

--- a/pkg/transaction/transact_get.go
+++ b/pkg/transaction/transact_get.go
@@ -61,7 +61,7 @@ func TransactGet(
 		return nil, err
 	}
 
-	client, err := sess.Client()
+	client, err := sess.API()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -365,7 +365,7 @@ func (tx *Transaction) Commit() error {
 			TransactItems: tx.writes,
 		}
 
-		client, err := tx.session.Client()
+		client, err := tx.session.API()
 		if err != nil {
 			return fmt.Errorf("failed to get client for transaction commit: %w", err)
 		}
@@ -382,7 +382,7 @@ func (tx *Transaction) Commit() error {
 			TransactItems: tx.reads,
 		}
 
-		client, err := tx.session.Client()
+		client, err := tx.session.API()
 		if err != nil {
 			return fmt.Errorf("failed to get client for transaction reads: %w", err)
 		}

--- a/py/docs/testing-guide.md
+++ b/py/docs/testing-guide.md
@@ -23,6 +23,34 @@ For tests involving encryption, inject deterministic `rand_bytes`:
 table = Table(model, client=fake_ddb, kms_key_arn="arn:aws:kms:...", kms_client=fake_kms, rand_bytes=lambda n: b"\x01" * n)
 ```
 
+## Stateful fake for behavioral unit tests
+
+Use `StatefulDynamoDBClient` from `tabletheory_py` or `tabletheory_py.testkit` when a test should exercise real
+TableTheory Python writes, queries, updates, batches, or transactions without scripting each low-level request:
+
+```python
+from tabletheory_py import StatefulDynamoDBClient, Table
+
+fake_ddb = StatefulDynamoDBClient()
+table = Table(model, client=fake_ddb, now=lambda: "2026-07-04T00:00:00.000000000Z")
+
+table.put(note)
+page = table.query("USER#1")
+
+assert len(page.items) == 1
+assert fake_ddb.items("notes")[0]["ttl"] == {"N": "1700000000"}
+```
+
+Choose the test double by intent:
+
+- `FakeDynamoDBClient`: ordered expectation mock for exact request-shape assertions and error injection.
+- `StatefulDynamoDBClient`: deterministic in-memory TableTheory behavior for write-then-query consumer tests. It honors
+  keys, basic expressions, optimistic-lock conditions, TTL attribute persistence, batches, and transactions, but it is not
+  a general DynamoDB emulator.
+- `moto`: useful only when a project already standardizes on moto-specific AWS emulation; it is outside TableTheory's
+  contract gate.
+- DynamoDB Local: authoritative choice for AWS-exact expression, index, pagination, throughput, and integration behavior.
+
 ## Integration testing (DynamoDB Local)
 
 Use DynamoDB Local to validate real DynamoDB constraints (pagination, conditional writes, batch limits).
@@ -38,4 +66,3 @@ Environment variables (typical for local):
 - `DYNAMODB_ENDPOINT` (default `http://localhost:8000`)
 - `AWS_REGION` (default `us-east-1`)
 - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (use `dummy`)
-

--- a/py/src/theorydb_py/__init__.py
+++ b/py/src/theorydb_py/__init__.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
         sum_field,
     )
     from .dms import assert_model_definition_equivalent_to_dms, get_dms_model, parse_dms_document
+    from .fakedb import StatefulDynamoDBClient
     from .lease import Lease, LeaseKey, LeaseManager
     from .multiaccount import AccountConfig, MultiAccountSessions
     from .optimizer import QueryOptimizer, QueryPlan, QueryShape, ScanShape
@@ -158,6 +159,10 @@ def __getattr__(name: str) -> Any:
         from .table import Table
 
         return {"DynamoDBClientProtocol": DynamoDBClientProtocol, "Table": Table}[name]
+    if name == "StatefulDynamoDBClient":
+        from .fakedb import StatefulDynamoDBClient
+
+        return StatefulDynamoDBClient
     if name in {
         "AggregateResult",
         "GroupByQuery",
@@ -310,6 +315,7 @@ __all__ = [
     "SimpleLimiter",
     "SortKeyCondition",
     "ScanShape",
+    "StatefulDynamoDBClient",
     "sum_field",
     "max_field",
     "min_field",

--- a/py/src/theorydb_py/fakedb.py
+++ b/py/src/theorydb_py/fakedb.py
@@ -177,7 +177,11 @@ class StatefulDynamoDBClient:
             for key in req.get("Keys", []):
                 item = table.items.get(_key_from_map(table, key))
                 if item is not None:
-                    found.append(_project(item, req.get("ProjectionExpression"), req.get("ExpressionAttributeNames") or {}))
+                    found.append(
+                        _project(
+                            item, req.get("ProjectionExpression"), req.get("ExpressionAttributeNames") or {}
+                        )
+                    )
             responses[str(table_name)] = found
         return {"Responses": responses}
 
@@ -293,7 +297,9 @@ def _apply_transact(tables: dict[str, _TableState], req: dict[str, Any]) -> None
             raise _client_error("ConditionalCheckFailedException", "conditional request failed")
 
 
-def _read_response(table: _TableState, source: list[Item], req: dict[str, Any], *, query: bool) -> dict[str, Any]:
+def _read_response(
+    table: _TableState, source: list[Item], req: dict[str, Any], *, query: bool
+) -> dict[str, Any]:
     names = req.get("ExpressionAttributeNames") or {}
     values = req.get("ExpressionAttributeValues") or {}
     items = [
@@ -351,7 +357,9 @@ def _matches(expression: Any, item: Item | None, names: dict[str, str], values: 
         return item is not None and item.get(_name(expr[len("attribute_exists(") : -1], names)) is not None
     if expr.startswith("begins_with("):
         left, right = _split_csv(expr[len("begins_with(") : -1])
-        return _string_value((item or {}).get(_name(left, names))).startswith(_string_value(values.get(right.strip())))
+        return _string_value((item or {}).get(_name(left, names))).startswith(
+            _string_value(values.get(right.strip()))
+        )
     for op in ("<>", ">=", "<=", "=", ">", "<"):
         marker = f" {op} "
         if marker not in expr:
@@ -520,7 +528,12 @@ def _table_description(table_name: str, table: _TableState) -> dict[str, Any]:
     key_schema = [{"AttributeName": table.pk, "KeyType": "HASH"}]
     if table.sk is not None:
         key_schema.append({"AttributeName": table.sk, "KeyType": "RANGE"})
-    return {"TableName": table_name, "TableStatus": "ACTIVE", "KeySchema": key_schema, "ItemCount": len(table.items)}
+    return {
+        "TableName": table_name,
+        "TableStatus": "ACTIVE",
+        "KeySchema": key_schema,
+        "ItemCount": len(table.items),
+    }
 
 
 def _client_error(code: str, message: str) -> ClientError:

--- a/py/src/theorydb_py/fakedb.py
+++ b/py/src/theorydb_py/fakedb.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+Item = dict[str, Any]
+
+
+@dataclass
+class _TableState:
+    pk: str = "PK"
+    sk: str | None = "SK"
+    items: dict[str, Item] = field(default_factory=dict)
+    ttl_attr: str | None = None
+
+
+class StatefulDynamoDBClient:
+    """State-backed in-memory DynamoDB client for TableTheory tests.
+
+    This is a deterministic local testing aid, not a DynamoDB emulator. Its
+    supported behavior is bounded to the TableTheory fake/testkit scenarios:
+    key-based writes/reads, basic query/scan filters, optimistic-lock
+    conditions, batches, transactions, and TTL attribute persistence.
+    """
+
+    def __init__(self) -> None:
+        self._tables: dict[str, _TableState] = {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def reset(self) -> None:
+        self._tables.clear()
+        self.calls.clear()
+
+    def seed(self, table_name: str, *items: Item) -> None:
+        table = self._table(table_name)
+        for item in items:
+            table.items[_item_key(table, item)] = deepcopy(item)
+
+    def items(self, table_name: str) -> list[Item]:
+        table = self._tables.get(table_name)
+        if table is None:
+            return []
+        return [deepcopy(item) for _, item in sorted(table.items.items())]
+
+    def create_table(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("create_table", kwargs)
+        table_name = str(kwargs.get("TableName") or "default")
+        if table_name in self._tables:
+            raise _client_error("ResourceInUseException", f"table already exists: {table_name}")
+        state = _TableState()
+        for key in kwargs.get("KeySchema", []):
+            if key.get("KeyType") == "HASH":
+                state.pk = str(key.get("AttributeName"))
+            if key.get("KeyType") == "RANGE":
+                state.sk = str(key.get("AttributeName"))
+        self._tables[table_name] = state
+        return {"TableDescription": _table_description(table_name, state)}
+
+    def describe_table(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("describe_table", kwargs)
+        table_name = str(kwargs.get("TableName") or "default")
+        table = self._tables.get(table_name)
+        if table is None:
+            raise _client_error("ResourceNotFoundException", f"table not found: {table_name}")
+        return {"Table": _table_description(table_name, table)}
+
+    def delete_table(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("delete_table", kwargs)
+        table_name = str(kwargs.get("TableName") or "default")
+        table = self._tables.get(table_name)
+        if table is None:
+            raise _client_error("ResourceNotFoundException", f"table not found: {table_name}")
+        del self._tables[table_name]
+        return {"TableDescription": _table_description(table_name, table)}
+
+    def update_time_to_live(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("update_time_to_live", kwargs)
+        table_name = str(kwargs.get("TableName") or "default")
+        table = self._tables.get(table_name)
+        if table is None:
+            raise _client_error("ResourceNotFoundException", f"table not found: {table_name}")
+        spec = dict(kwargs.get("TimeToLiveSpecification") or {})
+        attr = spec.get("AttributeName")
+        if attr:
+            table.ttl_attr = str(attr)
+        return {"TimeToLiveSpecification": spec}
+
+    def put_item(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("put_item", kwargs)
+        table = self._table(str(kwargs.get("TableName") or "default"))
+        item = deepcopy(dict(kwargs.get("Item") or {}))
+        key = _item_key(table, item)
+        existing = table.items.get(key)
+        if not _matches(
+            kwargs.get("ConditionExpression"),
+            existing,
+            kwargs.get("ExpressionAttributeNames") or {},
+            kwargs.get("ExpressionAttributeValues") or {},
+        ):
+            raise _client_error("ConditionalCheckFailedException", "conditional request failed")
+        table.items[key] = item
+        return {}
+
+    def get_item(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("get_item", kwargs)
+        table = self._table(str(kwargs.get("TableName") or "default"))
+        item = table.items.get(_key_from_map(table, dict(kwargs.get("Key") or {})))
+        if item is None:
+            return {}
+        return {
+            "Item": _project(
+                item,
+                kwargs.get("ProjectionExpression"),
+                kwargs.get("ExpressionAttributeNames") or {},
+            )
+        }
+
+    def update_item(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("update_item", kwargs)
+        table = self._table(str(kwargs.get("TableName") or "default"))
+        key = _key_from_map(table, dict(kwargs.get("Key") or {}))
+        current = table.items.get(key)
+        if not _matches(
+            kwargs.get("ConditionExpression"),
+            current,
+            kwargs.get("ExpressionAttributeNames") or {},
+            kwargs.get("ExpressionAttributeValues") or {},
+        ):
+            raise _client_error("ConditionalCheckFailedException", "conditional request failed")
+        item = deepcopy(current or kwargs.get("Key") or {})
+        _apply_update(
+            item,
+            str(kwargs.get("UpdateExpression") or ""),
+            kwargs.get("ExpressionAttributeNames") or {},
+            kwargs.get("ExpressionAttributeValues") or {},
+        )
+        table.items[key] = item
+        if kwargs.get("ReturnValues") in {"ALL_NEW", "UPDATED_NEW"}:
+            return {"Attributes": deepcopy(item)}
+        return {}
+
+    def delete_item(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("delete_item", kwargs)
+        table = self._table(str(kwargs.get("TableName") or "default"))
+        key = _key_from_map(table, dict(kwargs.get("Key") or {}))
+        current = table.items.get(key)
+        if not _matches(
+            kwargs.get("ConditionExpression"),
+            current,
+            kwargs.get("ExpressionAttributeNames") or {},
+            kwargs.get("ExpressionAttributeValues") or {},
+        ):
+            raise _client_error("ConditionalCheckFailedException", "conditional request failed")
+        table.items.pop(key, None)
+        return {}
+
+    def query(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("query", kwargs)
+        table = self._table(str(kwargs.get("TableName") or "default"))
+        return _read_response(table, list(table.items.values()), kwargs, query=True)
+
+    def scan(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("scan", kwargs)
+        table = self._table(str(kwargs.get("TableName") or "default"))
+        return _read_response(table, list(table.items.values()), kwargs, query=False)
+
+    def batch_get_item(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("batch_get_item", kwargs)
+        responses: dict[str, list[Item]] = {}
+        for table_name, req in (kwargs.get("RequestItems") or {}).items():
+            table = self._table(str(table_name))
+            found: list[Item] = []
+            for key in req.get("Keys", []):
+                item = table.items.get(_key_from_map(table, key))
+                if item is not None:
+                    found.append(_project(item, req.get("ProjectionExpression"), req.get("ExpressionAttributeNames") or {}))
+            responses[str(table_name)] = found
+        return {"Responses": responses}
+
+    def batch_write_item(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("batch_write_item", kwargs)
+        for table_name, requests in (kwargs.get("RequestItems") or {}).items():
+            table = self._table(str(table_name))
+            for req in requests:
+                if "PutRequest" in req:
+                    item = deepcopy(req["PutRequest"].get("Item") or {})
+                    table.items[_item_key(table, item)] = item
+                if "DeleteRequest" in req:
+                    table.items.pop(_key_from_map(table, req["DeleteRequest"].get("Key") or {}), None)
+        return {}
+
+    def transact_get_items(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("transact_get_items", kwargs)
+        responses: list[dict[str, Any]] = []
+        for req in kwargs.get("TransactItems") or []:
+            get = req.get("Get") or {}
+            table = self._table(str(get.get("TableName") or "default"))
+            item = table.items.get(_key_from_map(table, get.get("Key") or {}))
+            responses.append(
+                {
+                    "Item": _project(
+                        item or {},
+                        get.get("ProjectionExpression"),
+                        get.get("ExpressionAttributeNames") or {},
+                    )
+                }
+                if item is not None
+                else {}
+            )
+        return {"Responses": responses}
+
+    def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("transact_write_items", kwargs)
+        snapshot = deepcopy(self._tables)
+        try:
+            for req in kwargs.get("TransactItems") or []:
+                _apply_transact(snapshot, req)
+        except ClientError as err:
+            raise _transaction_error(err) from err
+        self._tables = snapshot
+        return {}
+
+    def _table(self, table_name: str) -> _TableState:
+        table = self._tables.get(table_name)
+        if table is None:
+            table = _TableState()
+            self._tables[table_name] = table
+        return table
+
+    def _record(self, method: str, kwargs: dict[str, Any]) -> None:
+        self.calls.append((method, deepcopy(kwargs)))
+
+
+def _apply_transact(tables: dict[str, _TableState], req: dict[str, Any]) -> None:
+    if "Put" in req:
+        put = req["Put"]
+        table = tables.setdefault(str(put.get("TableName") or "default"), _TableState())
+        item = deepcopy(put.get("Item") or {})
+        key = _item_key(table, item)
+        if not _matches(
+            put.get("ConditionExpression"),
+            table.items.get(key),
+            put.get("ExpressionAttributeNames") or {},
+            put.get("ExpressionAttributeValues") or {},
+        ):
+            raise _client_error("ConditionalCheckFailedException", "conditional request failed")
+        table.items[key] = item
+    if "Update" in req:
+        update = req["Update"]
+        table = tables.setdefault(str(update.get("TableName") or "default"), _TableState())
+        key = _key_from_map(table, update.get("Key") or {})
+        if not _matches(
+            update.get("ConditionExpression"),
+            table.items.get(key),
+            update.get("ExpressionAttributeNames") or {},
+            update.get("ExpressionAttributeValues") or {},
+        ):
+            raise _client_error("ConditionalCheckFailedException", "conditional request failed")
+        item = deepcopy(table.items.get(key) or update.get("Key") or {})
+        _apply_update(
+            item,
+            str(update.get("UpdateExpression") or ""),
+            update.get("ExpressionAttributeNames") or {},
+            update.get("ExpressionAttributeValues") or {},
+        )
+        table.items[key] = item
+    if "Delete" in req:
+        delete = req["Delete"]
+        table = tables.setdefault(str(delete.get("TableName") or "default"), _TableState())
+        key = _key_from_map(table, delete.get("Key") or {})
+        if not _matches(
+            delete.get("ConditionExpression"),
+            table.items.get(key),
+            delete.get("ExpressionAttributeNames") or {},
+            delete.get("ExpressionAttributeValues") or {},
+        ):
+            raise _client_error("ConditionalCheckFailedException", "conditional request failed")
+        table.items.pop(key, None)
+    if "ConditionCheck" in req:
+        check = req["ConditionCheck"]
+        table = tables.setdefault(str(check.get("TableName") or "default"), _TableState())
+        key = _key_from_map(table, check.get("Key") or {})
+        if not _matches(
+            check.get("ConditionExpression"),
+            table.items.get(key),
+            check.get("ExpressionAttributeNames") or {},
+            check.get("ExpressionAttributeValues") or {},
+        ):
+            raise _client_error("ConditionalCheckFailedException", "conditional request failed")
+
+
+def _read_response(table: _TableState, source: list[Item], req: dict[str, Any], *, query: bool) -> dict[str, Any]:
+    names = req.get("ExpressionAttributeNames") or {}
+    values = req.get("ExpressionAttributeValues") or {}
+    items = [
+        deepcopy(item)
+        for item in source
+        if (not query or _matches(req.get("KeyConditionExpression"), item, names, values))
+        and _matches(req.get("FilterExpression"), item, names, values)
+    ]
+    if table.sk is not None:
+        sort_key = table.sk
+        items.sort(key=lambda item: _key_part(item.get(sort_key)))
+    if req.get("ScanIndexForward") is False:
+        items.reverse()
+    if req.get("ExclusiveStartKey"):
+        start = _key_from_map(table, req["ExclusiveStartKey"])
+        for idx, item in enumerate(items):
+            if _item_key(table, item) == start:
+                items = items[idx + 1 :]
+                break
+    scanned = len(items)
+    last_key: Item | None = None
+    limit = req.get("Limit")
+    if isinstance(limit, int) and limit > 0 and len(items) > limit:
+        last_key = _key_map(table, items[limit - 1])
+        items = items[:limit]
+    if req.get("Select") == "COUNT":
+        out: dict[str, Any] = {"Count": scanned, "ScannedCount": scanned}
+    else:
+        out = {
+            "Items": [
+                _project(item, req.get("ProjectionExpression"), req.get("ExpressionAttributeNames") or {})
+                for item in items
+            ],
+            "Count": len(items),
+            "ScannedCount": scanned,
+        }
+    if last_key is not None:
+        out["LastEvaluatedKey"] = last_key
+    return out
+
+
+def _matches(expression: Any, item: Item | None, names: dict[str, str], values: dict[str, Any]) -> bool:
+    expr = _strip_parens(str(expression or "").strip())
+    if not expr:
+        return True
+    parts = _split_logical(expr, "OR")
+    if len(parts) > 1:
+        return any(_matches(part, item, names, values) for part in parts)
+    parts = _split_logical(expr, "AND")
+    if len(parts) > 1:
+        return all(_matches(part, item, names, values) for part in parts)
+    if expr.startswith("attribute_not_exists("):
+        return item is None or item.get(_name(expr[len("attribute_not_exists(") : -1], names)) is None
+    if expr.startswith("attribute_exists("):
+        return item is not None and item.get(_name(expr[len("attribute_exists(") : -1], names)) is not None
+    if expr.startswith("begins_with("):
+        left, right = _split_csv(expr[len("begins_with(") : -1])
+        return _string_value((item or {}).get(_name(left, names))).startswith(_string_value(values.get(right.strip())))
+    for op in ("<>", ">=", "<=", "=", ">", "<"):
+        marker = f" {op} "
+        if marker not in expr:
+            continue
+        left, right = expr.split(marker, 1)
+        cmp = _compare_av((item or {}).get(_name(left, names)), values.get(right.strip()))
+        return {
+            "=": cmp == 0,
+            "<>": cmp != 0,
+            ">": cmp > 0,
+            ">=": cmp >= 0,
+            "<": cmp < 0,
+            "<=": cmp <= 0,
+        }[op]
+    return False
+
+
+def _apply_update(item: Item, expression: str, names: dict[str, str], values: dict[str, Any]) -> None:
+    for action, body in _update_sections(expression):
+        if action == "SET":
+            for part in _split_csv(body):
+                left, right = part.split("=", 1)
+                item[_name(left, names)] = deepcopy(values[right.strip()])
+        if action == "ADD":
+            for part in _split_csv(body):
+                left, right = part.split()
+                item[_name(left, names)] = _add_av(item.get(_name(left, names)), values.get(right))
+        if action == "REMOVE":
+            for part in _split_csv(body):
+                item.pop(_name(part, names), None)
+
+
+def _update_sections(expression: str) -> list[tuple[str, str]]:
+    markers: list[tuple[int, str]] = []
+    for action in ("SET", "ADD", "REMOVE", "DELETE"):
+        idx = expression.find(action)
+        if idx >= 0:
+            markers.append((idx, action))
+    markers.sort()
+    out: list[tuple[str, str]] = []
+    for idx, (start, action) in enumerate(markers):
+        end = markers[idx + 1][0] if idx + 1 < len(markers) else len(expression)
+        out.append((action, expression[start + len(action) : end].strip()))
+    return out
+
+
+def _split_logical(expr: str, op: str) -> list[str]:
+    target = f" {op} "
+    depth = 0
+    start = 0
+    out: list[str] = []
+    i = 0
+    while i < len(expr):
+        if expr[i] == "(":
+            depth += 1
+        elif expr[i] == ")":
+            depth -= 1
+        elif depth == 0 and expr.startswith(target, i):
+            out.append(expr[start:i].strip())
+            i += len(target)
+            start = i
+            continue
+        i += 1
+    if not out:
+        return [expr]
+    out.append(expr[start:].strip())
+    return out
+
+
+def _split_csv(text: str) -> list[str]:
+    out: list[str] = []
+    depth = 0
+    start = 0
+    for idx, ch in enumerate(text):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            out.append(text[start:idx].strip())
+            start = idx + 1
+    tail = text[start:].strip()
+    if tail:
+        out.append(tail)
+    return out
+
+
+def _project(item: Item, expression: Any, names: dict[str, str]) -> Item:
+    if not expression:
+        return deepcopy(item)
+    out: Item = {}
+    for token in _split_csv(str(expression)):
+        attr = _name(token, names)
+        if attr in item:
+            out[attr] = deepcopy(item[attr])
+    return out
+
+
+def _name(token: str, names: dict[str, str]) -> str:
+    token = token.strip()
+    return names.get(token, token)
+
+
+def _item_key(table: _TableState, item: Item) -> str:
+    if table.pk not in item:
+        raise ValueError(f"missing partition key {table.pk}")
+    sk = table.sk
+    return _key_part(item[table.pk]) + ("|" + _key_part(item.get(sk)) if sk else "")
+
+
+def _key_from_map(table: _TableState, key: Item) -> str:
+    return _item_key(table, key)
+
+
+def _key_map(table: _TableState, item: Item) -> Item:
+    out = {table.pk: deepcopy(item[table.pk])}
+    if table.sk is not None:
+        out[table.sk] = deepcopy(item[table.sk])
+    return out
+
+
+def _key_part(av: Any) -> str:
+    if isinstance(av, dict):
+        if "S" in av:
+            return "S:" + str(av.get("S", ""))
+        if "N" in av:
+            return "N:" + str(av.get("N", ""))
+        if "B" in av:
+            return "B:" + repr(av.get("B", b""))
+    return repr(av)
+
+
+def _string_value(av: Any) -> str:
+    if isinstance(av, dict):
+        if "S" in av:
+            return str(av.get("S", ""))
+        if "N" in av:
+            return str(av.get("N", ""))
+    return _key_part(av)
+
+
+def _compare_av(left: Any, right: Any) -> int:
+    if isinstance(left, dict) and isinstance(right, dict) and "N" in left and "N" in right:
+        left_decimal = Decimal(str(left["N"]))
+        right_decimal = Decimal(str(right["N"]))
+        return (left_decimal > right_decimal) - (left_decimal < right_decimal)
+    lkey = _key_part(left)
+    rkey = _key_part(right)
+    return (lkey > rkey) - (lkey < rkey)
+
+
+def _add_av(left: Any, right: Any) -> Any:
+    if isinstance(left, dict) and isinstance(right, dict) and "N" in left and "N" in right:
+        total = Decimal(str(left["N"])) + Decimal(str(right["N"]))
+        return {"N": str(int(total)) if total == total.to_integral() else str(total)}
+    return deepcopy(right)
+
+
+def _strip_parens(expr: str) -> str:
+    while expr.startswith("(") and expr.endswith(")"):
+        expr = expr[1:-1].strip()
+    return expr
+
+
+def _table_description(table_name: str, table: _TableState) -> dict[str, Any]:
+    key_schema = [{"AttributeName": table.pk, "KeyType": "HASH"}]
+    if table.sk is not None:
+        key_schema.append({"AttributeName": table.sk, "KeyType": "RANGE"})
+    return {"TableName": table_name, "TableStatus": "ACTIVE", "KeySchema": key_schema, "ItemCount": len(table.items)}
+
+
+def _client_error(code: str, message: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": message}}, code)
+
+
+def _transaction_error(err: ClientError) -> ClientError:
+    return ClientError(
+        {
+            "Error": {"Code": "TransactionCanceledException", "Message": str(err)},
+            "CancellationReasons": [{"Code": "ConditionalCheckFailed", "Message": str(err)}],
+        },
+        "TransactWriteItems",
+    )

--- a/py/src/theorydb_py/testkit.py
+++ b/py/src/theorydb_py/testkit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from .fakedb import StatefulDynamoDBClient
 from .mocks import ANY, FakeDynamoDBClient, FakeKmsClient
 
 
@@ -28,6 +29,7 @@ __all__ = [
     "ANY",
     "FakeDynamoDBClient",
     "FakeKmsClient",
+    "StatefulDynamoDBClient",
     "fixed_rand_bytes",
     "no_sleep",
 ]

--- a/py/tests/unit/test_stateful_fakedb.py
+++ b/py/tests/unit/test_stateful_fakedb.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import pytest
+from botocore.exceptions import ClientError
 
 from tabletheory_py import StatefulDynamoDBClient as AliasStatefulDynamoDBClient
 from theorydb_py import (
@@ -14,6 +15,7 @@ from theorydb_py import (
     VersionConflictError,
     theorydb_field,
 )
+from theorydb_py import fakedb as fakedb_module
 from theorydb_py.testkit import StatefulDynamoDBClient as KitStatefulDynamoDBClient
 
 
@@ -32,6 +34,28 @@ class StatefulNote:
 def _table(client: StatefulDynamoDBClient) -> Table[StatefulNote]:
     model = ModelDefinition.from_dataclass(StatefulNote, table_name="notes_stateful")
     return Table(model, client=client, now=lambda: "2026-07-04T00:00:00.000000000Z")
+
+
+def _av_s(value: str) -> dict[str, str]:
+    return {"S": value}
+
+
+def _av_n(value: str) -> dict[str, str]:
+    return {"N": value}
+
+
+def _key(pk: str, sk: str) -> dict[str, dict[str, str]]:
+    return {"PK": _av_s(pk), "SK": _av_s(sk)}
+
+
+def _item(pk: str, sk: str, name: str, score: str) -> dict[str, object]:
+    return {
+        **_key(pk, sk),
+        "name": _av_s(name),
+        "score": _av_n(score),
+        "tag": _av_s(name[:1]),
+        "ttl": _av_n("1700000000"),
+    }
 
 
 def test_stateful_dynamodb_client_write_query_update_and_version_conflict() -> None:
@@ -73,3 +97,197 @@ def test_stateful_dynamodb_client_write_query_update_and_version_conflict() -> N
 def test_stateful_dynamodb_client_is_exported_from_testkit_and_top_level_aliases() -> None:
     assert KitStatefulDynamoDBClient is StatefulDynamoDBClient
     assert AliasStatefulDynamoDBClient is StatefulDynamoDBClient
+
+
+def test_stateful_dynamodb_client_admin_batches_scans_and_transactions() -> None:
+    client = StatefulDynamoDBClient()
+    table_name = "notes_direct"
+
+    client.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+    )
+    with pytest.raises(ClientError, match="ResourceInUseException"):
+        client.create_table(TableName=table_name)
+
+    ttl = client.update_time_to_live(
+        TableName=table_name,
+        TimeToLiveSpecification={"AttributeName": "ttl", "Enabled": True},
+    )
+    assert ttl["TimeToLiveSpecification"]["AttributeName"] == "ttl"
+
+    client.seed(
+        table_name,
+        _item("USER#1", "A", "one", "10"),
+        _item("USER#1", "B", "two", "20"),
+        _item("USER#2", "A", "three", "30"),
+    )
+    assert len(client.items(table_name)) == 3
+    assert client.describe_table(TableName=table_name)["Table"]["ItemCount"] == 3
+
+    projected = client.get_item(
+        TableName=table_name,
+        Key=_key("USER#1", "A"),
+        ProjectionExpression="PK, #n",
+        ExpressionAttributeNames={"#n": "name"},
+    )
+    assert projected["Item"]["name"] == _av_s("one")
+    assert "score" not in projected["Item"]
+    assert client.get_item(TableName=table_name, Key=_key("missing", "A")) == {}
+
+    scanned = client.scan(
+        TableName=table_name,
+        FilterExpression="(#score >= :min AND begins_with(#name, :prefix))",
+        ExpressionAttributeNames={"#name": "name", "#score": "score"},
+        ExpressionAttributeValues={":min": _av_n("10"), ":prefix": _av_s("t")},
+        Limit=1,
+    )
+    assert len(scanned["Items"]) == 1
+    assert scanned["LastEvaluatedKey"]
+
+    counted = client.scan(TableName=table_name, Select="COUNT")
+    assert counted["Count"] == 3
+    assert "Items" not in counted
+
+    query_page = client.query(
+        TableName=table_name,
+        KeyConditionExpression="#pk = :pk AND #sk >= :sk",
+        ExpressionAttributeNames={"#pk": "PK", "#sk": "SK"},
+        ExpressionAttributeValues={":pk": _av_s("USER#1"), ":sk": _av_s("A")},
+        ScanIndexForward=False,
+        Limit=1,
+    )
+    assert query_page["Items"][0]["SK"] == _av_s("B")
+
+    next_page = client.query(
+        TableName=table_name,
+        KeyConditionExpression="#pk = :pk AND #sk >= :sk",
+        ExpressionAttributeNames={"#pk": "PK", "#sk": "SK"},
+        ExpressionAttributeValues={":pk": _av_s("USER#1"), ":sk": _av_s("A")},
+        ExclusiveStartKey=query_page["LastEvaluatedKey"],
+        ScanIndexForward=False,
+    )
+    assert next_page["Items"][0]["SK"] == _av_s("A")
+
+    client.batch_write_item(
+        RequestItems={
+            table_name: [
+                {"PutRequest": {"Item": _item("USER#1", "C", "four", "40")}},
+                {"DeleteRequest": {"Key": _key("USER#1", "B")}},
+            ]
+        }
+    )
+    batch = client.batch_get_item(
+        RequestItems={table_name: {"Keys": [_key("USER#1", "A"), _key("USER#1", "C")]}}
+    )
+    assert len(batch["Responses"][table_name]) == 2
+
+    updated = client.update_item(
+        TableName=table_name,
+        Key=_key("USER#1", "C"),
+        UpdateExpression="SET #note = :note REMOVE #tag ADD #score :inc",
+        ExpressionAttributeNames={"#note": "note", "#score": "score", "#tag": "tag"},
+        ExpressionAttributeValues={":inc": _av_n("2"), ":note": _av_s("seeded")},
+        ReturnValues="ALL_NEW",
+    )
+    assert updated["Attributes"]["score"] == _av_n("42")
+    assert updated["Attributes"]["note"] == _av_s("seeded")
+    assert "tag" not in updated["Attributes"]
+
+    transact_read = client.transact_get_items(
+        TransactItems=[
+            {"Get": {"TableName": table_name, "Key": _key("USER#1", "C")}},
+            {"Get": {"TableName": table_name, "Key": _key("missing", "A")}},
+        ]
+    )
+    assert "Item" in transact_read["Responses"][0]
+    assert transact_read["Responses"][1] == {}
+
+    client.transact_write_items(
+        TransactItems=[
+            {"Put": {"TableName": table_name, "Item": _item("TX#1", "A", "tx", "1")}},
+            {
+                "ConditionCheck": {
+                    "TableName": table_name,
+                    "Key": _key("USER#1", "C"),
+                    "ConditionExpression": "attribute_exists(PK)",
+                }
+            },
+            {
+                "Update": {
+                    "TableName": table_name,
+                    "Key": _key("TX#1", "A"),
+                    "UpdateExpression": "ADD #score :inc",
+                    "ExpressionAttributeNames": {"#score": "score"},
+                    "ExpressionAttributeValues": {":inc": _av_n("1")},
+                }
+            },
+            {"Delete": {"TableName": table_name, "Key": _key("USER#2", "A")}},
+        ]
+    )
+    with pytest.raises(ClientError, match="TransactionCanceledException"):
+        client.transact_write_items(
+            TransactItems=[
+                {
+                    "ConditionCheck": {
+                        "TableName": table_name,
+                        "Key": _key("USER#1", "C"),
+                        "ConditionExpression": "attribute_not_exists(PK)",
+                    }
+                }
+            ]
+        )
+
+    client.delete_item(
+        TableName=table_name,
+        Key=_key("USER#1", "A"),
+        ConditionExpression="attribute_exists(PK)",
+    )
+    client.delete_table(TableName=table_name)
+    with pytest.raises(ClientError, match="ResourceNotFoundException"):
+        client.describe_table(TableName=table_name)
+    client.reset()
+    assert client.items(table_name) == []
+
+
+def test_stateful_fakedb_expression_helpers_cover_edge_branches() -> None:
+    item = {
+        "PK": _av_s("USER#1"),
+        "SK": _av_s("A"),
+        "blob": {"B": b"abc"},
+        "flag": {"BOOL": True},
+        "name": _av_s("one"),
+        "score": _av_n("7"),
+    }
+    names = {"#missing": "missing", "#name": "name", "#score": "score"}
+    values = {
+        ":max": _av_n("9"),
+        ":min": _av_n("1"),
+        ":not_name": _av_s("two"),
+        ":score": _av_n("7"),
+        ":value": _av_s("one"),
+    }
+
+    for expr in [
+        "(#score >= :score AND (#name = :value OR #name = :not_name))",
+        "#score <> :min",
+        "#score < :max",
+        "#score <= :score",
+        "#score > :min",
+        "attribute_exists(#name)",
+        "attribute_not_exists(#missing)",
+        "begins_with(#name, :value)",
+    ]:
+        assert fakedb_module._matches(expr, item, names, values)
+
+    assert not fakedb_module._matches("contains(#name, :value)", item, names, values)
+    assert fakedb_module._compare_av({"B": b"abc"}, {"B": b"abc"}) == 0
+    assert fakedb_module._compare_av({"BOOL": True}, {"BOOL": True}) == 0
+    assert fakedb_module._add_av(None, _av_s("fallback")) == _av_s("fallback")
+    assert fakedb_module._strip_parens("((#name = :value))") == "#name = :value"
+    assert fakedb_module._table_description("pk_only", fakedb_module._TableState(sk=None))["KeySchema"] == [
+        {"AttributeName": "PK", "KeyType": "HASH"}
+    ]

--- a/py/tests/unit/test_stateful_fakedb.py
+++ b/py/tests/unit/test_stateful_fakedb.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from tabletheory_py import StatefulDynamoDBClient as AliasStatefulDynamoDBClient
+from theorydb_py import (
+    FilterCondition,
+    ModelDefinition,
+    SortKeyCondition,
+    StatefulDynamoDBClient,
+    Table,
+    VersionConflictError,
+    theorydb_field,
+)
+from theorydb_py.testkit import StatefulDynamoDBClient as KitStatefulDynamoDBClient
+
+
+@dataclass(frozen=True)
+class StatefulNote:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    email: str = theorydb_field(name="email")
+    name: str = theorydb_field(name="name")
+    created_at: str = theorydb_field(name="createdAt", roles=["created_at"], default="")
+    updated_at: str = theorydb_field(name="updatedAt", roles=["updated_at"], default="")
+    version: int | None = theorydb_field(name="version", roles=["version"], default=None)
+    ttl: int = theorydb_field(name="ttl", roles=["ttl"], default=0)
+
+
+def _table(client: StatefulDynamoDBClient) -> Table[StatefulNote]:
+    model = ModelDefinition.from_dataclass(StatefulNote, table_name="notes_stateful")
+    return Table(model, client=client, now=lambda: "2026-07-04T00:00:00.000000000Z")
+
+
+def test_stateful_dynamodb_client_write_query_update_and_version_conflict() -> None:
+    client = StatefulDynamoDBClient()
+    table = _table(client)
+
+    table.put(
+        StatefulNote(
+            pk="USER#1",
+            sk="PROFILE",
+            email="test@example.com",
+            name="one",
+            ttl=1_700_000_000,
+        )
+    )
+
+    page = table.query(
+        "USER#1",
+        sort=SortKeyCondition.begins_with("PRO"),
+        filter=FilterCondition.eq("email", "test@example.com"),
+    )
+
+    assert len(page.items) == 1
+    assert page.items[0].created_at == "2026-07-04T00:00:00.000000000Z"
+    assert page.items[0].updated_at == "2026-07-04T00:00:00.000000000Z"
+    assert page.items[0].version == 0
+    assert client.items("notes_stateful")[0]["ttl"] == {"N": "1700000000"}
+
+    updated = table.update("USER#1", "PROFILE", {"name": "two"}, expected_version=0)
+    assert updated.name == "two"
+    assert updated.version == 1
+
+    with pytest.raises(VersionConflictError):
+        table.update("USER#1", "PROFILE", {"name": "stale"}, expected_version=0)
+
+    assert table.get("USER#1", "PROFILE").name == "two"
+
+
+def test_stateful_dynamodb_client_is_exported_from_testkit_and_top_level_aliases() -> None:
+    assert KitStatefulDynamoDBClient is StatefulDynamoDBClient
+    assert AliasStatefulDynamoDBClient is StatefulDynamoDBClient

--- a/tabletheory.go
+++ b/tabletheory.go
@@ -32,6 +32,7 @@ type (
 
 	// Re-export types for convenience.
 	Config            = session.Config
+	DynamoDBAPI       = session.DynamoDBAPI
 	AutoMigrateOption = schema.AutoMigrateOption
 	BatchGetOptions   = core.BatchGetOptions
 	KeyPair           = core.KeyPair
@@ -61,6 +62,12 @@ func UnmarshalStreamImage(streamImage map[string]events.DynamoDBAttributeValue, 
 
 func New(config session.Config) (core.ExtendedDB, error) {
 	return internaltheorydb.New(config)
+}
+
+// NewWithClient creates a TableTheory instance backed by an injected DynamoDBAPI.
+// It is intended for deterministic consumer tests and local fakes.
+func NewWithClient(config session.Config, client session.DynamoDBAPI) (core.ExtendedDB, error) {
+	return internaltheorydb.NewWithClient(config, client)
 }
 
 func NewBasic(config session.Config) (core.DB, error) {

--- a/ts/docs/testing-guide.md
+++ b/ts/docs/testing-guide.md
@@ -30,6 +30,34 @@ const db = new TheorydbClient(mock.client, {
 - Prefer deterministic clocks (`fixedNow(...)`) for lifecycle fields.
 - Prefer deterministic encryption providers for encrypted attributes.
 
+## Stateful fake for write-then-query tests
+
+Use `createStatefulDynamoDBClient()` when a consumer test should write through the real TableTheory TypeScript runtime and
+query the result back without DynamoDB Local:
+
+```ts
+import assert from 'node:assert/strict';
+
+import { TheorydbClient } from '@theory-cloud/tabletheory-ts';
+import {
+  createStatefulDynamoDBClient,
+  fixedNow,
+} from '@theory-cloud/tabletheory-ts/testkit';
+
+const { client, fake } = createStatefulDynamoDBClient();
+const db = new TheorydbClient(client, {
+  now: fixedNow('2026-07-04T00:00:00.000000000Z'),
+});
+
+// Register models, write through db, then query through db.
+assert.equal(fake.items('users').length, 0);
+```
+
+The stateful fake implements an AWS SDK v3-style `send()` backend for TableTheory's local test path: key-based reads and
+writes, conditional writes, optimistic-lock version updates, TTL attribute persistence, batches, transactions, and basic
+query/scan filters. It is deterministic and local; it is not a general DynamoDB emulator and does not replace DynamoDB
+Local for tests that require AWS-exact pagination, expression, throughput, or indexing behavior.
+
 ## Integration testing (DynamoDB Local)
 
 Use DynamoDB Local to validate real DynamoDB constraints (pagination, conditional writes, batch limits).

--- a/ts/src/testkit/index.ts
+++ b/ts/src/testkit/index.ts
@@ -24,6 +24,12 @@ import {
 
 import type { EncryptedEnvelope, EncryptionProvider } from '../encryption.js';
 
+export {
+  StatefulDynamoDBFake,
+  createStatefulDynamoDBClient,
+  type StatefulDynamoDBClient,
+} from './stateful-dynamodb.js';
+
 export type SupportedDynamoCommandCtor =
   | typeof PutItemCommand
   | typeof GetItemCommand

--- a/ts/src/testkit/stateful-dynamodb.ts
+++ b/ts/src/testkit/stateful-dynamodb.ts
@@ -1,0 +1,759 @@
+import {
+  BatchGetItemCommand,
+  BatchWriteItemCommand,
+  ConditionalCheckFailedException,
+  CreateTableCommand,
+  DeleteItemCommand,
+  DeleteTableCommand,
+  DescribeTableCommand,
+  GetItemCommand,
+  ListTablesCommand,
+  PutItemCommand,
+  QueryCommand,
+  ResourceInUseException,
+  ResourceNotFoundException,
+  ScanCommand,
+  TransactionCanceledException,
+  TransactGetItemsCommand,
+  TransactWriteItemsCommand,
+  UpdateItemCommand,
+  UpdateTimeToLiveCommand,
+  type AttributeValue,
+  type DynamoDBClient,
+  type WriteRequest,
+} from '@aws-sdk/client-dynamodb';
+
+type Item = Record<string, AttributeValue>;
+type Table = { items: Map<string, Item>; pk: string; sk?: string };
+
+export interface StatefulDynamoDBClient {
+  readonly client: DynamoDBClient;
+  readonly fake: StatefulDynamoDBFake;
+}
+
+type SupportedCommand =
+  | PutItemCommand
+  | GetItemCommand
+  | UpdateItemCommand
+  | DeleteItemCommand
+  | QueryCommand
+  | ScanCommand
+  | BatchGetItemCommand
+  | BatchWriteItemCommand
+  | CreateTableCommand
+  | DescribeTableCommand
+  | DeleteTableCommand
+  | ListTablesCommand
+  | UpdateTimeToLiveCommand
+  | TransactGetItemsCommand
+  | TransactWriteItemsCommand;
+
+export function createStatefulDynamoDBClient(): StatefulDynamoDBClient {
+  const fake = new StatefulDynamoDBFake();
+  return { fake, client: fake.client };
+}
+
+export class StatefulDynamoDBFake {
+  private readonly tables = new Map<string, Table>();
+
+  readonly client = {
+    send: async (command: SupportedCommand): Promise<unknown> =>
+      this.send(command),
+  } as unknown as DynamoDBClient;
+
+  reset(): void {
+    this.tables.clear();
+  }
+
+  seed(tableName: string, ...items: Item[]): void {
+    const table = this.table(tableName);
+    for (const item of items)
+      table.items.set(itemKey(table, item), cloneItem(item));
+  }
+
+  items(tableName: string): Item[] {
+    const table = this.tables.get(tableName);
+    if (!table) return [];
+    return [...table.items.values()]
+      .map(cloneItem)
+      .sort((a, b) => itemKey(table, a).localeCompare(itemKey(table, b)));
+  }
+
+  async send(command: SupportedCommand): Promise<unknown> {
+    if (command instanceof PutItemCommand) return this.put(command);
+    if (command instanceof GetItemCommand) return this.get(command);
+    if (command instanceof UpdateItemCommand) return this.update(command);
+    if (command instanceof DeleteItemCommand) return this.delete(command);
+    if (command instanceof QueryCommand) return this.query(command);
+    if (command instanceof ScanCommand) return this.scan(command);
+    if (command instanceof BatchGetItemCommand) return this.batchGet(command);
+    if (command instanceof BatchWriteItemCommand)
+      return this.batchWrite(command);
+    if (command instanceof CreateTableCommand) return this.createTable(command);
+    if (command instanceof DescribeTableCommand)
+      return this.describeTable(command);
+    if (command instanceof DeleteTableCommand) return this.deleteTable(command);
+    if (command instanceof ListTablesCommand) return this.listTables(command);
+    if (command instanceof UpdateTimeToLiveCommand)
+      return this.updateTimeToLive(command);
+    if (command instanceof TransactGetItemsCommand)
+      return this.transactGet(command);
+    if (command instanceof TransactWriteItemsCommand)
+      return this.transactWrite(command);
+    throw new Error('Unsupported DynamoDB command');
+  }
+
+  private createTable(command: CreateTableCommand): object {
+    const name = command.input.TableName ?? 'default';
+    if (this.tables.has(name)) throw resourceInUse(name);
+    const table: Table = {
+      pk: keySchemaAttribute(command.input.KeySchema, 'HASH') ?? 'PK',
+      items: new Map(),
+    };
+    const sk = keySchemaAttribute(command.input.KeySchema, 'RANGE');
+    if (sk) table.sk = sk;
+    this.tables.set(name, table);
+    return { $metadata: {}, TableDescription: tableDescription(name, table) };
+  }
+
+  private describeTable(command: DescribeTableCommand): object {
+    const name = command.input.TableName ?? 'default';
+    const table = this.tables.get(name);
+    if (!table) throw resourceNotFound(name);
+    return { $metadata: {}, Table: tableDescription(name, table) };
+  }
+
+  private deleteTable(command: DeleteTableCommand): object {
+    const name = command.input.TableName ?? 'default';
+    const table = this.tables.get(name);
+    if (!table) throw resourceNotFound(name);
+    this.tables.delete(name);
+    return { $metadata: {}, TableDescription: tableDescription(name, table) };
+  }
+
+  private listTables(command: ListTablesCommand): object {
+    const limit = command.input.Limit ?? this.tables.size;
+    return {
+      $metadata: {},
+      TableNames: [...this.tables.keys()].sort().slice(0, limit),
+    };
+  }
+
+  private updateTimeToLive(command: UpdateTimeToLiveCommand): object {
+    const name = command.input.TableName ?? 'default';
+    if (!this.tables.has(name)) throw resourceNotFound(name);
+    return {
+      $metadata: {},
+      TimeToLiveSpecification: command.input.TimeToLiveSpecification,
+    };
+  }
+
+  private put(command: PutItemCommand): object {
+    const input = command.input;
+    const table = this.table(input.TableName);
+    const key = itemKey(table, input.Item ?? {});
+    const existing = table.items.get(key);
+    if (
+      !matchesExpression(
+        input.ConditionExpression,
+        existing,
+        input.ExpressionAttributeNames,
+        input.ExpressionAttributeValues,
+      )
+    ) {
+      throw conditionalFailed();
+    }
+    table.items.set(key, cloneItem(input.Item ?? {}));
+    return { $metadata: {} };
+  }
+
+  private get(command: GetItemCommand): object {
+    const input = command.input;
+    const table = this.table(input.TableName);
+    const item = table.items.get(keyFromMap(table, input.Key ?? {}));
+    return {
+      $metadata: {},
+      ...(item
+        ? {
+            Item: projectItem(
+              item,
+              input.ProjectionExpression,
+              input.ExpressionAttributeNames,
+            ),
+          }
+        : {}),
+    };
+  }
+
+  private update(command: UpdateItemCommand): object {
+    const input = command.input;
+    const table = this.table(input.TableName);
+    const key = keyFromMap(table, input.Key ?? {});
+    const item = cloneItem(table.items.get(key) ?? input.Key ?? {});
+    if (
+      !matchesExpression(
+        input.ConditionExpression,
+        table.items.get(key),
+        input.ExpressionAttributeNames,
+        input.ExpressionAttributeValues,
+      )
+    ) {
+      throw conditionalFailed();
+    }
+    applyUpdate(
+      item,
+      input.UpdateExpression,
+      input.ExpressionAttributeNames,
+      input.ExpressionAttributeValues,
+    );
+    table.items.set(key, item);
+    return {
+      $metadata: {},
+      ...(input.ReturnValues === 'ALL_NEW' ||
+      input.ReturnValues === 'UPDATED_NEW'
+        ? { Attributes: cloneItem(item) }
+        : {}),
+    };
+  }
+
+  private delete(command: DeleteItemCommand): object {
+    const input = command.input;
+    const table = this.table(input.TableName);
+    const key = keyFromMap(table, input.Key ?? {});
+    const existing = table.items.get(key);
+    if (
+      !matchesExpression(
+        input.ConditionExpression,
+        existing,
+        input.ExpressionAttributeNames,
+        input.ExpressionAttributeValues,
+      )
+    ) {
+      throw conditionalFailed();
+    }
+    table.items.delete(key);
+    return { $metadata: {} };
+  }
+
+  private query(command: QueryCommand): object {
+    const input = command.input;
+    const table = this.table(input.TableName);
+    return readResponse(table, [...table.items.values()], {
+      keyExpression: input.KeyConditionExpression,
+      filterExpression: input.FilterExpression,
+      projectionExpression: input.ProjectionExpression,
+      names: input.ExpressionAttributeNames,
+      values: input.ExpressionAttributeValues,
+      limit: input.Limit,
+      exclusiveStartKey: input.ExclusiveStartKey,
+      forward: input.ScanIndexForward ?? true,
+      select: input.Select,
+    });
+  }
+
+  private scan(command: ScanCommand): object {
+    const input = command.input;
+    const table = this.table(input.TableName);
+    return readResponse(table, [...table.items.values()], {
+      filterExpression: input.FilterExpression,
+      projectionExpression: input.ProjectionExpression,
+      names: input.ExpressionAttributeNames,
+      values: input.ExpressionAttributeValues,
+      limit: input.Limit,
+      exclusiveStartKey: input.ExclusiveStartKey,
+      select: input.Select,
+    });
+  }
+
+  private batchGet(command: BatchGetItemCommand): object {
+    const responses: Record<string, Item[]> = {};
+    for (const [tableName, req] of Object.entries(
+      command.input.RequestItems ?? {},
+    )) {
+      const table = this.table(tableName);
+      responses[tableName] = [];
+      for (const key of req.Keys ?? []) {
+        const item = table.items.get(keyFromMap(table, key));
+        if (item) {
+          responses[tableName]!.push(
+            projectItem(
+              item,
+              req.ProjectionExpression,
+              req.ExpressionAttributeNames,
+            ),
+          );
+        }
+      }
+    }
+    return { $metadata: {}, Responses: responses };
+  }
+
+  private batchWrite(command: BatchWriteItemCommand): object {
+    for (const [tableName, writes] of Object.entries(
+      command.input.RequestItems ?? {},
+    )) {
+      const table = this.table(tableName);
+      for (const write of writes ?? []) this.applyWriteRequest(table, write);
+    }
+    return { $metadata: {} };
+  }
+
+  private transactGet(command: TransactGetItemsCommand): object {
+    const Responses = (command.input.TransactItems ?? []).map((op) => {
+      const get = op.Get;
+      if (!get) return {};
+      const table = this.table(get.TableName);
+      const item = table.items.get(keyFromMap(table, get.Key ?? {}));
+      return {
+        ...(item
+          ? {
+              Item: projectItem(
+                item,
+                get.ProjectionExpression,
+                get.ExpressionAttributeNames,
+              ),
+            }
+          : {}),
+      };
+    });
+    return { $metadata: {}, Responses };
+  }
+
+  private transactWrite(command: TransactWriteItemsCommand): object {
+    const snapshot = cloneTables(this.tables);
+    try {
+      for (const op of command.input.TransactItems ?? [])
+        applyTransact(snapshot, op);
+    } catch (err) {
+      throw transactionCanceled(err);
+    }
+    this.tables.clear();
+    for (const [name, table] of snapshot) this.tables.set(name, table);
+    return { $metadata: {} };
+  }
+
+  private applyWriteRequest(table: Table, write: WriteRequest): void {
+    if (write.PutRequest?.Item) {
+      table.items.set(
+        itemKey(table, write.PutRequest.Item),
+        cloneItem(write.PutRequest.Item),
+      );
+    }
+    if (write.DeleteRequest?.Key)
+      table.items.delete(keyFromMap(table, write.DeleteRequest.Key));
+  }
+
+  private table(name?: string): Table {
+    const tableName = name ?? 'default';
+    let table = this.tables.get(tableName);
+    if (!table) {
+      table = { pk: 'PK', sk: 'SK', items: new Map() };
+      this.tables.set(tableName, table);
+    }
+    return table;
+  }
+}
+
+function readResponse(
+  table: Table,
+  source: Item[],
+  opts: {
+    keyExpression?: string | undefined;
+    filterExpression?: string | undefined;
+    projectionExpression?: string | undefined;
+    names?: Record<string, string> | undefined;
+    values?: Record<string, AttributeValue> | undefined;
+    limit?: number | undefined;
+    exclusiveStartKey?: Item | undefined;
+    forward?: boolean | undefined;
+    select?: string | undefined;
+  },
+): object {
+  let items = source
+    .filter((item) =>
+      matchesExpression(opts.keyExpression, item, opts.names, opts.values),
+    )
+    .filter((item) =>
+      matchesExpression(opts.filterExpression, item, opts.names, opts.values),
+    )
+    .map(cloneItem)
+    .sort((a, b) => compareAV(a[table.sk ?? ''], b[table.sk ?? '']));
+  if (opts.forward === false) items = items.reverse();
+  if (opts.exclusiveStartKey) {
+    const start = keyFromMap(table, opts.exclusiveStartKey);
+    const index = items.findIndex((item) => itemKey(table, item) === start);
+    if (index >= 0) items = items.slice(index + 1);
+  }
+  const scanned = items.length;
+  let LastEvaluatedKey: Item | undefined;
+  if (opts.limit && items.length > opts.limit) {
+    LastEvaluatedKey = keyMap(table, items[opts.limit - 1]!);
+    items = items.slice(0, opts.limit);
+  }
+  if (opts.select === 'COUNT') {
+    return {
+      $metadata: {},
+      Count: scanned,
+      ScannedCount: scanned,
+      LastEvaluatedKey,
+    };
+  }
+  return {
+    $metadata: {},
+    Items: items.map((item) =>
+      projectItem(item, opts.projectionExpression, opts.names),
+    ),
+    Count: items.length,
+    ScannedCount: scanned,
+    LastEvaluatedKey,
+  };
+}
+
+function applyTransact(
+  tables: Map<string, Table>,
+  op: NonNullable<TransactWriteItemsCommand['input']['TransactItems']>[number],
+): void {
+  if (op.Put) {
+    const table = tableFrom(tables, op.Put.TableName);
+    const key = itemKey(table, op.Put.Item ?? {});
+    if (
+      !matchesExpression(
+        op.Put.ConditionExpression,
+        table.items.get(key),
+        op.Put.ExpressionAttributeNames,
+        op.Put.ExpressionAttributeValues,
+      )
+    )
+      throw conditionalFailed();
+    table.items.set(key, cloneItem(op.Put.Item ?? {}));
+  }
+  if (op.Update) {
+    const table = tableFrom(tables, op.Update.TableName);
+    const key = keyFromMap(table, op.Update.Key ?? {});
+    const item = cloneItem(table.items.get(key) ?? op.Update.Key ?? {});
+    if (
+      !matchesExpression(
+        op.Update.ConditionExpression,
+        table.items.get(key),
+        op.Update.ExpressionAttributeNames,
+        op.Update.ExpressionAttributeValues,
+      )
+    )
+      throw conditionalFailed();
+    applyUpdate(
+      item,
+      op.Update.UpdateExpression,
+      op.Update.ExpressionAttributeNames,
+      op.Update.ExpressionAttributeValues,
+    );
+    table.items.set(key, item);
+  }
+  if (op.Delete) {
+    const table = tableFrom(tables, op.Delete.TableName);
+    const key = keyFromMap(table, op.Delete.Key ?? {});
+    if (
+      !matchesExpression(
+        op.Delete.ConditionExpression,
+        table.items.get(key),
+        op.Delete.ExpressionAttributeNames,
+        op.Delete.ExpressionAttributeValues,
+      )
+    )
+      throw conditionalFailed();
+    table.items.delete(key);
+  }
+  if (op.ConditionCheck) {
+    const table = tableFrom(tables, op.ConditionCheck.TableName);
+    const key = keyFromMap(table, op.ConditionCheck.Key ?? {});
+    if (
+      !matchesExpression(
+        op.ConditionCheck.ConditionExpression,
+        table.items.get(key),
+        op.ConditionCheck.ExpressionAttributeNames,
+        op.ConditionCheck.ExpressionAttributeValues,
+      )
+    )
+      throw conditionalFailed();
+  }
+}
+
+function tableFrom(tables: Map<string, Table>, name?: string): Table {
+  const tableName = name ?? 'default';
+  let table = tables.get(tableName);
+  if (!table) {
+    table = { pk: 'PK', sk: 'SK', items: new Map() };
+    tables.set(tableName, table);
+  }
+  return table;
+}
+
+function keySchemaAttribute(
+  schema: NonNullable<CreateTableCommand['input']['KeySchema']> | undefined,
+  keyType: 'HASH' | 'RANGE',
+): string | undefined {
+  return schema?.find((key) => key.KeyType === keyType)?.AttributeName;
+}
+
+function tableDescription(name: string, table: Table): object {
+  return {
+    TableName: name,
+    TableStatus: 'ACTIVE',
+    KeySchema: [
+      { AttributeName: table.pk, KeyType: 'HASH' },
+      ...(table.sk ? [{ AttributeName: table.sk, KeyType: 'RANGE' }] : []),
+    ],
+    ItemCount: table.items.size,
+  };
+}
+
+function matchesExpression(
+  expression?: string,
+  item?: Item,
+  names: Record<string, string> = {},
+  values: Record<string, AttributeValue> = {},
+): boolean {
+  const expr = stripOuterParens(expression?.trim() ?? '');
+  if (!expr) return true;
+  const orParts = splitLogical(expr, 'OR');
+  if (orParts.length > 1)
+    return orParts.some((part) => matchesExpression(part, item, names, values));
+  const andParts = splitLogical(expr, 'AND');
+  if (andParts.length > 1)
+    return andParts.every((part) =>
+      matchesExpression(part, item, names, values),
+    );
+  if (expr.startsWith('attribute_not_exists('))
+    return item?.[nameOf(expr.slice(21, -1), names)] === undefined;
+  if (expr.startsWith('attribute_exists('))
+    return item?.[nameOf(expr.slice(17, -1), names)] !== undefined;
+  if (expr.startsWith('begins_with(')) {
+    const [attr, value] = splitCsv(expr.slice(12, -1));
+    return stringValue(item?.[nameOf(attr ?? '', names)]).startsWith(
+      stringValue(values[(value ?? '').trim()]),
+    );
+  }
+  for (const op of ['<>', '>=', '<=', '=', '>', '<']) {
+    const needle = ` ${op} `;
+    const idx = expr.indexOf(needle);
+    if (idx < 0) continue;
+    const left = expr.slice(0, idx);
+    const right = expr.slice(idx + needle.length).trim();
+    const cmp = compareAV(item?.[nameOf(left, names)], values[right]);
+    if (op === '=') return cmp === 0;
+    if (op === '<>') return cmp !== 0;
+    if (op === '>') return cmp > 0;
+    if (op === '>=') return cmp >= 0;
+    if (op === '<') return cmp < 0;
+    if (op === '<=') return cmp <= 0;
+  }
+  return false;
+}
+
+function applyUpdate(
+  item: Item,
+  expression?: string,
+  names: Record<string, string> = {},
+  values: Record<string, AttributeValue> = {},
+): void {
+  for (const [action, body] of updateSections(expression ?? '')) {
+    if (action === 'SET') {
+      for (const part of splitCsv(body)) {
+        const [left, right] = part.split(/\s*=\s*/);
+        if (left && right)
+          item[nameOf(left, names)] = cloneAV(values[right.trim()]);
+      }
+    }
+    if (action === 'ADD') {
+      for (const part of splitCsv(body)) {
+        const [left, right] = part.trim().split(/\s+/);
+        if (left && right)
+          item[nameOf(left, names)] = addAV(
+            item[nameOf(left, names)],
+            values[right],
+          );
+      }
+    }
+    if (action === 'REMOVE') {
+      for (const part of splitCsv(body)) delete item[nameOf(part, names)];
+    }
+  }
+}
+
+function updateSections(expression: string): Array<[string, string]> {
+  const re = /\b(SET|ADD|REMOVE|DELETE)\b/g;
+  const matches = [...expression.matchAll(re)];
+  return matches.map((match, index) => [
+    match[1]!,
+    expression
+      .slice(match.index! + match[1]!.length, matches[index + 1]?.index)
+      .trim(),
+  ]);
+}
+
+function splitLogical(expr: string, op: 'AND' | 'OR'): string[] {
+  const target = ` ${op} `;
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < expr.length; i += 1) {
+    if (expr[i] === '(') depth += 1;
+    if (expr[i] === ')') depth -= 1;
+    if (depth === 0 && expr.slice(i, i + target.length) === target) {
+      parts.push(expr.slice(start, i).trim());
+      start = i + target.length;
+      i += target.length - 1;
+    }
+  }
+  if (parts.length === 0) return [expr];
+  parts.push(expr.slice(start).trim());
+  return parts;
+}
+
+function stripOuterParens(expr: string): string {
+  while (expr.startsWith('(') && expr.endsWith(')'))
+    expr = expr.slice(1, -1).trim();
+  return expr;
+}
+
+function splitCsv(input: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    if (input[i] === '(') depth += 1;
+    if (input[i] === ')') depth -= 1;
+    if (input[i] === ',' && depth === 0) {
+      parts.push(input.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  const last = input.slice(start).trim();
+  if (last) parts.push(last);
+  return parts;
+}
+
+function projectItem(
+  item: Item,
+  projection?: string,
+  names: Record<string, string> = {},
+): Item {
+  if (!projection) return cloneItem(item);
+  const out: Item = {};
+  for (const token of splitCsv(projection)) {
+    const attr = nameOf(token, names);
+    if (item[attr] !== undefined) out[attr] = cloneAV(item[attr]);
+  }
+  return out;
+}
+
+function nameOf(token: string, names: Record<string, string>): string {
+  const trimmed = token.trim();
+  return names[trimmed] ?? trimmed;
+}
+
+function itemKey(table: Table, item: Item): string {
+  const pk = item[table.pk];
+  if (!pk) throw new Error(`missing partition key ${table.pk}`);
+  return `${keyPart(pk)}|${table.sk ? keyPart(item[table.sk]) : ''}`;
+}
+
+function keyFromMap(table: Table, key: Item): string {
+  return itemKey(table, key);
+}
+
+function keyMap(table: Table, item: Item): Item {
+  const out: Item = { [table.pk]: cloneAV(item[table.pk]) };
+  if (table.sk) out[table.sk] = cloneAV(item[table.sk]);
+  return out;
+}
+
+function keyPart(av?: AttributeValue): string {
+  if (!av) return '';
+  if ('S' in av) return `S:${av.S ?? ''}`;
+  if ('N' in av) return `N:${av.N ?? ''}`;
+  if ('B' in av) return `B:${String(av.B ?? '')}`;
+  return JSON.stringify(av);
+}
+
+function compareAV(left?: AttributeValue, right?: AttributeValue): number {
+  if (!left && !right) return 0;
+  if (!left) return -1;
+  if (!right) return 1;
+  if ('N' in left && 'N' in right) return Number(left.N) - Number(right.N);
+  return keyPart(left).localeCompare(keyPart(right));
+}
+
+function stringValue(av?: AttributeValue): string {
+  if (!av) return '';
+  if ('S' in av) return av.S ?? '';
+  if ('N' in av) return av.N ?? '';
+  return keyPart(av);
+}
+
+function addAV(left?: AttributeValue, right?: AttributeValue): AttributeValue {
+  if ('N' in (left ?? {}) && 'N' in (right ?? {})) {
+    return { N: String(Number(left!.N) + Number(right!.N)) };
+  }
+  return cloneAV(right);
+}
+
+function cloneTables(tables: Map<string, Table>): Map<string, Table> {
+  const out = new Map<string, Table>();
+  for (const [name, table] of tables) {
+    const cloned: Table = {
+      pk: table.pk,
+      items: new Map(
+        [...table.items].map(([key, item]) => [key, cloneItem(item)]),
+      ),
+    };
+    if (table.sk !== undefined) cloned.sk = table.sk;
+    out.set(name, cloned);
+  }
+  return out;
+}
+
+function cloneItem(item?: Item): Item {
+  const out: Item = {};
+  for (const [key, value] of Object.entries(item ?? {}))
+    out[key] = cloneAV(value);
+  return out;
+}
+
+function cloneAV(av?: AttributeValue): AttributeValue {
+  if (!av) return { NULL: true };
+  if ('B' in av && av.B) return { B: new Uint8Array(av.B) };
+  if ('L' in av) return { L: (av.L ?? []).map(cloneAV) };
+  if ('M' in av) return { M: cloneItem(av.M) };
+  if ('SS' in av) return { SS: [...(av.SS ?? [])] };
+  if ('NS' in av) return { NS: [...(av.NS ?? [])] };
+  if ('BS' in av) return { BS: (av.BS ?? []).map((b) => new Uint8Array(b)) };
+  return { ...av };
+}
+
+function conditionalFailed(): ConditionalCheckFailedException {
+  return new ConditionalCheckFailedException({
+    $metadata: {},
+    message: 'conditional request failed',
+  });
+}
+
+function resourceNotFound(tableName: string): ResourceNotFoundException {
+  return new ResourceNotFoundException({
+    $metadata: {},
+    message: `table not found: ${tableName}`,
+  });
+}
+
+function resourceInUse(tableName: string): ResourceInUseException {
+  return new ResourceInUseException({
+    $metadata: {},
+    message: `table already exists: ${tableName}`,
+  });
+}
+
+function transactionCanceled(cause: unknown): TransactionCanceledException {
+  return new TransactionCanceledException({
+    $metadata: {},
+    message: cause instanceof Error ? cause.message : 'transaction canceled',
+  });
+}

--- a/ts/test/unit/testkit.test.ts
+++ b/ts/test/unit/testkit.test.ts
@@ -8,8 +8,10 @@ import { defineModel } from '../../src/model.js';
 import {
   createDeterministicEncryptionProvider,
   createMockDynamoDBClient,
+  createStatefulDynamoDBClient,
   fixedNow,
 } from '../../src/testkit/index.js';
+import { hasTheorydbErrorCode } from '../../src/errors.js';
 
 function assertInstanceOf<T>(
   value: unknown,
@@ -116,4 +118,70 @@ test('createDeterministicEncryptionProvider round-trips + binds AAD to attribute
   await assert.rejects(() =>
     provider.decrypt(env, { model: 'T', attribute: 'other' }),
   );
+});
+
+test('createStatefulDynamoDBClient stores, queries, and checks versions', async () => {
+  const stateful = createStatefulDynamoDBClient();
+  const model = defineModel({
+    name: 'T',
+    table: { name: 'stateful_t' },
+    keys: {
+      partition: { attribute: 'PK', type: 'S' },
+      sort: { attribute: 'SK', type: 'S' },
+    },
+    attributes: [
+      { attribute: 'PK', type: 'S', roles: ['pk'] },
+      { attribute: 'SK', type: 'S', roles: ['sk'] },
+      { attribute: 'emailHash', type: 'S', optional: true },
+      { attribute: 'name', type: 'S', optional: true },
+      { attribute: 'createdAt', type: 'S', roles: ['created_at'] },
+      { attribute: 'updatedAt', type: 'S', roles: ['updated_at'] },
+      { attribute: 'version', type: 'N', roles: ['version'] },
+      { attribute: 'ttl', type: 'N', roles: ['ttl'], optional: true },
+    ],
+  });
+  const now = '2026-07-04T00:00:00.000000000Z';
+  const client = new TheorydbClient(stateful.client, {
+    now: fixedNow(now),
+  }).register(model);
+
+  await client.create('T', {
+    PK: 'USER#1',
+    SK: 'PROFILE',
+    emailHash: 'test@example',
+    name: 'one',
+    ttl: 1_700_000_000,
+  });
+
+  const page = await client
+    .query('T')
+    .partitionKey('USER#1')
+    .sortKey('begins_with', 'PRO')
+    .filter('emailHash', '=', 'test@example')
+    .all();
+  assert.equal(page.length, 1);
+  assert.equal(page[0]?.name, 'one');
+  assert.equal(page[0]?.version, 0);
+  assert.equal(page[0]?.createdAt, now);
+
+  await client.update(
+    'T',
+    { PK: 'USER#1', SK: 'PROFILE', name: 'two', version: 0 },
+    ['name'],
+  );
+  await assert.rejects(
+    () =>
+      client.update(
+        'T',
+        { PK: 'USER#1', SK: 'PROFILE', name: 'stale', version: 0 },
+        ['name'],
+      ),
+    (err) =>
+      hasTheorydbErrorCode(err, 'ErrConditionFailed') &&
+      hasTheorydbErrorCode(err, 'ErrVersionConflict'),
+  );
+
+  const got = await client.get('T', { PK: 'USER#1', SK: 'PROFILE' });
+  assert.equal(got.name, 'two');
+  assert.equal(got.version, 1);
 });

--- a/ts/test/unit/testkit.test.ts
+++ b/ts/test/unit/testkit.test.ts
@@ -1,7 +1,26 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { PutItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
+import {
+  BatchGetItemCommand,
+  BatchWriteItemCommand,
+  CreateTableCommand,
+  DeleteItemCommand,
+  DeleteTableCommand,
+  DescribeTableCommand,
+  GetItemCommand,
+  ListTablesCommand,
+  PutItemCommand,
+  QueryCommand,
+  ResourceInUseException,
+  ScanCommand,
+  TransactionCanceledException,
+  TransactGetItemsCommand,
+  TransactWriteItemsCommand,
+  UpdateItemCommand,
+  UpdateTimeToLiveCommand,
+  type AttributeValue,
+} from '@aws-sdk/client-dynamodb';
 
 import { TheorydbClient } from '../../src/client.js';
 import { defineModel } from '../../src/model.js';
@@ -22,6 +41,33 @@ function assertInstanceOf<T>(
 
 function assertDefined<T>(value: T): asserts value is NonNullable<T> {
   assert.ok(value !== undefined && value !== null);
+}
+
+function avS(value: string): AttributeValue {
+  return { S: value };
+}
+
+function avN(value: string): AttributeValue {
+  return { N: value };
+}
+
+function statefulKey(pk: string, sk: string): Record<string, AttributeValue> {
+  return { PK: avS(pk), SK: avS(sk) };
+}
+
+function statefulItem(
+  pk: string,
+  sk: string,
+  name: string,
+  score: string,
+): Record<string, AttributeValue> {
+  return {
+    ...statefulKey(pk, sk),
+    name: avS(name),
+    score: avN(score),
+    tag: avS(name.slice(0, 1)),
+    ttl: avN('1700000000'),
+  };
 }
 
 test('createMockDynamoDBClient is strict by default', async () => {
@@ -184,4 +230,217 @@ test('createStatefulDynamoDBClient stores, queries, and checks versions', async 
   const got = await client.get('T', { PK: 'USER#1', SK: 'PROFILE' });
   assert.equal(got.name, 'two');
   assert.equal(got.version, 1);
+});
+
+test('StatefulDynamoDBFake supports admin, batches, scans, and transactions', async () => {
+  const { client, fake } = createStatefulDynamoDBClient();
+  const tableName = 'stateful_admin';
+
+  await client.send(
+    new CreateTableCommand({
+      TableName: tableName,
+      KeySchema: [
+        { AttributeName: 'PK', KeyType: 'HASH' },
+        { AttributeName: 'SK', KeyType: 'RANGE' },
+      ],
+    }),
+  );
+  await assert.rejects(
+    () => client.send(new CreateTableCommand({ TableName: tableName })),
+    ResourceInUseException,
+  );
+  await client.send(
+    new UpdateTimeToLiveCommand({
+      TableName: tableName,
+      TimeToLiveSpecification: { AttributeName: 'ttl', Enabled: true },
+    }),
+  );
+
+  const listed = (await client.send(new ListTablesCommand({ Limit: 1 }))) as {
+    TableNames?: string[];
+  };
+  assert.deepEqual(listed.TableNames, [tableName]);
+
+  fake.seed(
+    tableName,
+    statefulItem('USER#1', 'A', 'one', '10'),
+    statefulItem('USER#1', 'B', 'two', '20'),
+    statefulItem('USER#2', 'A', 'three', '30'),
+  );
+
+  const described = (await client.send(
+    new DescribeTableCommand({ TableName: tableName }),
+  )) as { Table?: { ItemCount?: number } };
+  assert.equal(described.Table?.ItemCount, 3);
+
+  const got = (await client.send(
+    new GetItemCommand({
+      TableName: tableName,
+      Key: statefulKey('USER#1', 'A'),
+      ProjectionExpression: 'PK, #n',
+      ExpressionAttributeNames: { '#n': 'name' },
+    }),
+  )) as { Item?: Record<string, AttributeValue> };
+  assert.deepEqual(got.Item?.name, avS('one'));
+  assert.equal(got.Item?.score, undefined);
+
+  const scanned = (await client.send(
+    new ScanCommand({
+      TableName: tableName,
+      FilterExpression: '(#score >= :min AND begins_with(#name, :prefix))',
+      ExpressionAttributeNames: { '#name': 'name', '#score': 'score' },
+      ExpressionAttributeValues: { ':min': avN('10'), ':prefix': avS('t') },
+      Limit: 1,
+    }),
+  )) as {
+    Items?: Array<Record<string, AttributeValue>>;
+    LastEvaluatedKey?: Record<string, AttributeValue>;
+  };
+  assert.equal(scanned.Items?.length, 1);
+  assert.ok(scanned.LastEvaluatedKey);
+
+  const counted = (await client.send(
+    new ScanCommand({ TableName: tableName, Select: 'COUNT' }),
+  )) as { Count?: number; Items?: unknown[] };
+  assert.equal(counted.Count, 3);
+  assert.equal(counted.Items, undefined);
+
+  const queryPage = (await client.send(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: '#pk = :pk AND #sk >= :sk',
+      ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+      ExpressionAttributeValues: { ':pk': avS('USER#1'), ':sk': avS('A') },
+      ScanIndexForward: false,
+      Limit: 1,
+    }),
+  )) as {
+    Items?: Array<Record<string, AttributeValue>>;
+    LastEvaluatedKey?: Record<string, AttributeValue>;
+  };
+  assert.deepEqual(queryPage.Items?.[0]?.SK, avS('B'));
+
+  const nextQueryPage = (await client.send(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: '#pk = :pk AND #sk >= :sk',
+      ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+      ExpressionAttributeValues: { ':pk': avS('USER#1'), ':sk': avS('A') },
+      ExclusiveStartKey: queryPage.LastEvaluatedKey,
+      ScanIndexForward: false,
+    }),
+  )) as { Items?: Array<Record<string, AttributeValue>> };
+  assert.deepEqual(nextQueryPage.Items?.[0]?.SK, avS('A'));
+
+  await client.send(
+    new BatchWriteItemCommand({
+      RequestItems: {
+        [tableName]: [
+          { PutRequest: { Item: statefulItem('USER#1', 'C', 'four', '40') } },
+          { DeleteRequest: { Key: statefulKey('USER#1', 'B') } },
+        ],
+      },
+    }),
+  );
+  const batch = (await client.send(
+    new BatchGetItemCommand({
+      RequestItems: {
+        [tableName]: {
+          Keys: [statefulKey('USER#1', 'A'), statefulKey('USER#1', 'C')],
+        },
+      },
+    }),
+  )) as { Responses?: Record<string, unknown[]> };
+  assert.equal(batch.Responses?.[tableName]?.length, 2);
+
+  const updated = (await client.send(
+    new UpdateItemCommand({
+      TableName: tableName,
+      Key: statefulKey('USER#1', 'C'),
+      UpdateExpression: 'SET #note = :note REMOVE #tag ADD #score :inc',
+      ExpressionAttributeNames: {
+        '#note': 'note',
+        '#score': 'score',
+        '#tag': 'tag',
+      },
+      ExpressionAttributeValues: { ':inc': avN('2'), ':note': avS('seeded') },
+      ReturnValues: 'ALL_NEW',
+    }),
+  )) as { Attributes?: Record<string, AttributeValue> };
+  assert.deepEqual(updated.Attributes?.score, avN('42'));
+  assert.deepEqual(updated.Attributes?.note, avS('seeded'));
+  assert.equal(updated.Attributes?.tag, undefined);
+
+  const transactRead = (await client.send(
+    new TransactGetItemsCommand({
+      TransactItems: [
+        { Get: { TableName: tableName, Key: statefulKey('USER#1', 'C') } },
+        { Get: { TableName: tableName, Key: statefulKey('MISSING', 'A') } },
+      ],
+    }),
+  )) as { Responses?: Array<{ Item?: Record<string, AttributeValue> }> };
+  assert.ok(transactRead.Responses?.[0]?.Item);
+  assert.equal(transactRead.Responses?.[1]?.Item, undefined);
+
+  await client.send(
+    new TransactWriteItemsCommand({
+      TransactItems: [
+        {
+          Put: {
+            TableName: tableName,
+            Item: statefulItem('TX#1', 'A', 'tx', '1'),
+          },
+        },
+        {
+          ConditionCheck: {
+            TableName: tableName,
+            Key: statefulKey('USER#1', 'C'),
+            ConditionExpression: 'attribute_exists(PK)',
+          },
+        },
+        {
+          Update: {
+            TableName: tableName,
+            Key: statefulKey('TX#1', 'A'),
+            UpdateExpression: 'ADD #score :inc',
+            ExpressionAttributeNames: { '#score': 'score' },
+            ExpressionAttributeValues: { ':inc': avN('1') },
+          },
+        },
+        { Delete: { TableName: tableName, Key: statefulKey('USER#2', 'A') } },
+      ],
+    }),
+  );
+  await assert.rejects(
+    () =>
+      client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              ConditionCheck: {
+                TableName: tableName,
+                Key: statefulKey('USER#1', 'C'),
+                ConditionExpression: 'attribute_not_exists(PK)',
+              },
+            },
+          ],
+        }),
+      ),
+    TransactionCanceledException,
+  );
+
+  await client.send(
+    new DeleteItemCommand({
+      TableName: tableName,
+      Key: statefulKey('USER#1', 'A'),
+      ConditionExpression: 'attribute_exists(PK)',
+    }),
+  );
+  await client.send(new DeleteTableCommand({ TableName: tableName }));
+  await assert.rejects(
+    () => client.send(new DescribeTableCommand({ TableName: tableName })),
+    /not found/,
+  );
+  fake.reset();
+  assert.deepEqual(fake.items(tableName), []);
 });


### PR DESCRIPTION
## Milestone
M12 consumer-testing — stateful consumer testkit surfaces for Go, TypeScript, and Python.

## Linear
References THE-2395, THE-2397, THE-2400, THE-2402, THE-2403.

## Affected runtimes
Go, TypeScript, Python, contract runner, testing docs.

## Contract impact
- Adds Go `NewWithClient` over the public `DynamoDBAPI` seam.
- Adds deterministic state-backed local fakes/testkit clients for Go, TypeScript, and Python.
- Adds a Go fake-backed P0 contract lane; P0 divergences are fake bugs.
- No DMS changes, no release-lane changes, no cloud mutation.

## Backward compatibility
Additive only. Existing real DynamoDB/client behavior, optional-get/count behavior, typed APIs, and error semantics remain intact. Fakes are deterministic local testing aids only and are not DynamoDB replacements beyond documented/scenario-validated behavior.

## Tasks
- [x] THE-2395 TTIP-075 Add NewWithClient to Go
- [x] THE-2397 TTIP-076 Build Go state-backed in-memory fake
- [x] THE-2400 TTIP-077 Validate fake against contract corpus
- [x] THE-2402 TTIP-078 Add stateful table fake to TypeScript testkit
- [x] THE-2403 TTIP-079 Add stateful fake and expand Python testkit

## Validation
- `git diff --check` — PASS, no output
- `make contract-tests` — PASS; includes `TestContract_P0_Fake` and ends `contract-tests: PASS`
- `make test-unit` — PASS
- `make rubric` — PASS (`pass=36 fail=0 blocked=0`)
- `cd ts && npm run check` — PASS; 23 unit tests
- `uv --directory py run ruff check src tests/unit` — PASS
- `uv --directory py run mypy src` — PASS
- `uv --directory py run pytest -q tests/unit` — PASS (`271 passed in 2.29s`)
- `cd py && python -m unittest` — DRIFT/NOT PROOF (`Ran 0 tests`, exit 5)

## Cross-repo coordination
None. TableTheory-local contracts only.
