### PR TITLE
fix(ci): select v2 verifiers for protected promotions

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -160,13 +160,109 @@ jobs:
             --head "${GITHUB_HEAD_REF}" \
             --pr "${PR_NUMBER}"
 
+      - name: Resolve release verifier source
+        if: github.event_name == 'pull_request'
+        id: verifier-source
+        working-directory: pr
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          trusted_root="../trusted-release"
+          verifier_root="${trusted_root}"
+          verifier_label="trusted-base"
+          protected_promotion=false
+
+          if [[ "${BASE_REPOSITORY}" == "${EXPECTED_REPOSITORY}" && "${HEAD_REPOSITORY}" == "${EXPECTED_REPOSITORY}" ]]; then
+            case "${BASE_REF}:${HEAD_REF}" in
+              premain:staging|main:premain)
+                protected_promotion=true
+                ;;
+            esac
+          fi
+
+          add_v2_marker_reason() {
+            local root="$1"
+            local path="$2"
+            local marker="$3"
+            local description="$4"
+            local -n reasons_ref="$5"
+
+            if [[ ! -f "${root}/${path}" ]]; then
+              reasons_ref+=("missing ${path}")
+              return
+            fi
+            if ! grep -Fq -- "${marker}" "${root}/${path}"; then
+              reasons_ref+=("${path} lacks ${description}")
+            fi
+          }
+
+          collect_v2_marker_reasons() {
+            local root="$1"
+            local reasons_name="$2"
+            local -n reasons_ref="${reasons_name}"
+            reasons_ref=()
+
+            # These markers distinguish the v2 single-manifest release lane from
+            # the retired v1 verifier shape that required a premain manifest,
+            # prepare-stable-promotion helper, and legacy theorydb_py version path.
+            add_v2_marker_reason "${root}" "scripts/verify-release-cycle-state.sh" \
+              "scripts/prepare-release-package-versions.py" "package-version stamping marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-release-cycle-state.sh" \
+              "py/src/tabletheory_py/version.json" "canonical Python version marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
+              "scripts/prepare-release-package-versions.py" "package-version stamping marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
+              "single release-please manifest" "single-manifest policy marker" "${reasons_name}"
+          }
+
+          trusted_reasons=()
+          collect_v2_marker_reasons "${trusted_root}" trusted_reasons
+
+          if [[ "${#trusted_reasons[@]}" -eq 0 ]]; then
+            echo "release-verifier-source: trusted base supports v2 single-manifest verifier markers"
+          else
+            printf 'release-verifier-source: trusted base lacks v2 single-manifest support (%s)\n' "$(IFS='; '; echo "${trusted_reasons[*]}")"
+          fi
+
+          if [[ "${protected_promotion}" == "true" && "${#trusted_reasons[@]}" -ne 0 ]]; then
+            head_reasons=()
+            collect_v2_marker_reasons "." head_reasons
+            if [[ "${#head_reasons[@]}" -ne 0 ]]; then
+              printf 'release-verifier-source: FAIL (protected PR head lacks v2 verifier support: %s)\n' "$(IFS='; '; echo "${head_reasons[*]}")" >&2
+              exit 1
+            fi
+
+            verifier_root="."
+            verifier_label="protected-pr-head-v2"
+            echo "release-verifier-source: protected same-repo promotion may use PR-head v2 verifier scripts after provenance"
+          else
+            echo "release-verifier-source: using trusted base verifier scripts"
+          fi
+
+          {
+            echo "root=${verifier_root}"
+            echo "label=${verifier_label}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "release-verifier-source: selected ${verifier_label} (${verifier_root})"
+
       - name: Verify release cycle state
         if: github.event_name == 'pull_request'
         working-directory: pr
         env:
           RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION: ${{ github.base_ref == 'main' && github.head_ref == 'premain' && 'true' || 'false' }}
           RELEASE_CYCLE_REPO_ROOT: ${{ github.workspace }}/pr
-        run: bash ../trusted-release/scripts/verify-release-cycle-state.sh
+          VERIFIER_ROOT: ${{ steps.verifier-source.outputs.root }}
+          VERIFIER_LABEL: ${{ steps.verifier-source.outputs.label }}
+        run: |
+          set -euo pipefail
+          echo "release-cycle-state: using ${VERIFIER_LABEL} verifier source (${VERIFIER_ROOT})"
+          bash "${VERIFIER_ROOT}/scripts/verify-release-cycle-state.sh"
 
       - name: Verify release cycle state
         if: github.event_name != 'pull_request'
@@ -203,7 +299,13 @@ jobs:
       - name: Verify release supply-chain scaffolding
         if: github.event_name == 'pull_request'
         working-directory: pr
-        run: bash ../trusted-release/scripts/verify-branch-release-supply-chain.sh
+        env:
+          VERIFIER_ROOT: ${{ steps.verifier-source.outputs.root }}
+          VERIFIER_LABEL: ${{ steps.verifier-source.outputs.label }}
+        run: |
+          set -euo pipefail
+          echo "branch-release: using ${VERIFIER_LABEL} verifier source (${VERIFIER_ROOT})"
+          bash "${VERIFIER_ROOT}/scripts/verify-branch-release-supply-chain.sh"
 
       - name: Verify release supply-chain scaffolding
         if: github.event_name != 'pull_request'

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -51,6 +51,170 @@ expect_failure_contains() {
   fi
 }
 
+extract_workflow_step_run() {
+  local step_name="$1"
+
+  python3 - "${repo_root}/.github/workflows/release-hygiene.yml" "${step_name}" <<'PY'
+import re
+import sys
+
+workflow_path, step_name = sys.argv[1], sys.argv[2]
+lines = open(workflow_path, "r", encoding="utf-8").read().splitlines()
+
+for idx, line in enumerate(lines):
+    if not re.match(r"\s*-\s+name:\s*" + re.escape(step_name) + r"\s*$", line):
+        continue
+
+    search_idx = idx + 1
+    while search_idx < len(lines) and not re.match(r"\s*-\s+name:\s*", lines[search_idx]):
+        run_match = re.match(r"(\s*)run:\s*\|\s*$", lines[search_idx])
+        if not run_match:
+            search_idx += 1
+            continue
+
+        run_indent = len(run_match.group(1))
+        strip_indent = run_indent + 2
+        block = []
+        block_idx = search_idx + 1
+        while block_idx < len(lines):
+            block_line = lines[block_idx]
+            if block_line.strip() == "":
+                block.append("")
+                block_idx += 1
+                continue
+            current_indent = len(block_line) - len(block_line.lstrip(" "))
+            if current_indent <= run_indent:
+                break
+            if block_line.startswith(" " * strip_indent):
+                block.append(block_line[strip_indent:])
+            else:
+                block.append(block_line.lstrip(" "))
+            block_idx += 1
+
+        print("\n".join(block))
+        raise SystemExit(0)
+
+        search_idx += 1
+
+print(f"release-hygiene-policy-test: missing run block for workflow step {step_name}", file=sys.stderr)
+raise SystemExit(1)
+PY
+}
+
+write_v1_verifier_fixture() {
+  local root="$1"
+
+  mkdir -p "${root}/scripts"
+  cat >"${root}/scripts/verify-release-cycle-state.sh" <<'SH'
+#!/usr/bin/env bash
+required_files=(
+  "scripts/prepare-stable-promotion"".sh"
+  ".release-please-manifest.premain.json"
+  "py/src/theorydb_py/version.json"
+)
+SH
+  cat >"${root}/scripts/verify-branch-release-supply-chain.sh" <<'SH'
+#!/usr/bin/env bash
+require_fixed '.release-please-manifest.premain.json' "${p}" \
+  "prerelease workflow must reference .release-please-manifest.premain.json"
+require_regex '"path"\s*:\s*"py/src/theorydb_py/version\.json"' "${cfg}" \
+  "${cfg}: must bump py/src/theorydb_py/version.json version"
+SH
+}
+
+write_v2_verifier_fixture() {
+  local root="$1"
+
+  mkdir -p "${root}/scripts"
+  cat >"${root}/scripts/verify-release-cycle-state.sh" <<'SH'
+#!/usr/bin/env bash
+required_files=(
+  "scripts/prepare-release-package-versions.py"
+  "py/src/tabletheory_py/version.json"
+)
+SH
+  cat >"${root}/scripts/verify-branch-release-supply-chain.sh" <<'SH'
+#!/usr/bin/env bash
+required_files=(
+  "scripts/prepare-release-package-versions.py"
+)
+require_fixed "manifest-file:\s*\.release-please-manifest\.json" "${p}" \
+  "prerelease workflow must reference the single release-please manifest"
+SH
+}
+
+run_verifier_source_selector_fixture() {
+  local trusted_shape="$1"
+  local head_shape="$2"
+  local base_ref="$3"
+  local head_ref="$4"
+  local base_repo="$5"
+  local head_repo="$6"
+
+  local fixture
+  fixture="$(mktemp -d)"
+  tmpdirs+=("${fixture}")
+
+  mkdir -p "${fixture}/trusted-release" "${fixture}/pr"
+  case "${trusted_shape}" in
+    v1) write_v1_verifier_fixture "${fixture}/trusted-release" ;;
+    v2) write_v2_verifier_fixture "${fixture}/trusted-release" ;;
+    *) echo "release-hygiene-policy-test: unknown trusted fixture ${trusted_shape}" >&2; exit 1 ;;
+  esac
+  case "${head_shape}" in
+    v1) write_v1_verifier_fixture "${fixture}/pr" ;;
+    v2) write_v2_verifier_fixture "${fixture}/pr" ;;
+    *) echo "release-hygiene-policy-test: unknown head fixture ${head_shape}" >&2; exit 1 ;;
+  esac
+
+  local selector_script="${fixture}/selector.sh"
+  extract_workflow_step_run "Resolve release verifier source" >"${selector_script}"
+
+  local output_file="${fixture}/selector.out"
+  local github_output="${fixture}/github-output"
+  (
+    cd "${fixture}/pr"
+    env \
+      BASE_REF="${base_ref}" \
+      HEAD_REF="${head_ref}" \
+      BASE_REPOSITORY="${base_repo}" \
+      HEAD_REPOSITORY="${head_repo}" \
+      EXPECTED_REPOSITORY="${repo}" \
+      GITHUB_OUTPUT="${github_output}" \
+      bash "${selector_script}"
+  ) >"${output_file}" 2>&1
+
+  printf '%s\n' "${output_file}:${github_output}"
+}
+
+assert_selector_result() {
+  local output_pair="$1"
+  local expected_root="$2"
+  local expected_label="$3"
+  local expected_output="$4"
+
+  local output_file="${output_pair%%:*}"
+  local github_output="${output_pair#*:}"
+
+  if ! grep -Fxq "root=${expected_root}" "${github_output}"; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: selector root mismatch; expected ${expected_root}"
+    exit 1
+  fi
+  if ! grep -Fxq "label=${expected_label}" "${github_output}"; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: selector label mismatch; expected ${expected_label}"
+    exit 1
+  fi
+  if ! grep -Fq "${expected_output}" "${output_file}"; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: selector output missing: ${expected_output}"
+    exit 1
+  fi
+}
+
 common_args=(
   --repo "${repo}"
   --base premain
@@ -361,6 +525,94 @@ grep -Fq "trusted base script lacks --queue-freshness" "${repo_root}/.github/wor
   echo "release-hygiene-policy-test: release hygiene must document strict-freshness fallback"
   exit 1
 }
+
+grep -Fq "Resolve release verifier source" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must resolve verifier source for PR checks"
+  exit 1
+}
+
+grep -Fq "premain:staging|main:premain" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier fallback must be limited to protected promotion branch pairs"
+  exit 1
+}
+
+grep -Fq "trusted base lacks v2 single-manifest support" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must document old trusted-script fallback reasons"
+  exit 1
+}
+
+grep -Fq "protected-pr-head-v2" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must label protected PR-head v2 fallback"
+  exit 1
+}
+
+grep -Fq "scripts/prepare-release-package-versions.py" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect the v2 package-version marker"
+  exit 1
+}
+
+grep -Fq "single release-please manifest" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect the v2 single-manifest marker"
+  exit 1
+}
+
+grep -Fq 'bash "${VERIFIER_ROOT}/scripts/verify-release-cycle-state.sh"' "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release-cycle state must use the resolved verifier source"
+  exit 1
+}
+
+grep -Fq 'bash "${VERIFIER_ROOT}/scripts/verify-branch-release-supply-chain.sh"' "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: branch release supply-chain must use the resolved verifier source"
+  exit 1
+}
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v1 v2 \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "." \
+  "protected-pr-head-v2" \
+  "protected same-repo promotion may use PR-head v2 verifier scripts after provenance"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v1 v2 \
+    premain "feature/arbitrary-head" \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "using trusted base verifier scripts"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v1 v2 \
+    premain staging \
+    "${repo}" "attacker/TableTheory"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "using trusted base verifier scripts"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2 v2 \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "trusted base supports v2 single-manifest verifier markers"
 
 grep -Fq "pending stable promotion accepted on queued main merge group" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene must allow queued main pending stable promotion"


### PR DESCRIPTION
## Summary
- Adds a release-hygiene verifier-source selector for pull_request checks.
- Keeps trusted base verifier scripts as the default for ordinary PRs.
- Allows protected same-repository `staging -> premain` / `premain -> main` promotions to use PR-head v2 verifier scripts only when trusted base scripts lack v2 single-manifest markers.
- Covers both release-cycle-state and branch-release supply-chain verifier calls.
- Extends release-hygiene policy tests with exact workflow selector simulations for protected and non-protected heads.

## Validation
- `make test-unit` (baseline before branch)
- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/verify-release-cycle-state.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- protected `premain:staging` old-base verifier selector simulation: selected `protected-pr-head-v2`, then release-cycle-state and branch-release supply-chain passed
- arbitrary-head old-base verifier selector simulation: selected `trusted-base`
- `git diff --check`
- `make rubric` (PASS pass=36 fail=0 blocked=0)
- `git log --show-signature -1`

## Risk / compatibility
- Does not weaken provenance, promotion driver, branch, or SHA validation.
- Does not use PR-head verifier scripts for arbitrary feature heads, fork heads, or release-please generated heads.
