### PR TITLE
fix(release): tolerate Python version path transition

### DIFF
--- a/scripts/fixtures/release-policy/watch-legacy-py-path/fixture.env
+++ b/scripts/fixtures/release-policy/watch-legacy-py-path/fixture.env
@@ -1,0 +1,15 @@
+kind=watch
+strict=false
+main_stable=1.10.1
+main_premain=
+main_ts=1.10.1
+main_py=1.10.1
+main_py_path_mode=legacy
+premain_stable=
+premain_prerelease=1.10.2-rc.1
+staging_stable=1.10.1
+toolchain=go1.26.4
+expected_exit=0
+expected_pass='watch-release-cycle: PASS origin/main py/src/tabletheory_py/version.json (fallback py/src/theorydb_py/version.json) source version is stable (1.10.1)'
+expected_warn='watch-release-cycle: WARN GitHub PR and release asset watchpoints skipped by --skip-github'
+expected_fail=

--- a/scripts/fixtures/release-policy/watch-malformed-py-json/fixture.env
+++ b/scripts/fixtures/release-policy/watch-malformed-py-json/fixture.env
@@ -1,0 +1,15 @@
+kind=watch
+strict=true
+main_stable=1.10.1
+main_premain=
+main_ts=1.10.1
+main_py=1.10.1
+main_py_path_mode=malformed-legacy
+premain_stable=
+premain_prerelease=1.10.2-rc.1
+staging_stable=1.10.1
+toolchain=go1.26.4
+expected_exit=1
+expected_pass='watch-release-cycle: PASS origin/main single manifest is stable (1.10.1)'
+expected_warn='watch-release-cycle: WARN GitHub PR and release asset watchpoints skipped by --skip-github'
+expected_fail='watch-release-cycle: FAIL origin/main:py/src/theorydb_py/version.json contains malformed JSON'

--- a/scripts/fixtures/release-policy/watch-missing-py-path/fixture.env
+++ b/scripts/fixtures/release-policy/watch-missing-py-path/fixture.env
@@ -1,0 +1,15 @@
+kind=watch
+strict=true
+main_stable=1.10.1
+main_premain=
+main_ts=1.10.1
+main_py=1.10.1
+main_py_path_mode=missing
+premain_stable=
+premain_prerelease=1.10.2-rc.1
+staging_stable=1.10.1
+toolchain=go1.26.4
+expected_exit=1
+expected_pass='watch-release-cycle: PASS origin/main single manifest is stable (1.10.1)'
+expected_warn='watch-release-cycle: WARN GitHub PR and release asset watchpoints skipped by --skip-github'
+expected_fail='watch-release-cycle: FAIL origin/main py/src/tabletheory_py/version.json version is missing'

--- a/scripts/lib/release-cycle-core.sh
+++ b/scripts/lib/release-cycle-core.sh
@@ -7,25 +7,44 @@ release_cycle_json_value_at_ref() {
   local path="$2"
   local expr="$3"
 
+  if ! git cat-file -e "${ref}:${path}" 2>/dev/null; then
+    return 0
+  fi
+
   git show "${ref}:${path}" 2>/dev/null | python3 -c '
 import json
 import sys
 
 expr = sys.argv[1]
-data = json.load(sys.stdin)
+ref = sys.argv[2]
+path = sys.argv[3]
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError as exc:
+    print(
+        f"{ref}:{path} contains malformed JSON: {exc.msg} "
+        f"at line {exc.lineno} column {exc.colno}",
+        file=sys.stderr,
+    )
+    raise SystemExit(65)
 if expr == ".":
     print(data.get(".", "") if isinstance(data, dict) else "")
     raise SystemExit(0)
 value = data
 for part in expr.split("."):
-    if not part:
-        continue
     if isinstance(value, dict):
         value = value.get(part, "")
     else:
         value = ""
-print(value if isinstance(value, str) else "")
-' "${expr}"
+if isinstance(value, bool):
+    print("true" if value else "false")
+elif value is None:
+    print("")
+elif isinstance(value, (str, int, float)):
+    print(value)
+else:
+    print(json.dumps(value, separators=(",", ":")))
+' "${expr}" "${ref}" "${path}"
 }
 
 release_cycle_json_string_value() {

--- a/scripts/test-release-verifier-policy.sh
+++ b/scripts/test-release-verifier-policy.sh
@@ -42,10 +42,10 @@ write_version_files() {
   local ts="$4"
   local py="$5"
   local toolchain="${6:-go1.26.4}"
+  local py_path_mode="${7:-canonical}"
 
   mkdir -p \
     "${root}/ts" \
-    "${root}/py/src/tabletheory_py" \
     "${root}/scripts" \
     "${root}/.github/workflows" \
     "${root}/examples/multi-tenant"
@@ -53,7 +53,30 @@ write_version_files() {
   printf '{".":"%s"}\n' "${stable}" >"${root}/.release-please-manifest.json"
   printf '{"version":"%s"}\n' "${ts}" >"${root}/ts/package.json"
   printf '{"version":"%s","packages":{"":{"version":"%s"}}}\n' "${ts}" "${ts}" >"${root}/ts/package-lock.json"
-  printf '{"version":"%s"}\n' "${py}" >"${root}/py/src/tabletheory_py/version.json"
+  case "${py_path_mode}" in
+    canonical)
+      mkdir -p "${root}/py/src/tabletheory_py"
+      printf '{"version":"%s"}\n' "${py}" >"${root}/py/src/tabletheory_py/version.json"
+      ;;
+    legacy)
+      mkdir -p "${root}/py/src/theorydb_py"
+      printf '{"version":"%s"}\n' "${py}" >"${root}/py/src/theorydb_py/version.json"
+      ;;
+    missing)
+      ;;
+    malformed-canonical)
+      mkdir -p "${root}/py/src/tabletheory_py"
+      printf '{"version":' >"${root}/py/src/tabletheory_py/version.json"
+      ;;
+    malformed-legacy)
+      mkdir -p "${root}/py/src/theorydb_py"
+      printf '{"version":' >"${root}/py/src/theorydb_py/version.json"
+      ;;
+    *)
+      echo "release-verifier-policy-test: unknown py_path_mode ${py_path_mode}"
+      exit 1
+      ;;
+  esac
   printf 'module fixture\n\ngo 1.26\ntoolchain %s\n' "${toolchain}" >"${root}/go.mod"
   printf 'module fixture/example\n\ngo 1.26\ntoolchain %s\n' "${toolchain}" >"${root}/examples/multi-tenant/go.mod"
 
@@ -115,9 +138,10 @@ commit_watch_branch() {
   local ts="$5"
   local py="$6"
   local toolchain="$7"
+  local py_path_mode="${8:-canonical}"
 
   git -C "${repo}" rm -r --quiet . >/dev/null 2>&1 || true
-  write_version_files "${repo}" "${stable}" "${premain}" "${ts}" "${py}" "${toolchain}"
+  write_version_files "${repo}" "${stable}" "${premain}" "${ts}" "${py}" "${toolchain}" "${py_path_mode}"
   git -C "${repo}" add .
   git -C "${repo}" commit -q --allow-empty -m "fixture ${branch}"
   git -C "${repo}" update-ref "refs/remotes/origin/${branch}" HEAD
@@ -125,7 +149,7 @@ commit_watch_branch() {
 
 run_watch_fixture() {
   local fixture="$1"
-  unset kind strict main_stable main_premain main_ts main_py premain_stable premain_prerelease staging_stable toolchain expected_exit expected_pass expected_warn expected_fail
+  unset kind strict main_stable main_premain main_ts main_py main_py_path_mode premain_stable premain_prerelease premain_py_path_mode staging_stable staging_py_path_mode toolchain expected_exit expected_pass expected_warn expected_fail
   load_fixture "${fixture}"
 
   local work output status strict_args=()
@@ -135,9 +159,9 @@ run_watch_fixture() {
   git -C "${work}" config user.email fixture@example.com
   git -C "${work}" config user.name "Release Fixture"
 
-  commit_watch_branch "${work}" main "${main_stable}" "${main_premain}" "${main_ts}" "${main_py}" "${toolchain}"
-  commit_watch_branch "${work}" premain "${premain_prerelease}" "" "${main_ts}" "${main_py}" "${toolchain}"
-  commit_watch_branch "${work}" staging "${staging_stable}" "${staging_stable}" "${staging_stable}" "${staging_stable}" "${toolchain}"
+  commit_watch_branch "${work}" main "${main_stable}" "${main_premain}" "${main_ts}" "${main_py}" "${toolchain}" "${main_py_path_mode:-canonical}"
+  commit_watch_branch "${work}" premain "${premain_prerelease}" "" "${main_ts}" "${main_py}" "${toolchain}" "${premain_py_path_mode:-canonical}"
+  commit_watch_branch "${work}" staging "${staging_stable}" "${staging_stable}" "${staging_stable}" "${staging_stable}" "${toolchain}" "${staging_py_path_mode:-canonical}"
 
   if [[ "${strict}" == "true" ]]; then
     strict_args=(--strict)
@@ -156,6 +180,8 @@ run_watch_fixture() {
   expect_contains "${output}" "${expected_pass}" "$(basename "${fixture}")"
   expect_contains "${output}" "${expected_warn}" "$(basename "${fixture}")"
   expect_contains "${output}" "${expected_fail}" "$(basename "${fixture}")"
+  expect_absent "${output}" "Traceback" "$(basename "${fixture}")"
+  expect_absent "${output}" "JSONDecodeError" "$(basename "${fixture}")"
   if [[ -z "${expected_fail}" ]]; then
     expect_absent "${output}" "watch-release-cycle: FAIL" "$(basename "${fixture}")"
   fi

--- a/scripts/watch-release-cycle.sh
+++ b/scripts/watch-release-cycle.sh
@@ -93,6 +93,55 @@ fail() {
   fail_count=$((fail_count + 1))
 }
 
+watch_json_value_at_ref() {
+  local __target="$1"
+  local ref="$2"
+  local path="$3"
+  local expr="$4"
+  local output status
+
+  set +e
+  output="$(release_cycle_json_value_at_ref "${ref}" "${path}" "${expr}" 2>&1)"
+  status=$?
+  set -e
+
+  if [[ "${status}" -ne 0 ]]; then
+    if [[ -z "${output}" ]]; then
+      output="${ref}:${path} could not be parsed as JSON"
+    fi
+    while IFS= read -r line; do
+      if [[ -n "${line}" ]]; then
+        fail "${line}"
+      fi
+    done <<<"${output}"
+    printf -v "${__target}" '%s' ""
+    return 1
+  fi
+
+  printf -v "${__target}" '%s' "${output}"
+  return 0
+}
+
+watch_python_version_at_ref() {
+  local __version_target="$1"
+  local __label_target="$2"
+  local ref="$3"
+  local canonical_path="py/src/tabletheory_py/version.json"
+  local legacy_path="py/src/theorydb_py/version.json"
+  local path="${canonical_path}"
+  local label="${canonical_path}"
+
+  if git cat-file -e "${ref}:${canonical_path}" 2>/dev/null; then
+    path="${canonical_path}"
+  elif git cat-file -e "${ref}:${legacy_path}" 2>/dev/null; then
+    path="${legacy_path}"
+    label="${canonical_path} (fallback ${legacy_path})"
+  fi
+
+  printf -v "${__label_target}" '%s' "${label}"
+  watch_json_value_at_ref "${__version_target}" "${ref}" "${path}" version
+}
+
 refs=(origin/main origin/premain origin/staging)
 for ref in "${refs[@]}"; do
   if ! git rev-parse --verify --quiet "${ref}" >/dev/null; then
@@ -122,11 +171,11 @@ check_source_version() {
 }
 
 if git rev-parse --verify --quiet origin/main >/dev/null; then
-  main_stable="$(release_cycle_json_value_at_ref origin/main .release-please-manifest.json '.')"
-  main_ts="$(release_cycle_json_value_at_ref origin/main ts/package.json version)"
-  main_ts_lock="$(release_cycle_json_value_at_ref origin/main ts/package-lock.json version)"
-  main_ts_lock_pkg="$(git show origin/main:ts/package-lock.json 2>/dev/null | python3 -c 'import json,sys; print(json.load(sys.stdin).get("packages", {}).get("", {}).get("version", ""))')"
-  main_py="$(release_cycle_json_value_at_ref origin/main py/src/tabletheory_py/version.json version)"
+  watch_json_value_at_ref main_stable origin/main .release-please-manifest.json '.' || true
+  watch_json_value_at_ref main_ts origin/main ts/package.json version || true
+  watch_json_value_at_ref main_ts_lock origin/main ts/package-lock.json version || true
+  watch_json_value_at_ref main_ts_lock_pkg origin/main ts/package-lock.json 'packages..version' || true
+  watch_python_version_at_ref main_py main_py_label origin/main || true
 
   if git show origin/main:.release-please-manifest.premain.json >/dev/null 2>&1; then
     fail "origin/main still contains retired .release-please-manifest.premain.json"
@@ -144,7 +193,7 @@ if git rev-parse --verify --quiet origin/main >/dev/null; then
     "ts/package.json:${main_ts}" \
     "ts/package-lock.json:${main_ts_lock}" \
     "ts/package-lock.json packages['']:${main_ts_lock_pkg}" \
-    "py/src/tabletheory_py/version.json:${main_py}"; do
+    "${main_py_label}:${main_py}"; do
     check_source_version "origin/main" "${item%%:*}" "${item#*:}"
   done
 
@@ -164,7 +213,7 @@ if git rev-parse --verify --quiet origin/main >/dev/null; then
 fi
 
 if git rev-parse --verify --quiet origin/premain >/dev/null; then
-  premain_version="$(release_cycle_json_value_at_ref origin/premain .release-please-manifest.json '.')"
+  watch_json_value_at_ref premain_version origin/premain .release-please-manifest.json '.' || true
 
   if git show origin/premain:.release-please-manifest.premain.json >/dev/null 2>&1; then
     fail "origin/premain still contains retired .release-please-manifest.premain.json"
@@ -193,7 +242,7 @@ if git rev-parse --verify --quiet origin/premain >/dev/null; then
 fi
 
 if git rev-parse --verify --quiet origin/staging >/dev/null; then
-  staging_stable="$(release_cycle_json_value_at_ref origin/staging .release-please-manifest.json '.')"
+  watch_json_value_at_ref staging_stable origin/staging .release-please-manifest.json '.' || true
 
   if git show origin/staging:.release-please-manifest.premain.json >/dev/null 2>&1; then
     fail "origin/staging still contains retired .release-please-manifest.premain.json"


### PR DESCRIPTION
## Summary
- make release-cycle JSON reads at git refs tolerant of missing files while still failing closed with readable malformed-JSON findings
- add v2 Python package version path fallback from `py/src/tabletheory_py/version.json` to legacy `py/src/theorydb_py/version.json` for protected-ref watch checks
- extend release-policy watch fixtures for legacy path, missing path, and malformed JSON behavior without Python tracebacks

## Linear
Closes THE-2560

## Contract / release safety
- No DMS or runtime data-contract behavior changes.
- Preserves prerelease source-version, retired-manifest, branch-track, toolchain, GitHub release/tag/asset, and single-manifest watchpoints.
- THE-2522 remains operator/ruleset authorization follow-up; this PR does not mutate GitHub rulesets or branch protection.

## Validation
- `bash scripts/watch-release-cycle.sh --strict --skip-github` — bounded output, no traceback; exits 1 because current live `origin/{main,premain,staging}` still have retired premain manifests / premain behind main:
  - `watch-release-cycle: SUMMARY fail=4 warn=1 strict=1`
- `bash scripts/test-release-verifier-policy.sh` — PASS
- `bash scripts/verify-branch-release-supply-chain.sh` — PASS
- `bash scripts/verify-branch-version-sync.sh` — SKIP (expected on project branch)
- `bash scripts/verify-release-cycle-state.sh` — PASS
- `git diff --check` — PASS
- `make rubric` — PASS (`pass=36 fail=0 blocked=0`)

## Notes
- Initial local `make rubric` attempt failed before `ts/dist/cjs` existed in the ignored local build tree; after `cd ts && npm run build`, final `make rubric` passed on this branch tip.
