### PR TITLE
feat(ci): adopt merge queue for protected branches

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -3,6 +3,8 @@ name: Quality Gates (10/10 Rubric)
 on:
   pull_request:
     branches: ["staging"]
+  merge_group:
+    branches: ["staging"]
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -3,6 +3,8 @@ name: Release Hygiene
 on:
   pull_request:
     branches: ["premain", "main"]
+  merge_group:
+    branches: ["premain", "main"]
   workflow_dispatch: {}
 
 permissions:
@@ -46,7 +48,8 @@ jobs:
             --head-repo "${HEAD_REPOSITORY}" \
             --base-sha "${BASE_SHA}" \
             --head-sha "${HEAD_SHA}" \
-            --title "${PR_TITLE}"
+            --title "${PR_TITLE}" \
+            --queue-freshness
 
       - name: Checkout pull request head after provenance verification
         if: github.event_name == 'pull_request'
@@ -56,11 +59,45 @@ jobs:
           path: pr
           persist-credentials: false
 
-      - name: Checkout workflow dispatch ref
+      - name: Checkout merge queue or workflow dispatch ref
         if: github.event_name != 'pull_request'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      - name: Resolve release hygiene target branch
+        if: github.event_name != 'pull_request'
+        id: target
+        run: |
+          set -euo pipefail
+
+          target="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
+            target="$(
+              python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          base_ref = str(event.get("merge_group", {}).get("base_ref", ""))
+          if base_ref.startswith("refs/heads/"):
+              base_ref = base_ref.removeprefix("refs/heads/")
+          print(base_ref)
+          PY
+            )"
+          fi
+
+          case "${target}" in
+            premain|main)
+              ;;
+            *)
+              echo "release-hygiene: FAIL (unsupported target branch ${target:-<empty>})" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "branch=${target}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify human promotion release driver
         if: github.event_name == 'pull_request' && ((github.base_ref == 'premain' && github.head_ref == 'staging') || (github.base_ref == 'main' && github.head_ref == 'premain'))
@@ -89,8 +126,34 @@ jobs:
       - name: Verify release cycle state
         if: github.event_name != 'pull_request'
         env:
-          RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION: "false"
-        run: bash scripts/verify-release-cycle-state.sh
+          TARGET_BRANCH: ${{ steps.target.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          strict_log="$(mktemp)"
+          pending_log="$(mktemp)"
+          cleanup() {
+            rm -f "${strict_log}" "${pending_log}"
+          }
+          trap cleanup EXIT
+
+          if GITHUB_BASE_REF="${TARGET_BRANCH}" RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=false \
+            bash scripts/verify-release-cycle-state.sh >"${strict_log}" 2>&1; then
+            cat "${strict_log}"
+            exit 0
+          fi
+
+          if [[ "${TARGET_BRANCH}" == "main" ]] && \
+            GITHUB_BASE_REF=main GITHUB_HEAD_REF=premain RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true \
+              bash scripts/verify-release-cycle-state.sh >"${pending_log}" 2>&1; then
+            cat "${pending_log}"
+            echo "release-hygiene: pending stable promotion accepted on queued main merge group"
+            exit 0
+          fi
+
+          cat "${strict_log}"
+          cat "${pending_log}"
+          exit 1
 
       - name: Verify release supply-chain scaffolding
         if: github.event_name == 'pull_request'
@@ -115,7 +178,7 @@ jobs:
             --forbid-rc-only
 
       - name: Forbid RC-shaped main Release PRs
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.target.outputs.branch == 'main'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ The cross-framework release lane is exactly `staging -> premain -> main -> stagi
 requires the full gov-infra rubric, and only on PRs targeting `staging` plus manual workflow dispatch. PRs targeting
 `premain` or `main` require release-hygiene checks only, not the full rubric.
 
+Protected `staging`, `premain`, and `main` are merge-queue branches. Repo-owned workflows support this with
+`merge_group` triggers: `quality-gates.yml` validates queued `staging` merges with the full rubric, and
+`release-hygiene.yml` validates queued `premain`/`main` promotion or release-please merges with release hygiene. The live
+GitHub setting is still operator-owned: require the merge queue and the corresponding checks in branch protection/rulesets
+before relying on the v2 lane.
+
 Branch roles:
 
 - **`staging`**: integration branch (all work lands here first)
@@ -115,8 +121,8 @@ Stable promotion path:
 - Do not start `premain` -> `main` promotion until the intended RC exists as a GitHub release that is published,
   non-draft, marked prerelease, backed by `refs/tags/vX.Y.Z-rc.N`, and complete with the required TypeScript/Python
   assets.
-- Open and merge the promotion PR from `premain` to `main`; do not create a local stable-normalization branch as the
-  normal path.
+- Open the promotion PR from `premain` to `main` and merge it through the merge queue; do not create a local
+  stable-normalization branch as the normal path.
 - After the `premain` -> `main` promotion merges, `main` may briefly contain a single-manifest RC. This state is allowed
   only until `.github/workflows/release-pr.yml` opens the stable release-please PR and that PR merges.
 - Pending stable promotion is explicit automation state only:
@@ -139,6 +145,8 @@ Stable promotion path:
 
 Release watchpoints and stop conditions:
 
+- Stop if live GitHub branch protection/rulesets do not require the merge queue and the queue-compatible
+  `Quality Gates (10/10 Rubric)` / `Release Hygiene` checks for their protected target branches.
 - Stop if `main` carries an RC manifest outside explicit single-manifest pending stable promotion.
 - Stop if `.release-please-manifest.json` is an RC version on `staging`, or if the retired
   `.release-please-manifest.premain.json` appears on release branches.

--- a/docs/development/planning/tabletheory-release-lane-v2-design-2026.md
+++ b/docs/development/planning/tabletheory-release-lane-v2-design-2026.md
@@ -1,7 +1,9 @@
 # TableTheory release-lane v2 design (single manifest preparatory gate)
 
-Status: **design only**. This document satisfies TTIP-110 / THE-2448 and does not implement TTIP-111, TTIP-112, or
-TTIP-113. The next implementation item must not start until the maintainer explicitly signs off on this design.
+Status: **design record with implementation follow-ups**. This document was authored for TTIP-110 / THE-2448. TTIP-111 /
+THE-2449 implemented the single-manifest lane in repo-owned workflows and guards; TTIP-112 / THE-2450 implements the
+merge-queue workflow triggers and provenance-guard disposition below. TTIP-113 remains the cleanup item for retiring
+superseded scripts after the v2 lane soaks.
 
 ## Purpose
 
@@ -90,6 +92,17 @@ implementation PRs merge:
 If merge queue is unavailable, the fallback is a documented manual merge freeze: one release-lane PR open at a time, no
 parallel promotion/release-please merges, and a fresh strict release-lane verification immediately before merge.
 
+THE-2450 repo-owned implementation:
+
+- `.github/workflows/quality-gates.yml` has a `merge_group` trigger for queued `staging` merges.
+- `.github/workflows/release-hygiene.yml` has a `merge_group` trigger for queued `premain` and `main` merges and validates
+  the queued ref with release-cycle and supply-chain checks. On queued `main` merge groups, it accepts the same explicit
+  pending-stable-promotion state that a `premain` -> `main` promotion PR creates.
+- Pull-request provenance still rejects forks/name-spoofing and illegal release-lane source branches before checking out
+  PR-head code. The prior live-ref equality check is not required in the normal PR path because the merge queue validates
+  freshness against the protected branch tip; it remains available as the strict manual-freeze fallback.
+- Live GitHub branch-protection/ruleset changes are operator-owned and cannot be completed through a normal signed PR.
+
 ## Guard disposition map
 
 | Current guard / artifact | Current purpose | v2 disposition | Successor / rationale |
@@ -126,6 +139,17 @@ parallel promotion/release-please merges, and a fresh strict release-lane verifi
 | `gov-infra/verifiers/gov-verify-rubric.sh` COM-8 | Rubric release supply-chain gate | **Keep, update call graph only** | COM-8 remains the release-lane gate identity. |
 | `AGENTS.md` release policy | Operator/steward instructions | **Keep, update** | Must describe v2 after implementation; this design is not enough to change the live policy yet. |
 | `docs/development/planning/theorydb-branch-release-policy.md` | Current operator release policy | **Keep, update after sign-off** | Update only with the implementation PR so docs and automation change together. |
+
+THE-2450 guard disposition details:
+
+| Guard / threat | THE-2450 disposition | Rationale / successor |
+| --- | --- | --- |
+| Fork or name-spoofed release-lane PR checks out untrusted code | **Retained** | `release-hygiene.yml` still runs `verify-release-lane-provenance.sh` from the trusted base checkout before PR-head checkout. |
+| Illegal `premain`/`main` source branch or RC/stable release-please title shape | **Retained** | `verify-release-lane-provenance.sh` still allows only `staging`/generated RC heads for `premain` and `premain`/generated stable heads for `main`. |
+| Human promotion lacks release intent / lets release-please report "No user facing commits" | **Retained** | `verify-promotion-release-driver.sh` still runs on `staging` -> `premain` and `premain` -> `main` PRs. |
+| PR-event base/head SHA must equal current live branch refs | **Covered by queue semantics in normal path; retained for fallback** | The protected branch merge queue validates the queued merge ref against the target branch tip before merge. The strict live-ref check remains the default in `verify-release-lane-provenance.sh` for manual-freeze fallback; the workflow uses `--queue-freshness`. |
+| Release-cycle state, supply-chain scaffolding, main RC release-PR postcondition | **Retained and extended to queue refs** | `release-hygiene.yml` runs these checks on both PR-head checkouts and `merge_group` queue refs. |
+| Stable-promotion single-manifest RC on queued `main` merge group | **Replaced by kept pending-promotion check** | Queue validation first tries strict stable state, then accepts only explicit pending stable promotion mode for queued `main` refs. |
 
 ## Dry-run protocol for TTIP-111
 
@@ -177,15 +201,16 @@ Rollback stays PR-based and never reuses an immutable release version:
 5. `scripts/prepare-stable-promotion.sh` and the current two-manifest docs remain available until v2 completes one full
    RC-to-stable soak; remove them only in the follow-up cleanup item after the maintainer accepts the soak evidence.
 
-## Maintainer sign-off gate before TTIP-111
+## Historical maintainer sign-off gate before TTIP-111
 
-Required sign-off text before starting THE-2449 / TTIP-111:
+This sign-off text was required before starting THE-2449 / TTIP-111:
 
 > I approve TableTheory release-lane v2 implementation against
 > `docs/development/planning/tabletheory-release-lane-v2-design-2026.md`, including the single-manifest plan, generated
 > TS/Py release-build versions, merge-queue requirement, dry-run protocol, rollback plan, and between-cycles execution
 > window.
 
-Without that explicit sign-off, the correct next action is to keep THE-2449, THE-2450, and THE-2451 blocked and report the
-missing approval. Implementation pressure to consolidate release-please manifests, rewrite workflows, or remove guards
-before sign-off is scope creep and must stop.
+The Factory/operator THE-2450 assignment supersedes the remaining "do not start" language for this implementation path:
+release-cycle proof is a release execution/readiness gate, not an implementation prerequisite. If live branch-protection
+or merge-queue settings cannot be changed through PR files, the implementation reports the exact operator-owned setting
+that remains.

--- a/docs/development/planning/theorydb-branch-release-policy.md
+++ b/docs/development/planning/theorydb-branch-release-policy.md
@@ -87,10 +87,31 @@ Protect both `premain` and `main`:
 - Require CODEOWNERS/review approvals.
 - Require release-hygiene status checks for PRs targeting `premain` and `main`; do not require the full gov-infra rubric
   on those promotion branches.
+- Require the GitHub merge queue. The queue must require the `Release Hygiene` workflow's `merge_group` validation before
+  a promotion PR or generated release-please PR can merge.
 - Restrict force-pushes and deletions.
 
 Protect `staging` with the full gov-infra rubric on PRs targeting `staging`. The full rubric may also run by
-`workflow_dispatch`, but it must not run on push or on PRs targeting `premain` or `main`.
+`workflow_dispatch`, but it must not run on push or on PRs targeting `premain` or `main`. Require the GitHub merge queue
+for `staging` too, with the `Quality Gates (10/10 Rubric)` `merge_group` validation as the queue check.
+
+### Merge queue provenance disposition
+
+Release-lane v2 keeps the provenance checks that identify *what* is allowed to enter a protected release branch:
+
+- PR base/head repositories must be `theory-cloud/TableTheory`; forks and name-spoofed repositories are rejected before
+  any PR-head checkout.
+- `premain` accepts only `staging` promotions or generated `release-please--branches--premain` RC PRs, with numbered
+  `X.Y.Z-rc.N` release titles.
+- `main` accepts only `premain` promotions or generated `release-please--branches--main` stable PRs, with no RC-shaped
+  release title.
+- Human promotion PRs still run the release-driver guard, so release-please "No user facing commits" remains a failed
+  release-intent gate.
+
+The old required PR-time "event base/head SHA must equal the current live branch ref" guard is retired from the normal
+release-hygiene PR path because the merge queue now validates the exact queued merge ref against the latest protected
+branch tip before merge. The strict live-ref check remains in `scripts/verify-release-lane-provenance.sh` for documented
+manual-freeze fallback use if merge queue is unavailable.
 
 ## Automated releases (required)
 
@@ -174,10 +195,10 @@ promotion path, and it must not replace release-please-owned stable version/chan
 
 Release-lane quality workflow expectations:
 
-- `.github/workflows/quality-gates.yml` runs the full gov-infra rubric only for PRs targeting `staging` and for
-  manual dispatch.
-- `.github/workflows/release-hygiene.yml` runs lightweight source-branch, release-cycle, supply-chain, and main-RC-PR
-  checks for PRs targeting `premain` and `main`.
+- `.github/workflows/quality-gates.yml` runs the full gov-infra rubric only for PRs targeting `staging`, queued
+  `staging` merge groups, and manual dispatch.
+- `.github/workflows/release-hygiene.yml` runs lightweight source-branch/provenance, release-cycle, supply-chain, and
+  main-RC-PR checks for PRs targeting `premain`/`main`, plus queued `premain`/`main` merge groups.
 - Other security workflows, such as `.github/workflows/codeql.yml`, may run independently, but they do not replace the
   release-lane gate split above.
 

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -110,6 +110,34 @@ expect_failure_contains \
     --ref "refs/heads/premain=${advanced_base_sha}" \
     --ref "refs/heads/staging=${head_sha}"
 
+expect_success_contains \
+  "live ref freshness covered by merge queue" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head staging \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "Promote staging to premain" \
+    --queue-freshness \
+    --ref "refs/heads/premain=${advanced_base_sha}" \
+    --ref "refs/heads/staging=4444444444444444444444444444444444444444"
+
+expect_failure_contains \
+  "same-repository" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head staging \
+    --base-repo "${repo}" \
+    --head-repo "attacker/TableTheory" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "Promote staging to premain" \
+    --queue-freshness
+
 expect_failure_contains \
   "numbered RC version" \
   bash "${checker}" \
@@ -277,6 +305,26 @@ fi
 
 grep -Fq "persist-credentials: false" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene checkouts must disable persisted credentials"
+  exit 1
+}
+
+grep -Fq "merge_group:" "${repo_root}/.github/workflows/quality-gates.yml" || {
+  echo "release-hygiene-policy-test: quality gates must support merge_group for staging queue"
+  exit 1
+}
+
+grep -Fq "merge_group:" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must support merge_group for release queue"
+  exit 1
+}
+
+grep -Fq -- "--queue-freshness" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene PR provenance must delegate live ref freshness to merge queue"
+  exit 1
+}
+
+grep -Fq "pending stable promotion accepted on queued main merge group" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must allow queued main pending stable promotion"
   exit 1
 }
 

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # Verifies the TableTheory release-lane scaffolding:
 # - one lane: staging -> premain -> main -> staging
-# - full gov-infra rubric only on staging PRs and workflow_dispatch
-# - lightweight release hygiene on premain/main PRs
+# - full gov-infra rubric only on staging PRs, staging merge queue, and workflow_dispatch
+# - lightweight release hygiene on premain/main PRs and merge queues
 # - premain cuts RCs; main cuts stable releases only
 # - no post-stable CI direct-push sync to protected branches
 #
@@ -89,6 +89,8 @@ if [[ -f ".github/workflows/quality-gates.yml" ]]; then
   q=".github/workflows/quality-gates.yml"
   require_fixed "pull_request:" "${q}" \
     "quality-gates must run on pull_request"
+  require_fixed "merge_group:" "${q}" \
+    "quality-gates must run on merge_group for the staging merge queue"
   require_fixed 'branches: ["staging"]' "${q}" \
     "quality-gates pull_request must target staging only"
   require_fixed "workflow_dispatch:" "${q}" \
@@ -116,8 +118,12 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
   h=".github/workflows/release-hygiene.yml"
   require_fixed 'branches: ["premain", "main"]' "${h}" \
     "release-hygiene must target premain and main PRs"
+  require_fixed "merge_group:" "${h}" \
+    "release-hygiene must run on merge_group for premain/main queues"
   require_fixed "trusted-release/scripts/verify-release-lane-provenance.sh" "${h}" \
     "release-hygiene must verify release-lane same-repository provenance from trusted scripts"
+  require_fixed "--queue-freshness" "${h}" \
+    "release-hygiene PR provenance must delegate live ref freshness to merge queue semantics"
   require_fixed "github.event.pull_request.base.sha" "${h}" \
     "release-hygiene must check out trusted release scripts from the PR base SHA"
   require_fixed "github.event.pull_request.head.sha" "${h}" \
@@ -146,6 +152,8 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
     "release-hygiene must run the release driver guard on premain -> main PRs"
   require_fixed "../trusted-release/scripts/verify-promotion-release-driver.sh" "${h}" \
     "release-hygiene must run the promotion driver from trusted checkout"
+  require_fixed "pending stable promotion accepted on queued main merge group" "${h}" \
+    "release-hygiene must allow queued main pending stable promotion validation"
   if grep -Fq "secrets.RELEASE_PLEASE_TOKEN" "${h}"; then
     fail "release-hygiene must not expose release-please token"
   fi
@@ -415,7 +423,9 @@ if [[ -f "scripts/verify-release-lane-provenance.sh" ]]; then
   require_fixed "release-lane PRs must be same-repository" "${provenance}" \
     "release-lane provenance guard must reject fork/name-spoofed PRs"
   require_fixed "does not match same-repository refs/heads" "${provenance}" \
-    "release-lane provenance guard must verify exact branch SHAs"
+    "release-lane provenance guard must retain exact branch SHA verification for manual fallback"
+  require_fixed "live ref freshness covered by merge queue" "${provenance}" \
+    "release-lane provenance guard must document queue-covered live ref freshness"
   require_fixed "-rc\\.[0-9]+" "${provenance}" \
     "release-lane provenance guard must require numbered RC release-please PR titles"
 fi

--- a/scripts/verify-release-lane-provenance.sh
+++ b/scripts/verify-release-lane-provenance.sh
@@ -2,8 +2,11 @@
 set -euo pipefail
 
 # Read-only provenance guard for release-lane pull requests. It rejects branch
-# name spoofing by requiring the PR head/base repositories to be this repository
-# and the PR head/base SHAs to match the live same-repository branch refs.
+# name spoofing by requiring the PR head/base repositories to be this repository.
+# By default it also verifies the PR head/base SHAs against live same-repository
+# branch refs for the manual-freeze fallback. In the normal v2 path,
+# --queue-freshness delegates that live-ref freshness guard to the protected
+# branch merge queue while retaining same-repository and release-branch checks.
 
 usage() {
   cat <<'USAGE'
@@ -22,6 +25,7 @@ Options:
   --pr-merged BOOL        Whether the PR is known merged from the event payload or test fixture.
   --title TITLE           PR title for generated release-please PR validation.
   --ref REF=SHA           Test-only ref override, e.g. refs/heads/staging=<sha>.
+  --queue-freshness       Treat live ref freshness as covered by a required GitHub merge queue.
   -h, --help              Show this help.
 
 This command uses read-only GitHub ref lookups unless --ref supplies all needed
@@ -41,6 +45,7 @@ pr_number="${PR_NUMBER:-}"
 pr_state="${PR_STATE:-}"
 pr_merged="${PR_MERGED:-}"
 title="${PR_TITLE:-}"
+queue_freshness=0
 ref_overrides=()
 
 while [[ $# -gt 0 ]]; do
@@ -104,6 +109,10 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--ref requires a value)" >&2; exit 2; }
       ref_overrides+=("$2")
       shift 2
+      ;;
+    --queue-freshness)
+      queue_freshness=1
+      shift
       ;;
     -h|--help)
       usage
@@ -275,6 +284,11 @@ fi
 refresh_pr_lifecycle
 if is_premain_release_please_rc_pr && pr_is_merged; then
   stale_merged_rc_pr_allowed=1
+fi
+
+if [[ "${queue_freshness}" -eq 1 ]]; then
+  echo "release-lane-provenance: PASS (${head}@${head_sha} -> ${base}@${base_sha}; live ref freshness covered by merge queue)"
+  exit 0
 fi
 
 expected_base_sha="$(lookup_ref_sha "${base}")" || {


### PR DESCRIPTION
## Summary
- Add `merge_group` triggers for the protected-branch queue checks: full `Quality Gates (10/10 Rubric)` on queued `staging` merges and `Release Hygiene` on queued `premain`/`main` merges.
- Keep provenance checks for same-repository PRs, legal release-lane source branches, RC/stable release-please title shapes, release-intent promotion drivers, release-cycle state, supply-chain scaffolding, and main RC postconditions.
- Retire only the normal PR-path live-ref equality guard by routing it through `--queue-freshness`; the strict live-ref check remains in `verify-release-lane-provenance.sh` for manual-freeze fallback.
- Update release-lane docs/AGENTS with the THE-2450 guard disposition and merge-queue operator requirements.

## Guard disposition
| Guard / threat | Disposition |
| --- | --- |
| Fork/name-spoofed release-lane PR checks out untrusted code | Retained by trusted-base `verify-release-lane-provenance.sh` before PR-head checkout. |
| Illegal release-lane source branch or generated release-please title shape | Retained in `verify-release-lane-provenance.sh`. |
| Human promotion without release intent / release-please "No user facing commits" | Retained in `verify-promotion-release-driver.sh`. |
| PR-event base/head SHA must equal current live branch refs | Covered by protected-branch merge queue semantics in normal workflow; strict script mode retained for manual-freeze fallback. |
| Release-cycle/supply-chain/main RC postcondition checks | Retained and extended to queued merge refs. |
| Single-manifest RC during queued `premain` -> `main` promotion | Replaced by the existing explicit pending-stable-promotion check, now accepted on queued `main` merge groups. |

## Remaining operator / GitHub setting
This PR cannot mutate live GitHub branch protection or rulesets. Before relying on the v2 lane, an operator still needs to enable **Require merge queue** for protected `staging`, `premain`, and `main`, and require the queue-compatible checks:

- `staging`: `Quality Gates (10/10 Rubric)`
- `premain` / `main`: `Release Hygiene`

A live queue exercise remains a release-readiness/operator follow-up, not an implementation blocker.

## Validation
- `make test-unit` (baseline before implementation) — PASS
- `make rubric` (baseline before implementation) — PASS (36/0/0)
- `bash -n scripts/verify-release-lane-provenance.sh scripts/test-release-hygiene-policy.sh scripts/verify-branch-release-supply-chain.sh` — PASS
- PyYAML parse for touched workflows — PASS
- `bash scripts/test-release-hygiene-policy.sh` — PASS
- `bash scripts/test-release-verifier-policy.sh` — PASS
- `bash scripts/test-release-pr-tool-policy.sh` — PASS
- `bash scripts/verify-branch-release-supply-chain.sh` — PASS
- `bash scripts/verify-branch-version-sync.sh` — SKIP (expected on this project branch)
- `bash scripts/verify-release-cycle-state.sh` — PASS
- `bash scripts/verify-doc-integrity.sh` — PASS
- `bash scripts/verify-planning-docs.sh` — PASS
- `git diff --check` — PASS
- `make rubric` (final) — PASS (36/0/0)

Closes THE-2450