### PR TITLE
fix(ci): support premain compatibility checks

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          bash trusted-release/scripts/verify-release-lane-provenance.sh \
+          provenance_args=(
             --repo "${GITHUB_REPOSITORY}" \
             --base "${BASE_REF}" \
             --head "${HEAD_REF}" \
@@ -84,8 +84,16 @@ jobs:
             --head-repo "${HEAD_REPOSITORY}" \
             --base-sha "${BASE_SHA}" \
             --head-sha "${HEAD_SHA}" \
-            --title "${PR_TITLE}" \
-            --queue-freshness
+            --title "${PR_TITLE}"
+          )
+
+          if bash trusted-release/scripts/verify-release-lane-provenance.sh --help | grep -Fq -- "--queue-freshness"; then
+            provenance_args+=(--queue-freshness)
+          else
+            echo "release-lane-provenance: trusted base script lacks --queue-freshness; using strict live-ref freshness"
+          fi
+
+          bash trusted-release/scripts/verify-release-lane-provenance.sh "${provenance_args[@]}"
 
       - name: Checkout pull request head after provenance verification
         if: github.event_name == 'pull_request'

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -347,6 +347,21 @@ grep -Fq -- "--queue-freshness" "${repo_root}/.github/workflows/release-hygiene.
   exit 1
 }
 
+grep -Fq "verify-release-lane-provenance.sh --help" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must feature-detect trusted provenance flags"
+  exit 1
+}
+
+grep -Fq "provenance_args+=(--queue-freshness)" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must append --queue-freshness only after feature detection"
+  exit 1
+}
+
+grep -Fq "trusted base script lacks --queue-freshness" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must document strict-freshness fallback"
+  exit 1
+}
+
 grep -Fq "pending stable promotion accepted on queued main merge group" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene must allow queued main pending stable promotion"
   exit 1

--- a/scripts/verify-coverage.sh
+++ b/scripts/verify-coverage.sh
@@ -195,6 +195,17 @@ validate_suite() {
   fi
 }
 
+node_version_label() {
+  node --version 2>/dev/null || printf 'unknown\n'
+}
+
+node_supports_test_coverage_filters() {
+  local help
+  help="$(node --help 2>/dev/null || true)"
+  grep -Fq -- "--test-coverage-include" <<<"${help}" &&
+    grep -Fq -- "--test-coverage-exclude" <<<"${help}"
+}
+
 measure_typescript_coverage() {
   local selected_suite="$1"
 
@@ -216,16 +227,78 @@ measure_typescript_coverage() {
   export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-dummy}"
   export DYNAMODB_ENDPOINT="${DYNAMODB_ENDPOINT:-http://localhost:8000}"
 
-  local tests=(test/unit/*.test.ts)
+  local root_tests=(ts/test/unit/*.test.ts)
   if [[ "${selected_suite}" == "all" ]]; then
-    tests+=(test/integration/*.test.ts)
+    root_tests+=(ts/test/integration/*.test.ts)
   else
     validate_suite "coverage-ts" "${selected_suite}"
   fi
+  if [[ "${#root_tests[@]}" -eq 0 ]]; then
+    echo "coverage-ts: FAIL (no TypeScript tests matched for suite ${selected_suite})"
+    return 1
+  fi
+
+  local tests=()
+  local test_path
+  for test_path in "${root_tests[@]}"; do
+    if [[ "${test_path}" == *"*"* ]]; then
+      echo "coverage-ts: FAIL (unmatched TypeScript test glob ${test_path})"
+      return 1
+    fi
+    tests+=("${test_path#ts/}")
+  done
 
   local log="${outdir}/coverage-${selected_suite}.txt"
   local summary_json="${outdir}/coverage-${selected_suite}.json"
   local output status
+  local node_version
+  node_version="$(node_version_label)"
+
+  if ! node_supports_test_coverage_filters; then
+    if [[ "${record_only}" != "true" ]]; then
+      echo "coverage-ts: FAIL (Node ${node_version} lacks --test-coverage-include/--test-coverage-exclude; threshold mode requires precise src/**/*.ts filtering)"
+      return 1
+    fi
+
+    local v8_dir="${outdir}/v8-${selected_suite}"
+    rm -rf "${v8_dir}"
+    mkdir -p "${v8_dir}"
+
+    pushd ts >/dev/null
+    set +e
+    output="$(
+      NODE_V8_COVERAGE="coverage/v8-${selected_suite}" \
+        node --import tsx --test "${tests[@]}" 2>&1
+    )"
+    status=$?
+    set -e
+    popd >/dev/null
+
+    {
+      echo "coverage-ts: WARN (Node ${node_version} lacks source include/exclude filters; recorded raw V8 coverage instead of filtered percentages)"
+      printf "%s\n" "${output}"
+    } | tee "${log}"
+
+    if [[ "${status}" -ne 0 ]]; then
+      echo "coverage-ts: FAIL (tests failed; exit ${status})"
+      return "${status}"
+    fi
+
+    cat >"${summary_json}" <<JSON
+{
+  "suite": "${selected_suite}",
+  "node": "${node_version}",
+  "filtering": "unsupported",
+  "raw_v8_coverage": "coverage/v8-${selected_suite}",
+  "lines": null,
+  "branches": null,
+  "functions": null
+}
+JSON
+
+    echo "coverage-ts: PASS (${selected_suite}; Node ${node_version} record-only raw V8 coverage; filtered thresholds require Node 24+)"
+    return 0
+  fi
 
   pushd ts >/dev/null
   set +e
@@ -266,13 +339,15 @@ measure_typescript_coverage() {
   cat >"${summary_json}" <<JSON
 {
   "suite": "${selected_suite}",
+  "node": "${node_version}",
+  "filtering": "src/**/*.ts excluding test/**",
   "lines": ${lines},
   "branches": ${branches},
   "functions": ${functions}
 }
 JSON
 
-  echo "coverage-ts: PASS (${selected_suite}; lines ${lines}%, branches ${branches}%, functions ${functions}%)"
+  echo "coverage-ts: PASS (${selected_suite}; source-filtered lines ${lines}%, branches ${branches}%, functions ${functions}%)"
 }
 
 verify_typescript_coverage() {
@@ -285,7 +360,11 @@ verify_typescript_coverage() {
     return 1
   fi
 
-  measure_typescript_coverage "${selected_suite}" >/dev/null
+  local measure_output
+  if ! measure_output="$(measure_typescript_coverage "${selected_suite}" 2>&1)"; then
+    printf "%s\n" "${measure_output}"
+    return 1
+  fi
 
   local summary="ts/coverage/coverage-${selected_suite}.json"
   if [[ ! -f "${summary}" ]]; then


### PR DESCRIPTION
## Summary
- Feature-detect `--queue-freshness` before passing it to trusted base release-lane provenance scripts, preserving strict live-ref provenance for older base scripts during staging -> premain promotion PRs.
- Keep Node 24+ TypeScript coverage source-filtered with `--test-coverage-include/exclude`, while allowing Node 20 record-only coverage to run tests and save raw V8 coverage when those filters are unsupported.
- Extend release-hygiene policy coverage for the bootstrap guard.

## Validation
- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/verify-release-lane-provenance.sh --repo theory-cloud/TableTheory --base premain --head staging --base-repo theory-cloud/TableTheory --head-repo theory-cloud/TableTheory --base-sha acbb6715db3bc1bf73d37b7ab8d9588d8dfe8e91 --head-sha 5130b5dd35e66b05a3ca4ce2020dd8d659007a26 --title Staging --queue-freshness`
- Old trusted-script simulation: no `--queue-freshness` passed when `--help` lacks the flag
- `bash scripts/verify-coverage.sh --language typescript --suite unit --record-only`
- Node 20 PATH simulation: `bash scripts/verify-coverage.sh --language typescript --suite unit --record-only`
- Node 20 threshold simulation: explicit fail requiring precise source filters
- `npm --prefix ts run typecheck`
- `npm --prefix ts run lint`
- `git diff --check`
- `git log --show-signature --oneline -1`

## Pages
No repo-owned Pages workflow bug found in this scoped repair; recommend rerunning the failed Pages deployment if it remains red.
