### PR TITLE
test: harden go coverage baseline

### DIFF
--- a/internal/theorydb/query_executor_the2551_test.go
+++ b/internal/theorydb/query_executor_the2551_test.go
@@ -1,0 +1,58 @@
+package theorydb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/pkg/core"
+)
+
+func TestCompiledConditionReferencesVersion_TokenBoundaries_THE2551(t *testing.T) {
+	tests := []struct {
+		name        string
+		compiled    *core.CompiledQuery
+		versionAttr string
+		want        bool
+	}{
+		{
+			name:        "requires a version attribute",
+			compiled:    &core.CompiledQuery{ConditionExpression: "version = :v"},
+			versionAttr: "",
+			want:        false,
+		},
+		{
+			name:        "bare version token",
+			compiled:    &core.CompiledQuery{ConditionExpression: "attribute_exists(version) AND version = :v"},
+			versionAttr: "version",
+			want:        true,
+		},
+		{
+			name: "placeholder maps to version attribute",
+			compiled: &core.CompiledQuery{
+				ConditionExpression:      "#v = :expected",
+				ExpressionAttributeNames: map[string]string{"#v": "recordVersion"},
+			},
+			versionAttr: "recordVersion",
+			want:        true,
+		},
+		{
+			name:        "substring inside identifier is ignored",
+			compiled:    &core.CompiledQuery{ConditionExpression: "preview_version = :v OR versioned = :next"},
+			versionAttr: "version",
+			want:        false,
+		},
+		{
+			name:        "case insensitive bare token",
+			compiled:    &core.CompiledQuery{ConditionExpression: "Version >= :expected"},
+			versionAttr: "version",
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, compiledConditionReferencesVersion(tt.compiled, tt.versionAttr))
+		})
+	}
+}

--- a/pkg/dms/codegen_test.go
+++ b/pkg/dms/codegen_test.go
@@ -118,6 +118,90 @@ func TestGenerateCDKRejectsUnsupportedKeyType(t *testing.T) {
 	require.ErrorContains(t, err, "unsupported key attribute type")
 }
 
+func TestGenerateCDKCoversIndexProjectionBranches_THE2551(t *testing.T) {
+	t.Parallel()
+
+	doc := &Document{
+		DMSVersion: "0.1",
+		Models: []Model{
+			{
+				Name:  "Branchy",
+				Table: Table{Name: "branchy"},
+				Keys: Keys{
+					Partition: KeyAttribute{Attribute: "PK", Type: "S"},
+					Sort:      &KeyAttribute{Attribute: "SK", Type: "N"},
+				},
+				Attributes: []Attribute{
+					{Attribute: "PK", Type: "S", Roles: []string{"pk"}},
+					{Attribute: "SK", Type: "N", Roles: []string{"sk"}},
+					{Attribute: "blob", Type: "B", Roles: []string{"gsi1pk"}},
+					{Attribute: "score", Type: "N", Roles: []string{"lsi:by-score,sk"}},
+					{Attribute: "summary", Type: "S"},
+				},
+				Indexes: []Index{
+					{
+						Name:       "by-blob",
+						Type:       "GSI",
+						Partition:  KeyAttribute{Attribute: "blob", Type: "B"},
+						Projection: Projection{Type: "KEYS_ONLY"},
+					},
+					{
+						Name:       "by-score",
+						Type:       indexTypeLSI,
+						Partition:  KeyAttribute{Attribute: "PK", Type: "S"},
+						Sort:       &KeyAttribute{Attribute: "score", Type: "N"},
+						Projection: Projection{Type: projectionInclude, Fields: []string{"summary"}},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := Generate(doc, GenerateOptions{Lang: "cdk"})
+	require.NoError(t, err)
+	rendered := string(got)
+	require.Contains(t, rendered, "sortKey: { name: 'SK', type: dynamodb.AttributeType.NUMBER }")
+	require.Contains(t, rendered, "partitionKey: { name: 'blob', type: dynamodb.AttributeType.BINARY }")
+	require.Contains(t, rendered, "projectionType: dynamodb.ProjectionType.KEYS_ONLY")
+	require.Contains(t, rendered, "table.addLocalSecondaryIndex")
+	require.Contains(t, rendered, "sortKey: { name: 'score', type: dynamodb.AttributeType.NUMBER }")
+	require.Contains(t, rendered, "projectionType: dynamodb.ProjectionType.INCLUDE")
+	require.Contains(t, rendered, "nonKeyAttributes: ['summary']")
+	require.NotContains(t, rendered, "timeToLiveAttribute")
+}
+
+func TestGenerateCDKRejectsUnsupportedIndexKeyTypes_THE2551(t *testing.T) {
+	t.Parallel()
+
+	base := Model{
+		Name:  "BadIndex",
+		Table: Table{Name: "bad_index"},
+		Keys:  Keys{Partition: KeyAttribute{Attribute: "PK", Type: "S"}},
+		Attributes: []Attribute{
+			{Attribute: "PK", Type: "S", Roles: []string{"pk"}},
+		},
+	}
+
+	gsi := base
+	gsi.Indexes = []Index{{
+		Name:      "bad-gsi",
+		Type:      "GSI",
+		Partition: KeyAttribute{Attribute: "bad", Type: "BOOL"},
+	}}
+	_, err := Generate(&Document{DMSVersion: "0.1", Models: []Model{gsi}}, GenerateOptions{Lang: "cdk"})
+	require.ErrorContains(t, err, "index bad-gsi partition key")
+
+	lsi := base
+	lsi.Indexes = []Index{{
+		Name:      "bad-lsi",
+		Type:      indexTypeLSI,
+		Partition: KeyAttribute{Attribute: "PK", Type: "S"},
+		Sort:      &KeyAttribute{Attribute: "bad", Type: "BOOL"},
+	}}
+	_, err = Generate(&Document{DMSVersion: "0.1", Models: []Model{lsi}}, GenerateOptions{Lang: "cdk"})
+	require.ErrorContains(t, err, "index bad-lsi sort key")
+}
+
 func TestGenerateOptionsAndErrors(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/marshal/cov6_safe_marshaler_additional_test.go
+++ b/pkg/marshal/cov6_safe_marshaler_additional_test.go
@@ -3,6 +3,7 @@ package marshal
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,23 @@ func TestSafeMarshaler_getOrBuildSafeStructMarshaler_RebuildsOnBadCache_COV6(t *
 	sm := m.getOrBuildSafeStructMarshaler(typ, meta)
 	require.NotNil(t, sm)
 	require.NotEmpty(t, sm.fields)
+}
+
+func TestSafeMarshaler_MarshalStructValue_TimeBranches_THE2551(t *testing.T) {
+	m := NewSafeMarshaler()
+	stamp := time.Date(2026, time.July, 4, 12, 30, 0, 123, time.UTC)
+
+	asString, err := m.marshalStructValue(reflect.ValueOf(stamp), &safeFieldMarshaler{})
+	require.NoError(t, err)
+	asStringValue, ok := asString.(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	require.Equal(t, stamp.Format(time.RFC3339Nano), asStringValue.Value)
+
+	asTTL, err := m.marshalStructValue(reflect.ValueOf(stamp), &safeFieldMarshaler{isTTL: true})
+	require.NoError(t, err)
+	asTTLValue, ok := asTTL.(*types.AttributeValueMemberN)
+	require.True(t, ok)
+	require.Equal(t, "1783168200", asTTLValue.Value)
 }
 
 func TestSafeMarshaler_MarshalItem_NilMapAndInterface_COV6(t *testing.T) {

--- a/pkg/query/cov6_executor_helpers_test.go
+++ b/pkg/query/cov6_executor_helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/theory-cloud/tabletheory/pkg/core"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 )
 
 func TestApplyCompiledQueryReadFields_COV6(t *testing.T) {
@@ -125,6 +126,156 @@ func TestCalculateBatchRetryDelay_JitterRange_COV6(t *testing.T) {
 	delay := calculateBatchRetryDelay(policy, 0)
 	require.GreaterOrEqual(t, delay, time.Duration(float64(base)*0.5))
 	require.LessOrEqual(t, delay, time.Duration(float64(base)*1.5))
+}
+
+func TestCompiledConditionReferencesVersion_TokenBoundaries_THE2551(t *testing.T) {
+	tests := []struct {
+		name        string
+		compiled    *core.CompiledQuery
+		versionAttr string
+		want        bool
+	}{
+		{
+			name:        "nil query",
+			compiled:    nil,
+			versionAttr: "version",
+			want:        false,
+		},
+		{
+			name:        "bare default version token",
+			compiled:    &core.CompiledQuery{ConditionExpression: "attribute_exists(version) AND version >= :v"},
+			versionAttr: "",
+			want:        true,
+		},
+		{
+			name: "placeholder maps to version attribute",
+			compiled: &core.CompiledQuery{
+				ConditionExpression:      "#version = :expected",
+				ExpressionAttributeNames: map[string]string{"#version": "recordVersion"},
+			},
+			versionAttr: "recordVersion",
+			want:        true,
+		},
+		{
+			name:        "substring inside longer identifier is not a version token",
+			compiled:    &core.CompiledQuery{ConditionExpression: "preview_version = :v OR versioned = :next"},
+			versionAttr: "version",
+			want:        false,
+		},
+		{
+			name:        "case insensitive token match",
+			compiled:    &core.CompiledQuery{ConditionExpression: "Version BETWEEN :lo AND :hi"},
+			versionAttr: "version",
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, compiledConditionReferencesVersion(tt.compiled, tt.versionAttr))
+		})
+	}
+}
+
+type the2551RetryReadItem struct {
+	ID string
+}
+
+type the2551RetryReadExecutor struct {
+	batches [][]the2551RetryReadItem
+	errs    []error
+	calls   int
+}
+
+func (e *the2551RetryReadExecutor) ExecuteQuery(input *core.CompiledQuery, dest any) error {
+	return e.ExecuteScan(input, dest)
+}
+
+func (e *the2551RetryReadExecutor) ExecuteScan(_ *core.CompiledQuery, dest any) error {
+	call := e.calls
+	e.calls++
+
+	if call < len(e.errs) && e.errs[call] != nil {
+		return e.errs[call]
+	}
+	if call >= len(e.batches) {
+		return nil
+	}
+
+	reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(e.batches[call]))
+	return nil
+}
+
+func TestQueryRetryReadsRetryEmptyResults_THE2551(t *testing.T) {
+	exec := &the2551RetryReadExecutor{
+		batches: [][]the2551RetryReadItem{
+			{},
+			{},
+			{{ID: "ready"}},
+		},
+	}
+	q := New(&the2551RetryReadItem{}, cov5Metadata{
+		table:      "tbl",
+		primaryKey: core.KeySchema{PartitionKey: "id"},
+	}, exec)
+
+	var out the2551RetryReadItem
+	err := q.WithRetry(2, 0).First(&out)
+	require.NoError(t, err)
+	require.Equal(t, "ready", out.ID)
+	require.Equal(t, 3, exec.calls)
+}
+
+func TestQueryAllWithRetryClearsStaleDestination_THE2551(t *testing.T) {
+	exec := &the2551RetryReadExecutor{
+		batches: [][]the2551RetryReadItem{
+			{},
+			{{ID: "fresh"}},
+		},
+	}
+	q := New(&the2551RetryReadItem{}, cov5Metadata{
+		table:      "tbl",
+		primaryKey: core.KeySchema{PartitionKey: "id"},
+	}, exec)
+
+	out := []the2551RetryReadItem{{ID: "stale"}}
+	err := q.WithRetry(1, 0).All(&out)
+	require.NoError(t, err)
+	require.Equal(t, []the2551RetryReadItem{{ID: "fresh"}}, out)
+	require.Equal(t, 2, exec.calls)
+}
+
+func TestQueryRetryReadsReturnTerminalErrors_THE2551(t *testing.T) {
+	t.Run("first returns not found after retry budget", func(t *testing.T) {
+		exec := &the2551RetryReadExecutor{
+			batches: [][]the2551RetryReadItem{{}},
+		}
+		q := New(&the2551RetryReadItem{}, cov5Metadata{
+			table:      "tbl",
+			primaryKey: core.KeySchema{PartitionKey: "id"},
+		}, exec)
+
+		var out the2551RetryReadItem
+		err := q.WithRetry(0, 0).First(&out)
+		require.ErrorIs(t, err, theorydbErrors.ErrItemNotFound)
+		require.Equal(t, 1, exec.calls)
+	})
+
+	t.Run("all returns last executor error after retry budget", func(t *testing.T) {
+		expected := errors.New("read failed")
+		exec := &the2551RetryReadExecutor{
+			errs: []error{errors.New("transient"), expected},
+		}
+		q := New(&the2551RetryReadItem{}, cov5Metadata{
+			table:      "tbl",
+			primaryKey: core.KeySchema{PartitionKey: "id"},
+		}, exec)
+
+		var out []the2551RetryReadItem
+		err := q.WithRetry(1, 0).All(&out)
+		require.ErrorIs(t, err, expected)
+		require.Equal(t, 2, exec.calls)
+	})
 }
 
 func TestUnmarshalJSONString_ErrorBranches_COV6(t *testing.T) {

--- a/pkg/types/cov6_converter_additional_test.go
+++ b/pkg/types/cov6_converter_additional_test.go
@@ -113,6 +113,28 @@ func TestDetectNamingConvention_AndSplitTag_COV6(t *testing.T) {
 	require.Equal(t, []string{"attr:field", "omitempty", "naming:snake_case"}, splitTag("attr:field, omitempty, naming:snake_case"))
 }
 
+func TestResolveStructNaming_ReportsTheoryDBTagPresence_THE2551(t *testing.T) {
+	type withRoleTag struct {
+		ID string `theorydb:"pk" json:"id"`
+	}
+
+	type withoutTheoryDBTags struct {
+		ID string `json:"id"`
+	}
+
+	convention, ok := resolveStructNaming(reflect.TypeOf(withRoleTag{}), naming.PascalCase, false)
+	require.Equal(t, naming.CamelCase, convention)
+	require.True(t, ok, "theorydb tags opt the struct into TableTheory naming even without a naming sentinel")
+
+	convention, ok = resolveStructNaming(reflect.TypeOf(withoutTheoryDBTags{}), naming.PascalCase, false)
+	require.Equal(t, naming.CamelCase, convention)
+	require.False(t, ok)
+
+	convention, ok = resolveStructNaming(reflect.TypeOf(withoutTheoryDBTags{}), naming.PascalCase, true)
+	require.Equal(t, naming.PascalCase, convention)
+	require.True(t, ok, "inherited naming remains explicit for nested decode contexts")
+}
+
 func TestMapToStruct_ValidatesAttributeNames_COV6(t *testing.T) {
 	converter := NewConverter()
 

--- a/tabletheory_facade_test.go
+++ b/tabletheory_facade_test.go
@@ -1,0 +1,19 @@
+package tabletheory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type typedFacadeRecord struct {
+	PK string `theorydb:"pk" json:"PK"`
+	SK string `theorydb:"sk" json:"SK"`
+}
+
+func TestTypedFacadeHelpers_THE2551(t *testing.T) {
+	model := ModelOf[typedFacadeRecord](nil)
+
+	require.Equal(t, NewKeyPair("tenant#1", "record#1"), model.Key("tenant#1", "record#1").Core())
+	require.Equal(t, NewKeyPair("tenant#1"), NewTypedKey[typedFacadeRecord]("tenant#1").Core())
+}


### PR DESCRIPTION
## Milestone
THE-2551 coverage baseline hardening — restore durable QUA-3 headroom for the TableTheory project branch.

## Linear
https://linear.app/theorycloud/issue/THE-2551/follow-up-restore-tabletheory-project-branch-rubric-coverage-baseline

Closes THE-2551.

## Affected runtimes
Go tests only.

## Contract impact
No contract or DMS behavior change. Adds targeted coverage for existing Go behavior: typed facade helpers, version-condition token boundaries, read retry behavior, DMS CDK index/projection branches, safe time marshaling, and TableTheory naming-resolution branches.

## Backward compatibility
Additive test-only change; no public API or persisted-data behavior changes.

## Tasks
- [x] Investigate boundary-fragile QUA-3 Go coverage baseline.
- [x] Add legitimate targeted Go tests for existing behavior.
- [x] Verify `make rubric` is green with Go QUA-3 above the 90.0 boundary.

## Validation
- `git diff --check` — PASS
- `go test -run THE2551 ./ ./internal/theorydb ./pkg/dms ./pkg/marshal ./pkg/query ./pkg/types` — PASS
- `make lint` — PASS
- `make test-unit` — PASS
- `make contract-tests` — PASS
- `make rubric` — PASS (`36 pass / 0 fail / 0 blocked`; QUA-3 Go coverage `90.3% >= 90.0%`)

## Cross-repo coordination
None.
