### PR TITLE
test(contract): prove canonical decimal assertions

### DIFF
--- a/contract-tests/runners/go/internal/runner/runner_test.go
+++ b/contract-tests/runners/go/internal/runner/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/driver"
 	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/scenario"
 	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/spec"
@@ -100,4 +101,71 @@ func TestAssertReadResult_FailsClosedWhenReadAssertionHasErrorWithoutOk(t *testi
 			model,
 		)
 	})
+}
+
+func TestAssertStepResult_UsesCanonicalDecimalStringsForRawNumberAssertions(t *testing.T) {
+	r := &Runner{vars: map[string]any{}}
+	model := numberPrecisionModel()
+	expect := scenario.Expectation{ItemContains: map[string]any{
+		"largeInteger":   "9007199254740993",
+		"preciseDecimal": "0.12345678901234567",
+	}}
+	item := map[string]any{
+		"largeInteger":   "9007199254740993",
+		"preciseDecimal": "0.12345678901234567",
+	}
+	raw := map[string]ddbtypes.AttributeValue{
+		"largeInteger":   &ddbtypes.AttributeValueMemberN{Value: "9007199254740993"},
+		"preciseDecimal": &ddbtypes.AttributeValueMemberN{Value: "0.12345678901234567"},
+	}
+
+	r.assertStepResult(t, expect, item, nil, raw, model)
+
+	lossyRaw := map[string]ddbtypes.AttributeValue{
+		"largeInteger":   &ddbtypes.AttributeValueMemberN{Value: "9007199254740992"},
+		"preciseDecimal": &ddbtypes.AttributeValueMemberN{Value: "0.12345678901234566"},
+	}
+	requireFails(t, func(requireT *requireCaptureT) {
+		r.assertStepResult(requireT, expect, item, nil, lossyRaw, model)
+	})
+}
+
+func TestAssertReadResult_UsesCanonicalDecimalStringsForQueryNumberAssertions(t *testing.T) {
+	r := &Runner{vars: map[string]any{}}
+	model := numberPrecisionModel()
+	expect := scenario.Expectation{
+		ItemCount: intPtr(1),
+		ItemsContains: []map[string]any{{
+			"largeInteger":   "9007199254740993",
+			"preciseDecimal": "0.12345678901234567",
+		}},
+	}
+	exactResult := driver.ReadResult{Items: []map[string]any{{
+		"largeInteger":   "9007199254740993",
+		"preciseDecimal": "0.12345678901234567",
+	}}}
+
+	r.assertReadResult(t, expect, exactResult, nil, model)
+
+	lossyResult := driver.ReadResult{Items: []map[string]any{{
+		"largeInteger":   "9007199254740992",
+		"preciseDecimal": "0.12345678901234566",
+	}}}
+	requireFails(t, func(requireT *requireCaptureT) {
+		r.assertReadResult(requireT, expect, lossyResult, nil, model)
+	})
+}
+
+func numberPrecisionModel() spec.Model {
+	return spec.Model{
+		Name: "NumberPrecision",
+		Attributes: []spec.Attribute{
+			{Attribute: "largeInteger", Type: "N"},
+			{Attribute: "preciseDecimal", Type: "N"},
+		},
+	}
+}
+
+func intPtr(value int) *int {
+	return &value
 }

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -1051,12 +1051,103 @@ def test_assert_read_expectation_fails_closed_on_read_assertion_error_without_ok
         )
 
 
+def test_assert_expectation_preserves_canonical_decimal_strings_for_raw_numbers() -> None:
+    model = _minimal_number_precision_model()
+    expect = {
+        "item_contains": {
+            "largeInteger": "9007199254740993",
+            "preciseDecimal": "0.12345678901234567",
+        }
+    }
+    item = {
+        "largeInteger": "9007199254740993",
+        "preciseDecimal": "0.12345678901234567",
+    }
+
+    _assert_expectation(
+        expect,
+        error=None,
+        item=item,
+        raw={
+            "largeInteger": {"N": "9007199254740993"},
+            "preciseDecimal": {"N": "0.12345678901234567"},
+        },
+        model=model,
+        variables={},
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_expectation(
+            expect,
+            error=None,
+            item=item,
+            raw={
+                "largeInteger": {"N": "9007199254740992"},
+                "preciseDecimal": {"N": "0.12345678901234566"},
+            },
+            model=model,
+            variables={},
+        )
+
+
+def test_assert_read_expectation_preserves_canonical_decimal_strings_for_query_numbers() -> None:
+    model = _minimal_number_precision_model()
+    expect = {
+        "item_count": 1,
+        "items_contains": [
+            {
+                "largeInteger": "9007199254740993",
+                "preciseDecimal": "0.12345678901234567",
+            }
+        ],
+    }
+
+    _assert_read_expectation(
+        expect,
+        error=None,
+        result={
+            "items": [
+                {
+                    "largeInteger": "9007199254740993",
+                    "preciseDecimal": "0.12345678901234567",
+                }
+            ]
+        },
+        model=model,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_read_expectation(
+            expect,
+            error=None,
+            result={
+                "items": [
+                    {
+                        "largeInteger": "9007199254740992",
+                        "preciseDecimal": "0.12345678901234566",
+                    }
+                ]
+            },
+            model=model,
+        )
+
+
 def _minimal_user_model() -> dict[str, Any]:
     return {
         "name": "User",
         "attributes": [
             {"attribute": "PK", "type": "S"},
             {"attribute": "SK", "type": "S"},
+        ],
+    }
+
+
+def _minimal_number_precision_model() -> dict[str, Any]:
+    return {
+        "name": "NumberPrecision",
+        "attributes": [
+            {"attribute": "largeInteger", "type": "N"},
+            {"attribute": "preciseDecimal", "type": "N"},
         ],
     }
 
@@ -1141,7 +1232,7 @@ def _normalize_contract_value(value: Any) -> Any:
             return sorted(_base64_string(item) for item in value)
         return sorted(str(item) for item in value)
     if isinstance(value, Decimal):
-        return int(value) if value == value.to_integral_value() else float(value)
+        return format(value, "f")
     if isinstance(value, dict):
         return {key: _normalize_contract_value(val) for key, val in value.items()}
     if isinstance(value, list):

--- a/contract-tests/runners/ts/test/contract.interop.test.ts
+++ b/contract-tests/runners/ts/test/contract.interop.test.ts
@@ -50,7 +50,8 @@ test("cross-runtime interop scenarios (ts read phase)", async (t) => {
   for (const s of scenarios) {
     await t.test(s.name, async (st) => {
       const driver = new TheorydbDriver(ddb, compiled, {
-        exactNumbers: true,
+        exactNumbers:
+          s.requires_capabilities?.includes("number.precision.exact") ?? false,
         encryption: encryptionProviderForScenario(s.encryption),
       });
       const missing = missingCapabilities(s, driver);

--- a/contract-tests/runners/ts/test/contract.p0.test.ts
+++ b/contract-tests/runners/ts/test/contract.p0.test.ts
@@ -56,7 +56,8 @@ test("P0 contract scenarios (ts runner)", async (t) => {
   for (const s of scenarios) {
     await t.test(s.name, async (st) => {
       const driver = new TheorydbDriver(ddb, compiled, {
-        exactNumbers: true,
+        exactNumbers:
+          s.requires_capabilities?.includes("number.precision.exact") ?? false,
         encryption: encryptionProviderForScenario(s.encryption),
       });
       const missing = missingCapabilities(s, driver);

--- a/contract-tests/runners/ts/test/contract.p1.test.ts
+++ b/contract-tests/runners/ts/test/contract.p1.test.ts
@@ -56,7 +56,8 @@ test("P1 contract scenarios (ts runner)", async (t) => {
   for (const s of scenarios) {
     await t.test(s.name, async (st) => {
       const driver = new TheorydbDriver(ddb, compiled, {
-        exactNumbers: true,
+        exactNumbers:
+          s.requires_capabilities?.includes("number.precision.exact") ?? false,
         encryption: encryptionProviderForScenario(s.encryption),
       });
       const missing = missingCapabilities(s, driver);

--- a/contract-tests/runners/ts/test/contract.p2.test.ts
+++ b/contract-tests/runners/ts/test/contract.p2.test.ts
@@ -56,7 +56,8 @@ test("P2 contract scenarios (ts runner)", async (t) => {
   for (const s of scenarios) {
     await t.test(s.name, async (st) => {
       const driver = new TheorydbDriver(ddb, compiled, {
-        exactNumbers: true,
+        exactNumbers:
+          s.requires_capabilities?.includes("number.precision.exact") ?? false,
         encryption: encryptionProviderForScenario(s.encryption),
       });
       const missing = missingCapabilities(s, driver);

--- a/contract-tests/runners/ts/test/fixtures.test.ts
+++ b/contract-tests/runners/ts/test/fixtures.test.ts
@@ -130,6 +130,115 @@ test("interop read assertions fail closed on query errors without ok", async () 
   );
 });
 
+test("number read assertions compare canonical decimal strings from raw items", async () => {
+  const item = {
+    PK: "NUM#unit",
+    SK: "CASE#raw",
+    largeInteger: "9007199254740993",
+    preciseDecimal: "0.12345678901234567",
+  };
+  const expect = {
+    item_contains: {
+      largeInteger: "9007199254740993",
+      preciseDecimal: "0.12345678901234567",
+    },
+  };
+
+  await runScenario({
+    ddb: stubDdbWithRawItem({
+      PK: { S: "NUM#unit" },
+      SK: { S: "CASE#raw" },
+      largeInteger: { N: "9007199254740993" },
+      preciseDecimal: { N: "0.12345678901234567" },
+    }),
+    driver: stubDriver({ get: async () => item }),
+    scenario: scenarioWithNumberReadStep({
+      op: "get",
+      key: { PK: "NUM#unit", SK: "CASE#raw" },
+      expect,
+    }),
+    models: new Map([[numberPrecisionModel.name, numberPrecisionModel]]),
+  });
+
+  await assert.rejects(
+    () =>
+      runScenario({
+        ddb: stubDdbWithRawItem({
+          PK: { S: "NUM#unit" },
+          SK: { S: "CASE#raw" },
+          largeInteger: { N: "9007199254740992" },
+          preciseDecimal: { N: "0.12345678901234566" },
+        }),
+        driver: stubDriver({ get: async () => item }),
+        scenario: scenarioWithNumberReadStep({
+          op: "get",
+          key: { PK: "NUM#unit", SK: "CASE#raw" },
+          expect,
+        }),
+        models: new Map([[numberPrecisionModel.name, numberPrecisionModel]]),
+      }),
+    /Expected values to be strictly equal/,
+  );
+});
+
+test("number query assertions compare canonical decimal strings", async () => {
+  const exactItem = {
+    PK: "NUM#unit",
+    SK: "CASE#query",
+    largeInteger: "9007199254740993",
+    preciseDecimal: "0.12345678901234567",
+  };
+  const queryStep: Step = {
+    op: "query",
+    query: {
+      partition: {
+        attribute: "PK",
+        operator: "=",
+        value: "NUM#unit",
+      },
+    },
+    expect: {
+      item_count: 1,
+      items_contains: [
+        {
+          largeInteger: "9007199254740993",
+          preciseDecimal: "0.12345678901234567",
+        },
+      ],
+    },
+  };
+
+  await runScenario({
+    ddb: {} as never,
+    driver: stubDriver({
+      query: async () => ({ items: [exactItem] }),
+    }),
+    scenario: scenarioWithNumberReadStep(queryStep),
+    models: new Map([[numberPrecisionModel.name, numberPrecisionModel]]),
+  });
+
+  await assert.rejects(
+    () =>
+      runScenario({
+        ddb: {} as never,
+        driver: stubDriver({
+          query: async () => ({
+            items: [
+              {
+                ...exactItem,
+                largeInteger: "9007199254740992",
+                preciseDecimal: "0.12345678901234566",
+              },
+            ],
+          }),
+        }),
+        scenario: scenarioWithNumberReadStep(queryStep),
+        models: new Map([[numberPrecisionModel.name, numberPrecisionModel]]),
+      }),
+    /Expected values to be strictly equal/,
+  );
+});
+
 const userModel: DmsModel = {
   name: "User",
   table: { name: "users_contract" },
@@ -140,6 +249,21 @@ const userModel: DmsModel = {
   attributes: [
     { attribute: "PK", type: "S", required: true, roles: ["pk"] },
     { attribute: "SK", type: "S", required: true, roles: ["sk"] },
+  ],
+};
+
+const numberPrecisionModel: DmsModel = {
+  name: "NumberPrecision",
+  table: { name: "number_precision_contract" },
+  keys: {
+    partition: { attribute: "PK", type: "S" },
+    sort: { attribute: "SK", type: "S" },
+  },
+  attributes: [
+    { attribute: "PK", type: "S", required: true, roles: ["pk"] },
+    { attribute: "SK", type: "S", required: true, roles: ["sk"] },
+    { attribute: "largeInteger", type: "N", format: "decimal_string" },
+    { attribute: "preciseDecimal", type: "N", format: "decimal_string" },
   ],
 };
 
@@ -163,6 +287,37 @@ function scenarioWithReadStep(step: Step): Scenario {
   };
 }
 
+function scenarioWithNumberReadStep(step: Step): Scenario {
+  return {
+    name: "unit.number_precision.canonical_decimal_assertions",
+    dms_version: "0.1",
+    requires_capabilities: ["number.precision.exact"],
+    model: numberPrecisionModel.name,
+    table: { name: numberPrecisionModel.table.name },
+    steps: [],
+    seed_runtime: "go",
+    seed_steps: [
+      {
+        op: "create",
+        item: {
+          PK: "unused",
+          SK: "unused",
+          largeInteger: "0",
+          preciseDecimal: "0",
+        },
+        expect: { ok: true },
+      },
+    ],
+    read_steps: [step],
+  };
+}
+
+function stubDdbWithRawItem(item: Record<string, unknown>): never {
+  return {
+    send: async () => ({ Item: item }),
+  } as never;
+}
+
 function stubDriver(overrides: Partial<Driver>): Driver {
   const fail = async (): Promise<never> => {
     throw new Error("unexpected stub driver call");
@@ -171,11 +326,18 @@ function stubDriver(overrides: Partial<Driver>): Driver {
     capabilities: () => [],
     create: fail,
     get: fail,
+    getOptional: fail,
     update: fail,
     save: fail,
     delete: fail,
     query: fail,
     scan: fail,
+    countQuery: fail,
+    countScan: fail,
+    transactGet: fail,
+    batchGet: fail,
+    batchWrite: fail,
+    transactWrite: fail,
     transitionAppendEvent: fail,
     validateProvenance: fail,
     ...overrides,

--- a/contract-tests/scenarios/p0/10-number-precision.yml
+++ b/contract-tests/scenarios/p0/10-number-precision.yml
@@ -40,3 +40,39 @@ steps:
           SK: "CASE#1"
           largeInteger: "9007199254740993"
           preciseDecimal: "1234567890.125"
+
+  - op: create
+    item:
+      PK: "NUM#2"
+      SK: "CASE#lossy-decimal"
+      largeInteger: "9007199254740993"
+      preciseDecimal: "0.12345678901234567"
+    expect:
+      ok: true
+
+  - op: get
+    key:
+      PK: "NUM#2"
+      SK: "CASE#lossy-decimal"
+    expect:
+      raw_attribute_types:
+        largeInteger: "N"
+        preciseDecimal: "N"
+      item_contains:
+        PK: "NUM#2"
+        SK: "CASE#lossy-decimal"
+        largeInteger: "9007199254740993"
+        preciseDecimal: "0.12345678901234567"
+
+  - op: query
+    query:
+      partition: { attribute: "PK", operator: "=", value: "NUM#2" }
+      sort: { attribute: "SK", operator: "=", value: "CASE#lossy-decimal" }
+      projection: ["PK", "SK", "largeInteger", "preciseDecimal"]
+    expect:
+      item_count: 1
+      items_contains:
+        - PK: "NUM#2"
+          SK: "CASE#lossy-decimal"
+          largeInteger: "9007199254740993"
+          preciseDecimal: "0.12345678901234567"

--- a/contract-tests/scenarios/p0/11-type-matrix.yml
+++ b/contract-tests/scenarios/p0/11-type-matrix.yml
@@ -1,6 +1,6 @@
 name: "p0.type_matrix.round_trip"
 dms_version: "0.1"
-requires_capabilities: ["type.matrix"]
+requires_capabilities: ["type.matrix", "number.precision.exact"]
 model: "TypeMatrix"
 table:
   name: "type_matrix_contract"


### PR DESCRIPTION
## Summary
- Add a lossy-adjacent decimal proof case to `p0.number.precision` so get/read and query assertions cover `0.12345678901234567` plus a `>2^53` integer.
- Add Go, TypeScript, and Python runner tests proving canonical decimal assertions fail on rounded raw/read and query values.
- Keep TypeScript exact-number mode capability-scoped and mark the type-matrix fixture accordingly because it includes a `>2^53` number set value.

## Validation
- `git diff --check`
- `go test ./internal/runner -run 'TestAssert(StepResult|ReadResult)_.*(FailsClosed|CanonicalDecimal)' -v` (from `contract-tests/runners/go`)
- `npm --prefix contract-tests/runners/ts run test:fixtures`
- `uv --directory py run pytest -q ../contract-tests/runners/py/test_contract_p0.py -k 'canonical_decimal or fails_closed'`
- `bash scripts/verify-generated-models.sh --check`
- `go test . -run 'TestContract_P0/10-number-precision.yml' -count=1 -v` (from `contract-tests/runners/go`)
- `npm --prefix contract-tests/runners/ts run test:contract:p0`
- `uv --directory py run pytest -q ../contract-tests/runners/py/test_contract_p0.py -k 'p0.number.precision'`
- `make contract-tests`
- `make rubric`

Closes THE-2524