### PR TITLE
chore: harden M16 polish follow-ups

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -157,6 +157,12 @@ The planned removal belongs to the next major version after the deprecation wind
 `query.NewExecutor(...)` directly, migrate that construction to a normal TableTheory `DB`/model flow before adopting the
 next major release.
 
+Implementation note: the 1.x Go doc comments intentionally use compatibility-deprecation prose instead of the standard
+Go `Deprecated:` marker. Adding the marker now would make staticcheck/IDE deprecation signals fire on the in-repository
+compatibility coverage that still exercises `MainExecutor`, requiring broad test-only suppressions. Add the standard
+marker on the v2 removal train, or earlier only after those compatibility tests no longer need to call the legacy
+executor directly.
+
 ## M6 Go Contract-Parity Compatibility Notes
 
 M6 pins additional cross-runtime contract scenarios for number precision, GSI/projection behavior, pagination, and the

--- a/pkg/query/executor.go
+++ b/pkg/query/executor.go
@@ -38,10 +38,13 @@ type DynamoDBAPI interface {
 
 // MainExecutor is the legacy executor that implements the low-level query executor interfaces.
 //
-// Compatibility deprecation notice: MainExecutor is retained in 1.x as a test and
-// compatibility seam only. Production code should use tabletheory.Model() / DB.Model()
-// so reads and writes flow through the maintained runtime executor path. MainExecutor
-// is scheduled for removal in the next major version after the deprecation window.
+// Compatibility-deprecated notice: MainExecutor is retained in 1.x as a test
+// and compatibility seam only. Production code should use tabletheory.Model() /
+// DB.Model() so reads and writes flow through the maintained runtime executor
+// path. The standard Go deprecation marker is intentionally deferred until the
+// v2 removal train so in-repo compatibility tests do not need broad SA1019
+// suppressions; MainExecutor is scheduled for removal in the next major version
+// after the deprecation window.
 type MainExecutor struct {
 	client DynamoDBAPI
 	ctx    context.Context
@@ -335,9 +338,11 @@ func executeCompiledRead(
 
 // NewExecutor creates a legacy MainExecutor instance.
 //
-// Compatibility deprecation notice: NewExecutor is retained for tests and existing
-// compatibility callers only. Production code should use tabletheory.Model() /
-// DB.Model() instead of constructing MainExecutor directly.
+// Compatibility-deprecated notice: NewExecutor is retained for tests and
+// existing compatibility callers only. Production code should use
+// tabletheory.Model() / DB.Model() instead of constructing MainExecutor
+// directly. The standard Go deprecation marker is deferred with MainExecutor
+// until the v2 removal train to avoid broad test-only SA1019 suppressions.
 func NewExecutor(client DynamoDBAPI, ctx context.Context) *MainExecutor { //nolint:revive // context-as-argument: keep signature for compatibility
 	return &MainExecutor{
 		client: client,

--- a/ts/docs/development-guidelines.md
+++ b/ts/docs/development-guidelines.md
@@ -27,3 +27,11 @@ From the repo root:
 - Keep public APIs stable and documented in [API Reference](./api-reference.md).
 - Do not weaken testkit strictness: unit tests should fail if expected AWS commands were not issued.
 - Treat `encrypted` fields as fail-closed: do not allow silent plaintext fallbacks.
+
+## Type-aware lint posture
+
+- `recommended-type-checked` is active for the TypeScript runtime, and `no-floating-promises` is load-bearing.
+- A narrow legacy allowlist remains in `ts/eslint.config.js` for high-churn typed-safety cleanup rules, including the
+  current `no-unsafe-*` debt around dynamic DynamoDB marshalling and testkit boundaries.
+- Do not expand that allowlist as routine cleanup. Tighten it in a dedicated typed-safety pass that can cover affected
+  call sites without unrelated public API or runtime behavior churn.

--- a/ts/eslint.config.js
+++ b/ts/eslint.config.js
@@ -3,6 +3,20 @@ import globals from 'globals';
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 
+const deferredTypeAwareRules = Object.fromEntries(
+  [
+    '@typescript-eslint/no-base-to-string',
+    '@typescript-eslint/no-redundant-type-constituents',
+    '@typescript-eslint/no-unnecessary-type-assertion',
+    '@typescript-eslint/no-unsafe-argument',
+    '@typescript-eslint/no-unsafe-assignment',
+    '@typescript-eslint/no-unsafe-member-access',
+    '@typescript-eslint/only-throw-error',
+    '@typescript-eslint/require-await',
+    '@typescript-eslint/restrict-template-expressions',
+  ].map((rule) => [rule, 'off']),
+);
+
 /** @type {import("eslint").Linter.FlatConfig[]} */
 export default [
   {
@@ -32,18 +46,12 @@ export default [
     rules: {
       ...tseslint.configs.recommended.rules,
       ...tseslint.configs['recommended-type-checked'].rules,
-      // Type-aware lint is enabled first around promise-safety. These legacy
-      // cleanup rules are deliberately deferred so this milestone can preserve
-      // public API and behavior while making no-floating-promises enforceable.
-      '@typescript-eslint/no-base-to-string': 'off',
-      '@typescript-eslint/no-redundant-type-constituents': 'off',
-      '@typescript-eslint/no-unnecessary-type-assertion': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/only-throw-error': 'off',
-      '@typescript-eslint/require-await': 'off',
-      '@typescript-eslint/restrict-template-expressions': 'off',
+      // Deliberate typed-lint deferral: recommended-type-checked is active and
+      // no-floating-promises stays enforced, but the exact legacy high-churn
+      // rules below remain disabled until a dedicated typed-safety cleanup can
+      // touch dynamic DynamoDB marshalling and testkit boundaries without
+      // unrelated public behavior churn. Do not grow this allowlist casually.
+      ...deferredTypeAwareRules,
       // TypeScript handles undefined checks for types/namespaces (e.g., `NodeJS`).
       'no-undef': 'off',
     },

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -28,3 +28,4 @@ await import('./unit/release-state.test.js');
 await import('./unit/lease.test.js');
 await import('./unit/facetheory-isr.test.js');
 await import('./unit/package-exports.test.js');
+await import('./unit/eslint-config.test.js');

--- a/ts/test/unit/eslint-config.test.ts
+++ b/ts/test/unit/eslint-config.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const deferredTypeAwareRules = [
+  '@typescript-eslint/no-base-to-string',
+  '@typescript-eslint/no-redundant-type-constituents',
+  '@typescript-eslint/no-unnecessary-type-assertion',
+  '@typescript-eslint/no-unsafe-argument',
+  '@typescript-eslint/no-unsafe-assignment',
+  '@typescript-eslint/no-unsafe-member-access',
+  '@typescript-eslint/only-throw-error',
+  '@typescript-eslint/require-await',
+  '@typescript-eslint/restrict-template-expressions',
+];
+
+void test('typed ESLint config keeps promise safety enforced with bounded legacy deferrals', async () => {
+  const eslintConfig = (await import(
+    new URL('../../eslint.config.js', import.meta.url).href
+  )) as {
+    default: Array<{
+      files?: string[];
+      rules?: Record<string, unknown>;
+    }>;
+  };
+
+  const tsConfig = eslintConfig.default.find((config) =>
+    config.files?.includes('**/*.ts'),
+  );
+  assert.ok(tsConfig?.rules);
+
+  assert.equal(
+    tsConfig.rules['@typescript-eslint/no-floating-promises'],
+    'error',
+  );
+
+  for (const rule of deferredTypeAwareRules) {
+    assert.equal(tsConfig.rules[rule], 'off');
+  }
+
+  const disabledTypedRules = Object.entries(tsConfig.rules)
+    .filter(
+      ([rule, setting]) =>
+        rule.startsWith('@typescript-eslint/') && setting === 'off',
+    )
+    .map(([rule]) => rule)
+    .sort();
+
+  assert.deepEqual(disabledTypedRules, [...deferredTypeAwareRules].sort());
+});

--- a/ts/test/unit/package-exports.test.ts
+++ b/ts/test/unit/package-exports.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
+const require = createRequire(import.meta.url);
+const packageRoot = fileURLToPath(new URL('../../', import.meta.url));
 const packageJson = JSON.parse(
   readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
 ) as {
@@ -14,32 +19,81 @@ const packageJson = JSON.parse(
   >;
 };
 
+const domainSubpaths = [
+  {
+    subpath: './facetheory',
+    specifier: '@theory-cloud/tabletheory-ts/facetheory',
+    runtimeSymbols: [
+      'defineFaceTheoryCacheMetadataModel',
+      'FaceTheoryIsrMetaStore',
+      'createFaceTheoryIsrMetaStore',
+    ],
+    expected: {
+      import: {
+        types: './dist/facetheory-isr.d.ts',
+        default: './dist/facetheory-isr.js',
+      },
+      require: {
+        types: './dist/cjs/facetheory-isr.d.ts',
+        default: './dist/cjs/facetheory-isr.js',
+      },
+    },
+  },
+  {
+    subpath: './release-state',
+    specifier: '@theory-cloud/tabletheory-ts/release-state',
+    runtimeSymbols: [
+      'transitionReleaseState',
+      'validateDeployAuthorityMetadata',
+    ],
+    expected: {
+      import: {
+        types: './dist/release-state.d.ts',
+        default: './dist/release-state.js',
+      },
+      require: {
+        types: './dist/cjs/release-state.d.ts',
+        default: './dist/cjs/release-state.js',
+      },
+    },
+  },
+  {
+    subpath: './lease',
+    specifier: '@theory-cloud/tabletheory-ts/lease',
+    runtimeSymbols: ['LeaseManager'],
+    expected: {
+      import: { types: './dist/lease.d.ts', default: './dist/lease.js' },
+      require: {
+        types: './dist/cjs/lease.d.ts',
+        default: './dist/cjs/lease.js',
+      },
+    },
+  },
+] as const;
+
 void test('package exposes domain subpath exports', () => {
-  assert.deepEqual(packageJson.exports['./facetheory'], {
-    import: {
-      types: './dist/facetheory-isr.d.ts',
-      default: './dist/facetheory-isr.js',
-    },
-    require: {
-      types: './dist/cjs/facetheory-isr.d.ts',
-      default: './dist/cjs/facetheory-isr.js',
-    },
-  });
-  assert.deepEqual(packageJson.exports['./release-state'], {
-    import: {
-      types: './dist/release-state.d.ts',
-      default: './dist/release-state.js',
-    },
-    require: {
-      types: './dist/cjs/release-state.d.ts',
-      default: './dist/cjs/release-state.js',
-    },
-  });
-  assert.deepEqual(packageJson.exports['./lease'], {
-    import: { types: './dist/lease.d.ts', default: './dist/lease.js' },
-    require: {
-      types: './dist/cjs/lease.d.ts',
-      default: './dist/cjs/lease.js',
-    },
-  });
+  for (const entry of domainSubpaths) {
+    assert.deepEqual(packageJson.exports[entry.subpath], entry.expected);
+  }
+});
+
+void test('domain subpath exports resolve and load ESM and CommonJS artifacts', async () => {
+  for (const entry of domainSubpaths) {
+    const cjsResolved = require.resolve(entry.specifier);
+    assert.equal(
+      relative(packageRoot, cjsResolved).split(sep).join('/'),
+      entry.expected.require.default.replace(/^\.\//, ''),
+    );
+
+    const cjsModule = require(entry.specifier) as Record<string, unknown>;
+    const esmModule = (await import(entry.specifier)) as Record<
+      string,
+      unknown
+    >;
+
+    for (const symbol of entry.runtimeSymbols) {
+      assert.equal(typeof cjsModule[symbol], 'function');
+      assert.equal(typeof esmModule[symbol], 'function');
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- Clarify the 1.x MainExecutor compatibility-deprecation decision without adding Go `Deprecated:` markers before the v2 removal train.
- Make TypeScript domain subpath export coverage load-bearing with actual ESM import and CommonJS require.resolve/require checks.
- Encode the bounded typed-ESLint deferral list while keeping `no-floating-promises` enforced, with unit coverage and TS dev docs.

## Validation
- `git diff --check`
- `cd ts && npm run build && npx tsx test/unit/package-exports.test.ts`
- `cd ts && npm run check`
- `make lint`
- `make test-unit`
- `make contract-tests`
- `make rubric`

## Safety / scope
- Repo-local framework polish only; no public runtime behavior, DMS, contract scenario, package version, release, cloud, account, DNS, secret, deploy, or customer-workload changes.
- No broad `no-unsafe-*` cleanup in this PR; the deferral is deliberately bounded for a dedicated typed-safety pass.

Closes THE-2549
