### PR TITLE
fix(ci): accept unnumbered release-please RC PRs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     # Staging PRs run Python through Quality Gates to avoid duplicate suites.
     branches: ["premain", "main"]
+    paths-ignore:
+      - ".release-please-manifest.json"
+      - "CHANGELOG.md"
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     # Staging PRs run TypeScript through Quality Gates to avoid duplicate suites.
     branches: ["premain", "main"]
+    paths-ignore:
+      - ".release-please-manifest.json"
+      - "CHANGELOG.md"
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/unit-cover.yml
+++ b/.github/workflows/unit-cover.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     # Staging PRs run Go unit coverage through Quality Gates to avoid duplicate suites.
     branches: [ "premain", "main" ]
+    paths-ignore:
+      - ".release-please-manifest.json"
+      - "CHANGELOG.md"
 
 permissions:
   contents: read

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -51,6 +51,70 @@ expect_failure_contains() {
   fi
 }
 
+write_prerelease_postcondition_fixture() {
+  local root="$1"
+  local version="$2"
+  local title="${3:-chore(premain): release ${version}}"
+  local include_manifest="${4:-true}"
+  local include_changelog="${5:-true}"
+  local manifest_version="${6:-${version}}"
+
+  mkdir -p "${root}"
+  cat >"${root}/open-prs.json" <<JSON
+[
+  {
+    "number": 353,
+    "title": "${title}",
+    "headRefName": "release-please--branches--premain",
+    "url": "https://github.example.test/theory-cloud/TableTheory/pull/353"
+  }
+]
+JSON
+
+  python3 - "${root}/details.json" "${title}" "${include_manifest}" "${include_changelog}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, title, include_manifest, include_changelog = sys.argv[1:5]
+files = []
+if include_manifest == "true":
+    files.append({"path": ".release-please-manifest.json"})
+if include_changelog == "true":
+    files.append({"path": "CHANGELOG.md"})
+Path(path).write_text(
+    json.dumps(
+        {
+            "number": 353,
+            "title": title,
+            "headRefName": "release-please--branches--premain",
+            "baseRefName": "premain",
+            "headRefOid": "2222222222222222222222222222222222222222",
+            "url": "https://github.example.test/theory-cloud/TableTheory/pull/353",
+            "files": files,
+        }
+    ),
+    encoding="utf-8",
+)
+PY
+
+  printf '{".":"%s"}\n' "${manifest_version}" >"${root}/manifest.json"
+}
+
+run_prerelease_postcondition_fixture() {
+  local fixture="$1"
+  shift
+
+  bash "${repo_root}/scripts/verify-prerelease-pr-postcondition.sh" \
+    --repo "${repo}" \
+    --base premain \
+    --open-prs-file "${fixture}/open-prs.json" \
+    --details-file "${fixture}/details.json" \
+    --manifest-file "${fixture}/manifest.json" \
+    --dry-run \
+    "$@"
+}
+
 extract_workflow_step_run() {
   local step_name="$1"
 
@@ -302,8 +366,8 @@ expect_failure_contains \
     --title "Promote staging to premain" \
     --queue-freshness
 
-expect_failure_contains \
-  "numbered RC version" \
+expect_success_contains \
+  "release-lane-provenance: PASS" \
   bash "${checker}" \
     --repo "${repo}" \
     --base premain \
@@ -313,6 +377,20 @@ expect_failure_contains \
     --base-sha "${base_sha}" \
     --head-sha "${head_sha}" \
     --title "chore(premain): release 1.9.3-rc" \
+    --ref "refs/heads/premain=${base_sha}" \
+    --ref "refs/heads/release-please--branches--premain=${head_sha}"
+
+expect_failure_contains \
+  "must advertise an RC version" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head release-please--branches--premain \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "chore(premain): release 1.9.3-beta.1" \
     --ref "refs/heads/premain=${base_sha}" \
     --ref "refs/heads/release-please--branches--premain=${head_sha}"
 
@@ -348,8 +426,8 @@ expect_failure_contains \
     --ref "refs/heads/premain=${advanced_base_sha}" \
     --ref "refs/heads/release-please--branches--premain=${head_sha}"
 
-expect_failure_contains \
-  "X.Y.Z-rc.N" \
+expect_success_contains \
+  "RC Release-As 1.9.3-rc" \
   bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
     --base premain \
     --head staging \
@@ -364,6 +442,31 @@ expect_success_contains \
     --head staging \
     --title "Promote staging to premain" \
     --body "Release-As: 1.9.3-rc.1" \
+    --dry-run
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+    --base premain \
+    --head staging \
+    --title "Promote staging to premain" \
+    --body "Release-As: 1.9.3" \
+    --dry-run
+
+expect_success_contains \
+  "generated premain RC PR" \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+    --base premain \
+    --head release-please--branches--premain \
+    --title "chore(premain): release 1.9.3-rc" \
+    --dry-run
+
+expect_failure_contains \
+  "must be RC-shaped" \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+    --base premain \
+    --head release-please--branches--premain \
+    --title "chore(premain): release 1.9.3-beta.1" \
     --dry-run
 
 pending_fixture="$(mktemp -d)"
@@ -462,11 +565,68 @@ expect_failure_contains \
       --body "" \
       --dry-run
 
+prerelease_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_fixture}")
+write_prerelease_postcondition_fixture "${prerelease_fixture}" "2.0.0-rc"
+expect_success_contains \
+  "manifest 2.0.0-rc" \
+  run_prerelease_postcondition_fixture "${prerelease_fixture}" \
+    --expected-version 2.0.0-rc
+
+prerelease_numbered_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_numbered_fixture}")
+write_prerelease_postcondition_fixture "${prerelease_numbered_fixture}" "2.0.0-rc.1"
+expect_success_contains \
+  "manifest 2.0.0-rc.1" \
+  run_prerelease_postcondition_fixture "${prerelease_numbered_fixture}" \
+    --expected-version 2.0.0-rc.1
+
+prerelease_bad_title_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_bad_title_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_bad_title_fixture}" \
+  "2.0.0-beta.1" \
+  "chore(premain): release 2.0.0-beta.1"
 expect_failure_contains \
-  "numbered RC-shaped X.Y.Z-rc.N" \
-  bash "${repo_root}/scripts/verify-prerelease-pr-postcondition.sh" \
-    --expected-version 1.9.3-rc \
-    --dry-run
+  "not RC-shaped" \
+  run_prerelease_postcondition_fixture "${prerelease_bad_title_fixture}"
+
+prerelease_missing_manifest_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_missing_manifest_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_missing_manifest_fixture}" \
+  "2.0.0-rc" \
+  "chore(premain): release 2.0.0-rc" \
+  false \
+  true
+expect_failure_contains \
+  "missing single-manifest prerelease files" \
+  run_prerelease_postcondition_fixture "${prerelease_missing_manifest_fixture}"
+
+prerelease_missing_changelog_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_missing_changelog_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_missing_changelog_fixture}" \
+  "2.0.0-rc" \
+  "chore(premain): release 2.0.0-rc" \
+  true \
+  false
+expect_failure_contains \
+  "missing single-manifest prerelease files" \
+  run_prerelease_postcondition_fixture "${prerelease_missing_changelog_fixture}"
+
+prerelease_non_rc_manifest_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_non_rc_manifest_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_non_rc_manifest_fixture}" \
+  "2.0.0-rc" \
+  "chore(premain): release 2.0.0-rc" \
+  true \
+  true \
+  "2.0.0-beta.1"
+expect_failure_contains \
+  "manifest version is not RC-shaped" \
+  run_prerelease_postcondition_fixture "${prerelease_non_rc_manifest_fixture}"
 
 expect_failure_contains \
   "non-numbered-RC tag_name" \
@@ -505,6 +665,28 @@ grep -Fq "merge_group:" "${repo_root}/.github/workflows/release-hygiene.yml" || 
   echo "release-hygiene-policy-test: release hygiene must support merge_group for release queue"
   exit 1
 }
+
+for workflow in \
+  "${repo_root}/.github/workflows/typescript.yml" \
+  "${repo_root}/.github/workflows/python.yml" \
+  "${repo_root}/.github/workflows/unit-cover.yml"; do
+  grep -Fq "paths-ignore:" "${workflow}" || {
+    echo "release-hygiene-policy-test: ${workflow} must use trigger-level paths-ignore for release-please PRs"
+    exit 1
+  }
+  grep -Fq '".release-please-manifest.json"' "${workflow}" || {
+    echo "release-hygiene-policy-test: ${workflow} must ignore manifest-only release-please PR changes"
+    exit 1
+  }
+  grep -Fq '"CHANGELOG.md"' "${workflow}" || {
+    echo "release-hygiene-policy-test: ${workflow} must ignore changelog-only release-please PR changes"
+    exit 1
+  }
+  if grep -Eq '^[[:space:]]*paths:' "${workflow}"; then
+    echo "release-hygiene-policy-test: ${workflow} must not replace normal PR validation with a paths allowlist"
+    exit 1
+  fi
+done
 
 grep -Fq -- "--queue-freshness" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene PR provenance must delegate live ref freshness to merge queue"

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -185,6 +185,23 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
   fi
 fi
 
+for workflow in \
+  ".github/workflows/typescript.yml" \
+  ".github/workflows/python.yml" \
+  ".github/workflows/unit-cover.yml"; do
+  if [[ -f "${workflow}" ]]; then
+    require_fixed "paths-ignore:" "${workflow}" \
+      "${workflow} pull_request trigger must suppress manifest/changelog-only release-please PR fan-out"
+    require_fixed '".release-please-manifest.json"' "${workflow}" \
+      "${workflow} must ignore release-please manifest-only PR changes"
+    require_fixed '"CHANGELOG.md"' "${workflow}" \
+      "${workflow} must ignore release-please changelog-only PR changes"
+    if grep -Eq '^[[:space:]]*paths:' "${workflow}"; then
+      fail "${workflow} must not replace normal PR validation with a paths allowlist"
+    fi
+  fi
+done
+
 for doc in \
   "AGENTS.md" \
   "docs/development/planning/theorydb-branch-release-policy.md" \
@@ -434,8 +451,8 @@ if [[ -f "scripts/verify-promotion-release-driver.sh" ]]; then
     "promotion release driver guard must name release-please no-op as a failed precondition"
   require_fixed "do not use tags, resets, manual manifests" "${driver}" \
     "promotion release driver guard must instruct normal PR-flow remediation"
-  require_fixed "X.Y.Z-rc.N" "${driver}" \
-    "promotion release driver guard must require numbered RC syntax"
+  require_fixed "X.Y.Z-rc or X.Y.Z-rc.N" "${driver}" \
+    "promotion release driver guard must accept release-please first RC and numbered later RC syntax"
 fi
 
 if [[ -f "scripts/verify-release-lane-provenance.sh" ]]; then
@@ -446,8 +463,8 @@ if [[ -f "scripts/verify-release-lane-provenance.sh" ]]; then
     "release-lane provenance guard must retain exact branch SHA verification for manual fallback"
   require_fixed "live ref freshness covered by merge queue" "${provenance}" \
     "release-lane provenance guard must document queue-covered live ref freshness"
-  require_fixed "-rc\\.[0-9]+" "${provenance}" \
-    "release-lane provenance guard must require numbered RC release-please PR titles"
+  require_fixed "-rc(\\.[0-9]+)?" "${provenance}" \
+    "release-lane provenance guard must accept release-please first RC and numbered later RC PR titles"
 fi
 
 if [[ -f "scripts/verify-prerelease-pr-postcondition.sh" ]]; then
@@ -456,8 +473,8 @@ if [[ -f "scripts/verify-prerelease-pr-postcondition.sh" ]]; then
     "prerelease PR postcondition must require the generated premain head branch"
   require_fixed "rc_title_re = re.compile" "${prerelease_postcondition}" \
     "prerelease PR postcondition must require RC-shaped release titles"
-  require_fixed "-rc\\.\\d+" "${prerelease_postcondition}" \
-    "prerelease PR postcondition must require numbered RC version syntax"
+  require_fixed "-rc(?:\\.\\d+)?" "${prerelease_postcondition}" \
+    "prerelease PR postcondition must accept release-please first RC and numbered later RC version syntax"
   require_fixed ".release-please-manifest.json" "${prerelease_postcondition}" \
     "prerelease PR postcondition must require the single manifest"
 fi

--- a/scripts/verify-prerelease-pr-postcondition.sh
+++ b/scripts/verify-prerelease-pr-postcondition.sh
@@ -12,7 +12,10 @@ Options:
   --repo OWNER/REPO         GitHub repository. Defaults to $GITHUB_REPOSITORY or theory-cloud/TableTheory.
   --base BRANCH            Release PR base branch. Defaults to premain.
   --head BRANCH            Release-please PR head branch. Defaults to release-please--branches--premain.
-  --expected-version VER   Optional numbered RC version the PR must advertise, e.g. 1.9.4-rc.1.
+  --expected-version VER   Optional RC version the PR must advertise, e.g. 2.0.0-rc or 2.0.0-rc.1.
+  --open-prs-file PATH     Test-only gh pr list JSON fixture.
+  --details-file PATH      Test-only gh pr view JSON fixture for the selected PR.
+  --manifest-file PATH     Test-only .release-please-manifest.json fixture for the selected PR head.
   --dry-run                Read-only local validation mode; no GitHub state is changed.
   -h, --help               Show this help.
 
@@ -26,6 +29,9 @@ base="premain"
 head="release-please--branches--premain"
 expected_version="${PRERELEASE_PR_EXPECTED_VERSION:-}"
 dry_run=0
+open_prs_fixture=""
+details_fixture=""
+manifest_fixture=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -61,6 +67,30 @@ while [[ $# -gt 0 ]]; do
       expected_version="$2"
       shift 2
       ;;
+    --open-prs-file)
+      if [[ $# -lt 2 ]]; then
+        echo "prerelease-pr-postcondition: FAIL (--open-prs-file requires a value)" >&2
+        exit 2
+      fi
+      open_prs_fixture="$2"
+      shift 2
+      ;;
+    --details-file)
+      if [[ $# -lt 2 ]]; then
+        echo "prerelease-pr-postcondition: FAIL (--details-file requires a value)" >&2
+        exit 2
+      fi
+      details_fixture="$2"
+      shift 2
+      ;;
+    --manifest-file)
+      if [[ $# -lt 2 ]]; then
+        echo "prerelease-pr-postcondition: FAIL (--manifest-file requires a value)" >&2
+        exit 2
+      fi
+      manifest_fixture="$2"
+      shift 2
+      ;;
     --dry-run)
       dry_run=1
       shift
@@ -82,16 +112,30 @@ fail() {
   exit 1
 }
 
-if [[ -n "${expected_version}" && ! "${expected_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
-  fail "expected version must be numbered RC-shaped X.Y.Z-rc.N, got ${expected_version}"
+if [[ -n "${expected_version}" && ! "${expected_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]; then
+  fail "expected version must be RC-shaped X.Y.Z-rc or X.Y.Z-rc.N, got ${expected_version}"
 fi
 
-if ! command -v gh >/dev/null 2>&1; then
-  fail "gh is required"
+fixture_count=0
+[[ -z "${open_prs_fixture}" ]] || fixture_count=$((fixture_count + 1))
+[[ -z "${details_fixture}" ]] || fixture_count=$((fixture_count + 1))
+[[ -z "${manifest_fixture}" ]] || fixture_count=$((fixture_count + 1))
+if [[ "${fixture_count}" -ne 0 && "${fixture_count}" -ne 3 ]]; then
+  fail "--open-prs-file, --details-file, and --manifest-file must be supplied together"
 fi
 
-if ! gh auth status >/dev/null 2>&1; then
-  fail "gh is not authenticated"
+if [[ "${fixture_count}" -eq 3 ]]; then
+  for fixture in "${open_prs_fixture}" "${details_fixture}" "${manifest_fixture}"; do
+    [[ -f "${fixture}" ]] || fail "fixture file not found: ${fixture}"
+  done
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    fail "gh is required"
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    fail "gh is not authenticated"
+  fi
 fi
 
 if [[ "${dry_run}" -eq 1 ]]; then
@@ -101,16 +145,21 @@ fi
 open_prs="$(mktemp)"
 candidate_number_file="$(mktemp)"
 details="$(mktemp)"
+manifest="$(mktemp)"
 cleanup() {
-  rm -f "${open_prs}" "${candidate_number_file}" "${details}"
+  rm -f "${open_prs}" "${candidate_number_file}" "${details}" "${manifest}"
 }
 trap cleanup EXIT
 
-gh pr list \
-  --repo "${repo}" \
-  --base "${base}" \
-  --state open \
-  --json number,title,headRefName,url >"${open_prs}"
+if [[ "${fixture_count}" -eq 3 ]]; then
+  cp "${open_prs_fixture}" "${open_prs}"
+else
+  gh pr list \
+    --repo "${repo}" \
+    --base "${base}" \
+    --state open \
+    --json number,title,headRefName,url >"${open_prs}"
+fi
 
 python3 - "${open_prs}" "${expected_version}" "${base}" "${head}" >"${candidate_number_file}" <<'PY'
 import json
@@ -120,7 +169,7 @@ from pathlib import Path
 
 path, expected_version, base, head = sys.argv[1:5]
 prs = json.loads(Path(path).read_text(encoding="utf-8"))
-rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc\.\d+$")
+rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
 
 
 def fail(message: str) -> None:
@@ -140,7 +189,7 @@ if bad:
     details = ", ".join(
         f"#{pr.get('number')} {pr.get('title')} {pr.get('url')}" for pr in bad
     )
-    fail(f"generated premain release-please PR is not numbered RC-shaped: {details}")
+    fail(f"generated premain release-please PR is not RC-shaped: {details}")
 
 if expected_version:
     expected = expected_version[1:] if expected_version.startswith("v") else expected_version
@@ -169,19 +218,42 @@ PY
 
 candidate_number="$(cat "${candidate_number_file}")"
 
-gh pr view "${candidate_number}" \
-  --repo "${repo}" \
-  --json number,title,headRefName,baseRefName,url,files >"${details}"
+if [[ "${fixture_count}" -eq 3 ]]; then
+  cp "${details_fixture}" "${details}"
+  cp "${manifest_fixture}" "${manifest}"
+else
+  gh pr view "${candidate_number}" \
+    --repo "${repo}" \
+    --json number,title,headRefName,baseRefName,headRefOid,url,files >"${details}"
 
-python3 - "${details}" "${base}" "${head}" <<'PY'
+  manifest_ref="$(
+    python3 - "${details}" "${head}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, head = sys.argv[1:3]
+pr = json.loads(Path(path).read_text(encoding="utf-8"))
+print(pr.get("headRefOid") or pr.get("headRefName") or head)
+PY
+  )"
+
+  gh api -X GET "repos/${repo}/contents/.release-please-manifest.json" \
+    -f "ref=${manifest_ref}" \
+    --jq '.content' | base64 --decode >"${manifest}"
+fi
+
+python3 - "${details}" "${manifest}" "${base}" "${head}" <<'PY'
 import json
 import re
 import sys
 from pathlib import Path
 
-path, base, head = sys.argv[1:4]
-pr = json.loads(Path(path).read_text(encoding="utf-8"))
-rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc\.\d+$")
+details_path, manifest_path, base, head = sys.argv[1:5]
+pr = json.loads(Path(details_path).read_text(encoding="utf-8"))
+manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+rc_version_re = re.compile(r"^\d+\.\d+\.\d+-rc(?:\.\d+)?$")
+rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release (\d+\.\d+\.\d+-rc(?:\.\d+)?)$")
 required_paths = {
     ".release-please-manifest.json",
     "CHANGELOG.md",
@@ -199,8 +271,22 @@ if pr.get("baseRefName") != base:
 if pr.get("headRefName") != head:
     fail(f"PR #{pr.get('number')} head {pr.get('headRefName')!r} != {head!r}")
 
-if not rc_title_re.fullmatch(pr.get("title", "")):
-    fail(f"PR #{pr.get('number')} title is not numbered RC-shaped: {pr.get('title')!r}")
+title_match = rc_title_re.fullmatch(pr.get("title", ""))
+if not title_match:
+    fail(f"PR #{pr.get('number')} title is not RC-shaped: {pr.get('title')!r}")
+
+title_version = title_match.group(1)
+manifest_version = manifest.get(".") if isinstance(manifest, dict) else None
+if not isinstance(manifest_version, str) or not rc_version_re.fullmatch(manifest_version):
+    fail(
+        f"PR #{pr.get('number')} manifest version is not RC-shaped "
+        f"X.Y.Z-rc or X.Y.Z-rc.N: {manifest_version!r}"
+    )
+if manifest_version != title_version:
+    fail(
+        f"PR #{pr.get('number')} manifest version {manifest_version!r} "
+        f"does not match title release {title_version!r}"
+    )
 
 paths = {entry.get("path", "") for entry in pr.get("files", [])}
 missing = sorted(required_paths - paths)
@@ -209,6 +295,7 @@ if missing:
 
 print(
     "prerelease-pr-postcondition: PASS "
-    f"(#{pr.get('number')} {pr.get('title')}; single-manifest prerelease files present)"
+    f"(#{pr.get('number')} {pr.get('title')}; manifest {manifest_version}; "
+    "single-manifest prerelease files present)"
 )
 PY

--- a/scripts/verify-promotion-release-driver.sh
+++ b/scripts/verify-promotion-release-driver.sh
@@ -190,9 +190,9 @@ metadata_path = Path(sys.argv[1])
 base = os.environ["BASE_REF"]
 head = os.environ["HEAD_REF"]
 
-rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc\.\d+$")
+rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc(?:\.\d+)?$")
 stable_version_re = re.compile(r"^v?\d+\.\d+\.\d+$")
-rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc\.\d+$")
+rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
 stable_title_re = re.compile(r"^chore\(main\): release \d+\.\d+\.\d+$")
 any_rc_re = re.compile(r"\d+\.\d+\.\d+-rc(?:[.\-\w]*)?")
 
@@ -282,7 +282,7 @@ def pending_stable_promotion_version() -> str:
     if not isinstance(manifest, str) or not rc_version_re.match(manifest):
         fail(
             "premain -> main promotion must carry a single-manifest RC "
-            f"with numbered -rc.N syntax; .release-please-manifest.json is {manifest!r}"
+            f"with X.Y.Z-rc or X.Y.Z-rc.N syntax; .release-please-manifest.json is {manifest!r}"
         )
     return manifest
 
@@ -293,7 +293,7 @@ pr_text = "\n\n".join([title, body])
 
 if base == "premain" and head == "release-please--branches--premain":
     if not rc_title_re.fullmatch(title):
-        fail(f"generated premain release-please PR must be numbered RC-shaped, got {title!r}")
+        fail(f"generated premain release-please PR must be RC-shaped, got {title!r}")
     print(f"promotion-release-driver: PASS (generated premain RC PR {title!r})")
     raise SystemExit(0)
 
@@ -311,7 +311,7 @@ if base == "premain":
     if invalid:
         fail(
             "staging -> premain Release-As footers must be RC-shaped "
-            f"X.Y.Z-rc.N, got {', '.join(invalid)}"
+            f"X.Y.Z-rc or X.Y.Z-rc.N, got {', '.join(invalid)}"
         )
     if versions:
         print(

--- a/scripts/verify-release-lane-provenance.sh
+++ b/scripts/verify-release-lane-provenance.sh
@@ -225,7 +225,7 @@ pr_is_merged() {
 is_premain_release_please_rc_pr() {
   [[ "${base}" == "premain" ]] &&
     [[ "${head}" == "release-please--branches--premain" ]] &&
-    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]
+    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]
 }
 
 stale_merged_rc_pr_allowed=0
@@ -260,8 +260,8 @@ if [[ "${base}" == "premain" ]]; then
   if [[ "${head}" == "staging" ]]; then
     :
   elif [[ "${head}" == "release-please--branches--premain" ]]; then
-    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]] ||
-      fail "premain release-please PR must advertise a numbered RC version, got ${title@Q}"
+    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]] ||
+      fail "premain release-please PR must advertise an RC version (X.Y.Z-rc or X.Y.Z-rc.N), got ${title@Q}"
   else
     fail "premain PR head must be staging or release-please--branches--premain, got ${head@Q}"
   fi


### PR DESCRIPTION
## Summary
- accept release-please first-RC PR/manifest shape (`X.Y.Z-rc`) alongside numbered later RCs (`X.Y.Z-rc.N`)
- keep release-please PR validation fail-closed for wrong head/base, wrong title, missing manifest/changelog, and non-RC manifest values
- suppress TypeScript, Python, and Unit Coverage pull_request fan-out for manifest/changelog-only release-please PRs while leaving normal code PR validation enabled

## Validation
- `bash scripts/verify-prerelease-pr-postcondition.sh --repo theory-cloud/TableTheory --base premain --expected-version 2.0.0-rc`
- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/test-release-verifier-policy.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/verify-promotion-release-driver.sh` fixture checks for `2.0.0-rc`, `2.0.0-rc.1`, and pending stable promotion from `2.0.0-rc`
- workflow trigger inspection for TS/Py/unit-cover manifest/changelog-only PR skip and normal code PR trigger
- `git diff --check`
- `make rubric` (PASS: 36 pass / 0 fail / 0 blocked)
