### PR TITLE
docs(examples): show quickstart version after update

### DIFF
--- a/docs/examples/go-local-quickstart.md
+++ b/docs/examples/go-local-quickstart.md
@@ -12,9 +12,13 @@ make docker-up
 make example-local
 ```
 
-Expected final line:
+Expected output:
 
 ```text
+created note NOTE#local (version 0)
+read note: title="Hello TableTheory" value=42 version=0
+updated note: title="Hello TableTheory (updated)" persistedVersion=1
+deleted note NOTE#local
 OK: TableTheory Go quickstart CRUD against DynamoDB Local succeeded
 ```
 
@@ -22,5 +26,6 @@ The target runs the checked-in program at
 [`examples/local-quickstart/main.go`](https://github.com/theory-cloud/TableTheory/blob/main/examples/local-quickstart/main.go).
 It sets dummy local credentials, points the runtime at `DYNAMODB_ENDPOINT=http://localhost:8000`, creates the demo table
 idempotently, writes a note, reads it back, updates it, deletes it, and fails the process if any step returns an error.
+After the update, it re-reads the item so the output shows DynamoDB's persisted optimistic-lock version increment.
 
 For the complete walkthrough and source listing, see [Getting Started](../getting-started.md#two-command-local-quickstart).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,11 +37,18 @@ make example-local
 ```
 
 `make example-local` runs [`examples/local-quickstart/main.go`](https://github.com/theory-cloud/TableTheory/blob/main/examples/local-quickstart/main.go) against DynamoDB
-Local with dummy local credentials and expects this final line:
+Local with dummy local credentials. Its output includes the persisted optimistic-lock version after the update:
 
 ```text
+created note NOTE#local (version 0)
+read note: title="Hello TableTheory" value=42 version=0
+updated note: title="Hello TableTheory (updated)" persistedVersion=1
+deleted note NOTE#local
 OK: TableTheory Go quickstart CRUD against DynamoDB Local succeeded
 ```
+
+The update step re-reads the item before printing `persistedVersion` because TableTheory's `Update` call does not mutate
+the caller's struct in memory.
 
 If Docker is unavailable in your environment, use the deterministic fake-backed testing APIs from
 [`pkg/testing/fakedb`](https://github.com/theory-cloud/TableTheory/tree/main/pkg/testing/fakedb) for unit tests, but keep this DynamoDB Local proof for onboarding and
@@ -100,20 +107,28 @@ func main() {
     if err := db.Model(note).IfNotExists().Create(); err != nil {
         log.Fatalf("create: %v", err)
     }
+    fmt.Printf("created note %s (version %d)\n", note.PK, note.Version)
 
     var got Note
     if err := db.Model(&Note{}).Where("PK", "=", note.PK).Where("SK", "=", note.SK).First(&got); err != nil {
         log.Fatalf("read: %v", err)
     }
+    fmt.Printf("read note: title=%q value=%d version=%d\n", got.Title, got.Value, got.Version)
 
     got.Title = "Hello TableTheory (updated)"
     if err := db.Model(&got).Update("title"); err != nil {
         log.Fatalf("update: %v", err)
     }
+    var updated Note
+    if err := db.Model(&Note{}).Where("PK", "=", note.PK).Where("SK", "=", note.SK).First(&updated); err != nil {
+        log.Fatalf("read after update: %v", err)
+    }
+    fmt.Printf("updated note: title=%q persistedVersion=%d\n", updated.Title, updated.Version)
 
     if err := db.Model(&Note{}).Where("PK", "=", note.PK).Where("SK", "=", note.SK).Delete(); err != nil {
         log.Fatalf("delete: %v", err)
     }
+    fmt.Printf("deleted note %s\n", updated.PK)
 
     fmt.Println("OK: TableTheory Go quickstart CRUD against DynamoDB Local succeeded")
 }

--- a/examples/local-quickstart/main.go
+++ b/examples/local-quickstart/main.go
@@ -62,12 +62,16 @@ func main() {
 	if err := db.Model(&got).Update("title"); err != nil {
 		log.Fatalf("update: %v", err)
 	}
-	fmt.Printf("updated note %s (version %d)\n", got.PK, got.Version)
+	var updated Note
+	if err := db.Model(&Note{}).Where("PK", "=", note.PK).Where("SK", "=", note.SK).First(&updated); err != nil {
+		log.Fatalf("read after update: %v", err)
+	}
+	fmt.Printf("updated note: title=%q persistedVersion=%d\n", updated.Title, updated.Version)
 
 	if err := db.Model(&Note{}).Where("PK", "=", note.PK).Where("SK", "=", note.SK).Delete(); err != nil {
 		log.Fatalf("delete: %v", err)
 	}
-	fmt.Printf("deleted note %s\n", got.PK)
+	fmt.Printf("deleted note %s\n", updated.PK)
 
 	fmt.Println("OK: TableTheory Go quickstart CRUD against DynamoDB Local succeeded")
 }


### PR DESCRIPTION
## Summary
- Re-read the local quickstart note after `Update("title")` so the output shows the persisted optimistic-lock version increment.
- Update the Go getting-started and local quickstart docs to snapshot the version-aware output and explain that `Update` does not mutate the caller's struct in memory.

Closes THE-2544

## Validation
- `git diff --check` — PASS
- `make example-local` — PASS; output includes `updated note: title="Hello TableTheory (updated)" persistedVersion=1`
- `make verify-generative-artifacts` — PASS
- `bash scripts/verify-doc-integrity.sh` — PASS
- `make lint` — PASS (`0 issues`)
- `make test-unit` — PASS
- `make contract-tests` — PASS
- `make rubric` — PASS (`pass=36 fail=0 blocked=0`)

## Safety
- Repo-local example/docs change only; no runtime behavior, public API, DMS/contracts, release config, workflows, package versions, cloud/deploy/release, customer workload, receipt, DNS, AWS account, or secrets changes.
