### PR TITLE
fix(cli): show persisted version in Go scaffold

### DIFF
--- a/cmd/tabletheory/init_test.go
+++ b/cmd/tabletheory/init_test.go
@@ -30,6 +30,11 @@ func TestInitScaffoldGo(t *testing.T) {
 	main := readFile(t, filepath.Join(dir, "main.go"))
 	require.Contains(t, main, "func (Note) TableName() string")
 	require.Contains(t, main, "db.Model(note).Create()")
+	require.Contains(t, main, `db.Model(&got).Update("title")`)
+	require.Contains(t, main, "does not mutate got.Version")
+	require.Contains(t, main, "read after update")
+	require.Contains(t, main, "persistedVersion=%d")
+	require.NotContains(t, main, `updated note %s (version %d)`)
 	require.Contains(t, main, "OK: TableTheory CRUD against DynamoDB Local succeeded")
 
 	// The generated DMS must be valid.

--- a/cmd/tabletheory/templates/go/main.go.tmpl
+++ b/cmd/tabletheory/templates/go/main.go.tmpl
@@ -60,15 +60,21 @@ func main() {
 	fmt.Printf("read note: title=%q value=%d version=%d\n", got.Title, got.Value, got.Version)
 
 	got.Title = "Hello TableTheory (updated)"
-	if err := db.Model(&got).Update(); err != nil {
+	if err := db.Model(&got).Update("title"); err != nil {
 		log.Fatalf("update: %v", err)
 	}
-	fmt.Printf("updated note %s (version %d)\n", got.PK, got.Version)
+	// Update succeeds with the read version but does not mutate got.Version;
+	// re-read to show the persisted optimistic-lock version increment.
+	var updated Note
+	if err := db.Model(&Note{}).Where("PK", "=", got.PK).Where("SK", "=", got.SK).First(&updated); err != nil {
+		log.Fatalf("read after update: %v", err)
+	}
+	fmt.Printf("updated note: title=%q persistedVersion=%d\n", updated.Title, updated.Version)
 
-	if err := db.Model(&Note{}).Where("PK", "=", "NOTE#1").Where("SK", "=", "v1").Delete(); err != nil {
+	if err := db.Model(&Note{}).Where("PK", "=", updated.PK).Where("SK", "=", updated.SK).Delete(); err != nil {
 		log.Fatalf("delete: %v", err)
 	}
-	fmt.Printf("deleted note %s\n", got.PK)
+	fmt.Printf("deleted note %s\n", updated.PK)
 
 	fmt.Println("OK: TableTheory CRUD against DynamoDB Local succeeded")
 }


### PR DESCRIPTION
## Summary
- Update the Go `tabletheory init` scaffold to re-read the note after `Update("title")` before printing the optimistic-lock version.
- Print `persistedVersion` from the item read back from DynamoDB so scaffold output no longer implies the caller struct's stale version was incremented in memory.
- Add scaffold-generation assertions to pin the re-read pattern and reject the old stale-version message.

## TypeScript/Python scaffold decision
TS/Py templates are intentionally unchanged: they do not perform a post-read update or print a post-update version today. They read the initial version and then delete the item, so they do not have the stale optimistic-lock version messaging gap fixed here. Adding equivalent update flows would broaden THE-2557 beyond the Go scaffold follow-up.

## Validation
- `git diff --check` — PASS
- `go test ./cmd/tabletheory` — PASS
- `bash scripts/verify-init-scaffold.sh` — PASS; scaffold output includes `updated note: title="Hello TableTheory (updated)" persistedVersion=1`
- `make rubric` — PASS (`pass=36 fail=0 blocked=0`)

Closes THE-2557
