### PR TITLE
Promote staging to premain for RC branch-sync fix

### DIFF
--- a/scripts/test-release-verifier-policy.sh
+++ b/scripts/test-release-verifier-policy.sh
@@ -187,6 +187,51 @@ run_watch_fixture() {
   fi
 }
 
+run_branch_version_sync_fixture() {
+  local work remote output status
+  work="$(mktemp -d)"
+  remote="$(mktemp -d)"
+  tmpdirs+=("${work}" "${remote}")
+
+  git -C "${remote}" init --bare -q
+  git -C "${work}" init -q
+  git -C "${work}" config user.email fixture@example.com
+  git -C "${work}" config user.name "Release Fixture"
+
+  write_version_files "${work}" "1.10.1" "" "1.10.0" "1.10.0"
+  git -C "${work}" add .
+  git -C "${work}" commit -q -m "fixture main"
+  git -C "${work}" branch -M main
+  git -C "${work}" remote add origin "${remote}"
+  git -C "${remote}" fetch -q "${work}" HEAD:refs/heads/main
+
+  write_version_files "${work}" "1.10.1-rc.1" "" "1.10.0" "1.10.0"
+  git -C "${work}" add .
+  git -C "${work}" commit -q -m "fixture premain"
+
+  set +e
+  output="$(
+    GIT_FETCH_RETRIES=1 \
+    GITHUB_REF_NAME=premain \
+      bash "${repo_root}/scripts/verify-branch-version-sync.sh" --repo-root "${work}" 2>&1
+  )"
+  status=$?
+  set -e
+
+  if [[ "${status}" -ne 0 ]]; then
+    printf '%s\n' "${output}"
+    echo "release-verifier-policy-test: branch-version-sync fixture: expected success, got ${status}"
+    exit 1
+  fi
+  expect_contains \
+    "${output}" \
+    "branch-version-sync: PASS (main=1.10.1, candidate=1.10.1-rc.1, mode=premain)" \
+    "branch-version-sync fixture"
+  expect_absent "${output}" "JSONDecodeError" "branch-version-sync fixture"
+}
+
+run_branch_version_sync_fixture
+
 for fixture in "${fixtures_dir}"/cycle-*; do
   run_cycle_fixture "${fixture}"
 done

--- a/scripts/verify-branch-version-sync.sh
+++ b/scripts/verify-branch-version-sync.sh
@@ -81,12 +81,17 @@ git_ref_json_value() {
   local ref="$1"
   local path="$2"
   local expr="$3"
-  git show "${ref}:${path}" | python3 - "${expr}" <<'PY'
+  git show "${ref}:${path}" | python3 -c '
 import json
 import sys
 
-expr = sys.argv[1]
-data = json.load(sys.stdin)
+ref, path, expr = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError as exc:
+    print(f"branch-version-sync: FAIL ({ref}:{path} is not valid JSON: {exc})", file=sys.stderr)
+    raise SystemExit(1)
+
 if expr == ".":
     print(data.get(".", "") if isinstance(data, dict) else "")
     raise SystemExit(0)
@@ -99,7 +104,7 @@ for part in expr.split("."):
     else:
         value = ""
 print(value if isinstance(value, str) else "")
-PY
+' "${ref}" "${path}" "${expr}"
 }
 
 git_fetch_retry() {


### PR DESCRIPTION
## Summary\n- carry PR #351's branch-version-sync JSON stdin fix from staging to premain\n- restores the premain release-candidate workflows that failed after PR #338 with JSONDecodeError in scripts/verify-branch-version-sync.sh\n\n## Evidence\n- PR #351 merged to staging at c7da8e7e37a04af6003735d04882ce8c79bb3818\n- local: GITHUB_REF_NAME=premain bash scripts/verify-branch-version-sync.sh PASS\n- local: bash scripts/verify-release-cycle-state.sh PASS\n- local: git diff --check PASS\n- adversarial review for PR #351 ACCEPT: /home/aron/.claude/tmp/delegate-claude-session/20260705T220946Z-TableTheory-528285/final.md\n\n## Release note\nThis is a release-lane repair promotion only; it is not v2.0.0 release proof. After merge, the premain prerelease workflows must rerun successfully before continuing the release path.