### PR TITLE
Promote staging to premain for RC release-lane fix

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     # Staging PRs run Python through Quality Gates to avoid duplicate suites.
     branches: ["premain", "main"]
+    paths-ignore:
+      - ".release-please-manifest.json"
+      - "CHANGELOG.md"
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -208,9 +208,9 @@ jobs:
             local -n reasons_ref="${reasons_name}"
             reasons_ref=()
 
-            # These markers distinguish the v2 single-manifest release lane from
-            # the retired v1 verifier shape that required a premain manifest,
-            # prepare-stable-promotion helper, and legacy theorydb_py version path.
+            # These markers distinguish the current single-manifest release lane from
+            # older trusted verifier shapes that either required the retired premain
+            # manifest/helper/Python path or still assumed numbered-only RC syntax.
             add_v2_marker_reason "${root}" "scripts/verify-release-cycle-state.sh" \
               "scripts/prepare-release-package-versions.py" "package-version stamping marker" "${reasons_name}"
             add_v2_marker_reason "${root}" "scripts/verify-release-cycle-state.sh" \
@@ -219,28 +219,32 @@ jobs:
               "scripts/prepare-release-package-versions.py" "package-version stamping marker" "${reasons_name}"
             add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
               "single release-please manifest" "single-manifest policy marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
+              "accept release-please first RC and numbered later RC PR titles" "release-please first-RC PR-title marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
+              "accept release-please first RC and numbered later RC version syntax" "release-please first-RC version marker" "${reasons_name}"
           }
 
           trusted_reasons=()
           collect_v2_marker_reasons "${trusted_root}" trusted_reasons
 
           if [[ "${#trusted_reasons[@]}" -eq 0 ]]; then
-            echo "release-verifier-source: trusted base supports v2 single-manifest verifier markers"
+            echo "release-verifier-source: trusted base supports v2 single-manifest and RC-first verifier markers"
           else
-            printf 'release-verifier-source: trusted base lacks v2 single-manifest support (%s)\n' "$(IFS='; '; echo "${trusted_reasons[*]}")"
+            printf 'release-verifier-source: trusted base lacks v2 single-manifest support or RC-first verifier support (%s)\n' "$(IFS='; '; echo "${trusted_reasons[*]}")"
           fi
 
           if [[ "${protected_promotion}" == "true" && "${#trusted_reasons[@]}" -ne 0 ]]; then
             head_reasons=()
             collect_v2_marker_reasons "." head_reasons
             if [[ "${#head_reasons[@]}" -ne 0 ]]; then
-              printf 'release-verifier-source: FAIL (protected PR head lacks v2 verifier support: %s)\n' "$(IFS='; '; echo "${head_reasons[*]}")" >&2
+              printf 'release-verifier-source: FAIL (protected PR head lacks v2 single-manifest support or RC-first verifier support: %s)\n' "$(IFS='; '; echo "${head_reasons[*]}")" >&2
               exit 1
             fi
 
             verifier_root="."
             verifier_label="protected-pr-head-v2"
-            echo "release-verifier-source: protected same-repo promotion may use PR-head v2 verifier scripts after provenance"
+            echo "release-verifier-source: protected same-repo promotion may use PR-head v2/RC-first verifier scripts after provenance"
           else
             echo "release-verifier-source: using trusted base verifier scripts"
           fi

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     # Staging PRs run TypeScript through Quality Gates to avoid duplicate suites.
     branches: ["premain", "main"]
+    paths-ignore:
+      - ".release-please-manifest.json"
+      - "CHANGELOG.md"
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/unit-cover.yml
+++ b/.github/workflows/unit-cover.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     # Staging PRs run Go unit coverage through Quality Gates to avoid duplicate suites.
     branches: [ "premain", "main" ]
+    paths-ignore:
+      - ".release-please-manifest.json"
+      - "CHANGELOG.md"
 
 permissions:
   contents: read

--- a/scripts/prepare-release-package-versions.py
+++ b/scripts/prepare-release-package-versions.py
@@ -15,7 +15,7 @@ import re
 from pathlib import Path
 
 
-VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-rc\.\d+)?$")
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-rc(?:\.\d+)?)?$")
 
 
 def release_version(raw: str) -> str:
@@ -25,7 +25,7 @@ def release_version(raw: str) -> str:
     if not VERSION_RE.fullmatch(version):
         raise SystemExit(
             "release-package-versions: FAIL "
-            f"(version must be stable X.Y.Z or numbered RC X.Y.Z-rc.N, got {raw!r})"
+            f"(version must be stable X.Y.Z or RC X.Y.Z-rc or X.Y.Z-rc.N, got {raw!r})"
         )
     return version
 
@@ -39,7 +39,7 @@ def main() -> int:
         description="Write TS/Python release-build versions from a tag or version."
     )
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--tag-name", help="GitHub release tag, e.g. v1.10.1-rc.1")
+    group.add_argument("--tag-name", help="GitHub release tag, e.g. v1.10.1-rc or v1.10.1-rc.1")
     group.add_argument("--version", help="Release version without leading v")
     parser.add_argument(
         "--repo-root",

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -51,6 +51,70 @@ expect_failure_contains() {
   fi
 }
 
+write_prerelease_postcondition_fixture() {
+  local root="$1"
+  local version="$2"
+  local title="${3:-chore(premain): release ${version}}"
+  local include_manifest="${4:-true}"
+  local include_changelog="${5:-true}"
+  local manifest_version="${6:-${version}}"
+
+  mkdir -p "${root}"
+  cat >"${root}/open-prs.json" <<JSON
+[
+  {
+    "number": 353,
+    "title": "${title}",
+    "headRefName": "release-please--branches--premain",
+    "url": "https://github.example.test/theory-cloud/TableTheory/pull/353"
+  }
+]
+JSON
+
+  python3 - "${root}/details.json" "${title}" "${include_manifest}" "${include_changelog}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, title, include_manifest, include_changelog = sys.argv[1:5]
+files = []
+if include_manifest == "true":
+    files.append({"path": ".release-please-manifest.json"})
+if include_changelog == "true":
+    files.append({"path": "CHANGELOG.md"})
+Path(path).write_text(
+    json.dumps(
+        {
+            "number": 353,
+            "title": title,
+            "headRefName": "release-please--branches--premain",
+            "baseRefName": "premain",
+            "headRefOid": "2222222222222222222222222222222222222222",
+            "url": "https://github.example.test/theory-cloud/TableTheory/pull/353",
+            "files": files,
+        }
+    ),
+    encoding="utf-8",
+)
+PY
+
+  printf '{".":"%s"}\n' "${manifest_version}" >"${root}/manifest.json"
+}
+
+run_prerelease_postcondition_fixture() {
+  local fixture="$1"
+  shift
+
+  bash "${repo_root}/scripts/verify-prerelease-pr-postcondition.sh" \
+    --repo "${repo}" \
+    --base premain \
+    --open-prs-file "${fixture}/open-prs.json" \
+    --details-file "${fixture}/details.json" \
+    --manifest-file "${fixture}/manifest.json" \
+    --dry-run \
+    "$@"
+}
+
 extract_workflow_step_run() {
   local step_name="$1"
 
@@ -302,8 +366,8 @@ expect_failure_contains \
     --title "Promote staging to premain" \
     --queue-freshness
 
-expect_failure_contains \
-  "numbered RC version" \
+expect_success_contains \
+  "release-lane-provenance: PASS" \
   bash "${checker}" \
     --repo "${repo}" \
     --base premain \
@@ -313,6 +377,20 @@ expect_failure_contains \
     --base-sha "${base_sha}" \
     --head-sha "${head_sha}" \
     --title "chore(premain): release 1.9.3-rc" \
+    --ref "refs/heads/premain=${base_sha}" \
+    --ref "refs/heads/release-please--branches--premain=${head_sha}"
+
+expect_failure_contains \
+  "must advertise an RC version" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head release-please--branches--premain \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "chore(premain): release 1.9.3-beta.1" \
     --ref "refs/heads/premain=${base_sha}" \
     --ref "refs/heads/release-please--branches--premain=${head_sha}"
 
@@ -348,8 +426,8 @@ expect_failure_contains \
     --ref "refs/heads/premain=${advanced_base_sha}" \
     --ref "refs/heads/release-please--branches--premain=${head_sha}"
 
-expect_failure_contains \
-  "X.Y.Z-rc.N" \
+expect_success_contains \
+  "RC Release-As 1.9.3-rc" \
   bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
     --base premain \
     --head staging \
@@ -364,6 +442,31 @@ expect_success_contains \
     --head staging \
     --title "Promote staging to premain" \
     --body "Release-As: 1.9.3-rc.1" \
+    --dry-run
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+    --base premain \
+    --head staging \
+    --title "Promote staging to premain" \
+    --body "Release-As: 1.9.3" \
+    --dry-run
+
+expect_success_contains \
+  "generated premain RC PR" \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+    --base premain \
+    --head release-please--branches--premain \
+    --title "chore(premain): release 1.9.3-rc" \
+    --dry-run
+
+expect_failure_contains \
+  "must be RC-shaped" \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+    --base premain \
+    --head release-please--branches--premain \
+    --title "chore(premain): release 1.9.3-beta.1" \
     --dry-run
 
 pending_fixture="$(mktemp -d)"
@@ -462,11 +565,68 @@ expect_failure_contains \
       --body "" \
       --dry-run
 
+prerelease_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_fixture}")
+write_prerelease_postcondition_fixture "${prerelease_fixture}" "2.0.0-rc"
+expect_success_contains \
+  "manifest 2.0.0-rc" \
+  run_prerelease_postcondition_fixture "${prerelease_fixture}" \
+    --expected-version 2.0.0-rc
+
+prerelease_numbered_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_numbered_fixture}")
+write_prerelease_postcondition_fixture "${prerelease_numbered_fixture}" "2.0.0-rc.1"
+expect_success_contains \
+  "manifest 2.0.0-rc.1" \
+  run_prerelease_postcondition_fixture "${prerelease_numbered_fixture}" \
+    --expected-version 2.0.0-rc.1
+
+prerelease_bad_title_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_bad_title_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_bad_title_fixture}" \
+  "2.0.0-beta.1" \
+  "chore(premain): release 2.0.0-beta.1"
 expect_failure_contains \
-  "numbered RC-shaped X.Y.Z-rc.N" \
-  bash "${repo_root}/scripts/verify-prerelease-pr-postcondition.sh" \
-    --expected-version 1.9.3-rc \
-    --dry-run
+  "not RC-shaped" \
+  run_prerelease_postcondition_fixture "${prerelease_bad_title_fixture}"
+
+prerelease_missing_manifest_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_missing_manifest_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_missing_manifest_fixture}" \
+  "2.0.0-rc" \
+  "chore(premain): release 2.0.0-rc" \
+  false \
+  true
+expect_failure_contains \
+  "missing single-manifest prerelease files" \
+  run_prerelease_postcondition_fixture "${prerelease_missing_manifest_fixture}"
+
+prerelease_missing_changelog_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_missing_changelog_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_missing_changelog_fixture}" \
+  "2.0.0-rc" \
+  "chore(premain): release 2.0.0-rc" \
+  true \
+  false
+expect_failure_contains \
+  "missing single-manifest prerelease files" \
+  run_prerelease_postcondition_fixture "${prerelease_missing_changelog_fixture}"
+
+prerelease_non_rc_manifest_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_non_rc_manifest_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_non_rc_manifest_fixture}" \
+  "2.0.0-rc" \
+  "chore(premain): release 2.0.0-rc" \
+  true \
+  true \
+  "2.0.0-beta.1"
+expect_failure_contains \
+  "manifest version is not RC-shaped" \
+  run_prerelease_postcondition_fixture "${prerelease_non_rc_manifest_fixture}"
 
 expect_failure_contains \
   "non-numbered-RC tag_name" \
@@ -505,6 +665,28 @@ grep -Fq "merge_group:" "${repo_root}/.github/workflows/release-hygiene.yml" || 
   echo "release-hygiene-policy-test: release hygiene must support merge_group for release queue"
   exit 1
 }
+
+for workflow in \
+  "${repo_root}/.github/workflows/typescript.yml" \
+  "${repo_root}/.github/workflows/python.yml" \
+  "${repo_root}/.github/workflows/unit-cover.yml"; do
+  grep -Fq "paths-ignore:" "${workflow}" || {
+    echo "release-hygiene-policy-test: ${workflow} must use trigger-level paths-ignore for release-please PRs"
+    exit 1
+  }
+  grep -Fq '".release-please-manifest.json"' "${workflow}" || {
+    echo "release-hygiene-policy-test: ${workflow} must ignore manifest-only release-please PR changes"
+    exit 1
+  }
+  grep -Fq '"CHANGELOG.md"' "${workflow}" || {
+    echo "release-hygiene-policy-test: ${workflow} must ignore changelog-only release-please PR changes"
+    exit 1
+  }
+  if grep -Eq '^[[:space:]]*paths:' "${workflow}"; then
+    echo "release-hygiene-policy-test: ${workflow} must not replace normal PR validation with a paths allowlist"
+    exit 1
+  fi
+done
 
 grep -Fq -- "--queue-freshness" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene PR provenance must delegate live ref freshness to merge queue"

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -115,6 +115,94 @@ run_prerelease_postcondition_fixture() {
     "$@"
 }
 
+write_package_version_fixture() {
+  local root="$1"
+  local version="${2:-1.10.1}"
+
+  mkdir -p "${root}/ts" "${root}/py/src/tabletheory_py"
+  printf '{"version":"%s"}\n' "${version}" >"${root}/ts/package.json"
+  printf '{"version":"%s","packages":{"":{"version":"%s"}}}\n' \
+    "${version}" "${version}" >"${root}/ts/package-lock.json"
+  printf '{"version":"%s"}\n' "${version}" >"${root}/py/src/tabletheory_py/version.json"
+}
+
+assert_package_version_fixture() {
+  local root="$1"
+  local version="$2"
+
+  python3 - "${root}" "${version}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+expected = sys.argv[2]
+
+checks = [
+    ("ts/package.json", json.loads((root / "ts/package.json").read_text())["version"]),
+    ("ts/package-lock.json", json.loads((root / "ts/package-lock.json").read_text())["version"]),
+    (
+        "ts/package-lock.json packages['']",
+        json.loads((root / "ts/package-lock.json").read_text())["packages"][""]["version"],
+    ),
+    (
+        "py/src/tabletheory_py/version.json",
+        json.loads((root / "py/src/tabletheory_py/version.json").read_text())["version"],
+    ),
+]
+for label, actual in checks:
+    if actual != expected:
+        print(f"release-hygiene-policy-test: {label} = {actual!r}, expected {expected!r}")
+        raise SystemExit(1)
+PY
+}
+
+write_release_asset_fixture() {
+  local root="$1"
+  local version="$2"
+
+  python3 - "${root}" "${version}" <<'PY'
+import io
+import json
+import re
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+root = Path(sys.argv[1])
+version = sys.argv[2]
+root.mkdir(parents=True, exist_ok=True)
+
+match = re.fullmatch(r"(\d+\.\d+\.\d+)-rc(?:\.(\d+))?", version)
+pep440 = f"{match.group(1)}rc{match.group(2) or '0'}" if match else version
+version_json = json.dumps({"version": version}).encode("utf-8")
+
+npm_package = json.dumps(
+    {"name": "@theory-cloud/tabletheory-ts", "version": version},
+    separators=(",", ":"),
+).encode("utf-8")
+with tarfile.open(root / f"theory-cloud-tabletheory-ts-{version}.tgz", "w:gz") as archive:
+    info = tarfile.TarInfo("package/package.json")
+    info.size = len(npm_package)
+    archive.addfile(info, io.BytesIO(npm_package))
+
+metadata = f"Metadata-Version: 2.1\nName: tabletheory-py\nVersion: {pep440}\n".encode("utf-8")
+with zipfile.ZipFile(root / f"tabletheory_py-{pep440}-py3-none-any.whl", "w") as archive:
+    archive.writestr(f"tabletheory_py-{pep440}.dist-info/METADATA", metadata)
+    archive.writestr("tabletheory_py/version.json", version_json)
+
+with tarfile.open(root / f"tabletheory_py-{pep440}.tar.gz", "w:gz") as archive:
+    for name, payload in (
+        (f"tabletheory_py-{pep440}/PKG-INFO", metadata),
+        (f"tabletheory_py-{pep440}/src/tabletheory_py/version.json", version_json),
+    ):
+        info = tarfile.TarInfo(name)
+        info.size = len(payload)
+        archive.addfile(info, io.BytesIO(payload))
+PY
+}
+
 extract_workflow_step_run() {
   local step_name="$1"
 
@@ -204,7 +292,41 @@ required_files=(
 )
 require_fixed "manifest-file:\s*\.release-please-manifest\.json" "${p}" \
   "prerelease workflow must reference the single release-please manifest"
+require_fixed "-rc(\\.[0-9]+)?" "${provenance}" \
+  "release-lane provenance guard must accept release-please first RC and numbered later RC PR titles"
+require_fixed "-rc(?:\\.\\d+)?" "${prerelease_postcondition}" \
+  "prerelease PR postcondition must accept release-please first RC and numbered later RC version syntax"
 SH
+}
+
+write_v2_numbered_rc_verifier_fixture() {
+  local root="$1"
+
+  write_v2_verifier_fixture "${root}"
+  cat >>"${root}/scripts/verify-branch-release-supply-chain.sh" <<'SH'
+require_fixed "-rc\.[0-9]+" "${provenance}" \
+  "release-lane provenance guard must require numbered RC release-please PR titles"
+require_fixed "-rc\\.\\d+" "${prerelease_postcondition}" \
+  "prerelease PR postcondition must require numbered RC version syntax"
+SH
+  python3 - "${root}/scripts/verify-branch-release-supply-chain.sh" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    'require_fixed "-rc(\\\\.[0-9]+)?" "${provenance}" \\\n'
+    '  "release-lane provenance guard must accept release-please first RC and numbered later RC PR titles"\n',
+    "",
+)
+text = text.replace(
+    'require_fixed "-rc(?:\\\\.\\\\d+)?" "${prerelease_postcondition}" \\\n'
+    '  "prerelease PR postcondition must accept release-please first RC and numbered later RC version syntax"\n',
+    "",
+)
+path.write_text(text, encoding="utf-8")
+PY
 }
 
 run_verifier_source_selector_fixture() {
@@ -222,11 +344,13 @@ run_verifier_source_selector_fixture() {
   mkdir -p "${fixture}/trusted-release" "${fixture}/pr"
   case "${trusted_shape}" in
     v1) write_v1_verifier_fixture "${fixture}/trusted-release" ;;
+    v2-numbered-rc) write_v2_numbered_rc_verifier_fixture "${fixture}/trusted-release" ;;
     v2) write_v2_verifier_fixture "${fixture}/trusted-release" ;;
     *) echo "release-hygiene-policy-test: unknown trusted fixture ${trusted_shape}" >&2; exit 1 ;;
   esac
   case "${head_shape}" in
     v1) write_v1_verifier_fixture "${fixture}/pr" ;;
+    v2-numbered-rc) write_v2_numbered_rc_verifier_fixture "${fixture}/pr" ;;
     v2) write_v2_verifier_fixture "${fixture}/pr" ;;
     *) echo "release-hygiene-policy-test: unknown head fixture ${head_shape}" >&2; exit 1 ;;
   esac
@@ -236,6 +360,7 @@ run_verifier_source_selector_fixture() {
 
   local output_file="${fixture}/selector.out"
   local github_output="${fixture}/github-output"
+  set +e
   (
     cd "${fixture}/pr"
     env \
@@ -247,8 +372,10 @@ run_verifier_source_selector_fixture() {
       GITHUB_OUTPUT="${github_output}" \
       bash "${selector_script}"
   ) >"${output_file}" 2>&1
+  local status=$?
+  set -e
 
-  printf '%s\n' "${output_file}:${github_output}"
+  printf '%s\n' "${output_file}:${github_output}:${status}"
 }
 
 assert_selector_result() {
@@ -258,7 +385,15 @@ assert_selector_result() {
   local expected_output="$4"
 
   local output_file="${output_pair%%:*}"
-  local github_output="${output_pair#*:}"
+  local remainder="${output_pair#*:}"
+  local github_output="${remainder%%:*}"
+  local status="${remainder#*:}"
+
+  if [[ "${status}" -ne 0 ]]; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: selector expected success, got ${status}"
+    exit 1
+  fi
 
   if ! grep -Fxq "root=${expected_root}" "${github_output}"; then
     cat "${output_file}"
@@ -275,6 +410,28 @@ assert_selector_result() {
   if ! grep -Fq "${expected_output}" "${output_file}"; then
     cat "${output_file}"
     echo "release-hygiene-policy-test: selector output missing: ${expected_output}"
+    exit 1
+  fi
+}
+
+assert_selector_failure() {
+  local output_pair="$1"
+  local expected_output="$2"
+
+  local output_file="${output_pair%%:*}"
+  local remainder="${output_pair#*:}"
+  local github_output="${remainder%%:*}"
+  local status="${remainder#*:}"
+
+  if [[ "${status}" -eq 0 ]]; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: selector expected failure"
+    exit 1
+  fi
+  if ! grep -Fq "${expected_output}" "${output_file}"; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: selector failure output missing: ${expected_output}"
     exit 1
   fi
 }
@@ -628,14 +785,14 @@ expect_failure_contains \
   "manifest version is not RC-shaped" \
   run_prerelease_postcondition_fixture "${prerelease_non_rc_manifest_fixture}"
 
-expect_failure_contains \
-  "non-numbered-RC tag_name" \
+expect_success_contains \
+  "published v1.9.3-rc" \
   bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
     --kind prerelease \
     --branch premain \
     --release-created true \
     --tag-name v1.9.3-rc \
-    --commit-message "Merge pull request from release-please--branches--premain"
+    --commit-message "chore(premain): release 1.9.3-rc"
 
 expect_success_contains \
   "published v1.9.3-rc.1" \
@@ -645,6 +802,93 @@ expect_success_contains \
     --release-created true \
     --tag-name v1.9.3-rc.1 \
     --commit-message "chore(premain): release 1.9.3-rc.1"
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3 \
+    --commit-message "chore(premain): release 1.9.3-rc"
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-beta.1 \
+    --commit-message "chore(premain): release 1.9.3-rc"
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-rc. \
+    --commit-message "chore(premain): release 1.9.3-rc"
+
+expect_failure_contains \
+  "does not match generated RC release 1.9.3-rc" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-rc.1 \
+    --commit-message "chore(premain): release 1.9.3-rc"
+
+expect_failure_contains \
+  "non-generated RC release PR merge" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-rc \
+    --commit-message "chore(premain): release 1.9.3-rc."
+
+for version in 2.0.0-rc 2.0.0-rc.1; do
+  package_fixture="$(mktemp -d)"
+  tmpdirs+=("${package_fixture}")
+  write_package_version_fixture "${package_fixture}"
+  expect_success_contains \
+    "version=${version}" \
+    python3 "${repo_root}/scripts/prepare-release-package-versions.py" \
+      --tag-name "v${version}" \
+      --repo-root "${package_fixture}"
+  assert_package_version_fixture "${package_fixture}" "${version}"
+
+  assets_fixture="$(mktemp -d)"
+  tmpdirs+=("${assets_fixture}")
+  write_release_asset_fixture "${assets_fixture}" "${version}"
+  expect_success_contains \
+    "version=${version}" \
+    python3 "${repo_root}/scripts/verify-release-package-version-assets.py" \
+      --tag-name "v${version}" \
+      --assets-dir "${assets_fixture}"
+done
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  python3 "${repo_root}/scripts/prepare-release-package-versions.py" \
+    --version 2.0.0-beta.1 \
+    --repo-root "${repo_root}"
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  python3 "${repo_root}/scripts/verify-release-package-version-assets.py" \
+    --version 2.0.0-rc. \
+    --assets-dir "${repo_root}/release-assets"
+
+mismatch_assets_fixture="$(mktemp -d)"
+tmpdirs+=("${mismatch_assets_fixture}")
+write_release_asset_fixture "${mismatch_assets_fixture}" "2.0.0-rc.1"
+expect_failure_contains \
+  "!= '2.0.0-rc'" \
+  python3 "${repo_root}/scripts/verify-release-package-version-assets.py" \
+    --tag-name v2.0.0-rc \
+    --assets-dir "${mismatch_assets_fixture}"
 
 if grep -Fq "secrets.RELEASE_PLEASE_TOKEN" "${repo_root}/.github/workflows/release-hygiene.yml"; then
   echo "release-hygiene-policy-test: release hygiene must not expose release-please token"
@@ -718,8 +962,8 @@ grep -Fq "premain:staging|main:premain" "${repo_root}/.github/workflows/release-
   exit 1
 }
 
-grep -Fq "trusted base lacks v2 single-manifest support" "${repo_root}/.github/workflows/release-hygiene.yml" || {
-  echo "release-hygiene-policy-test: verifier selector must document old trusted-script fallback reasons"
+grep -Fq "trusted base lacks v2 single-manifest support or RC-first verifier support" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must document old trusted-script and RC-first fallback reasons"
   exit 1
 }
 
@@ -735,6 +979,16 @@ grep -Fq "scripts/prepare-release-package-versions.py" "${repo_root}/.github/wor
 
 grep -Fq "single release-please manifest" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: verifier selector must feature-detect the v2 single-manifest marker"
+  exit 1
+}
+
+grep -Fq "accept release-please first RC and numbered later RC PR titles" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect the RC-first PR-title marker"
+  exit 1
+}
+
+grep -Fq "accept release-please first RC and numbered later RC version syntax" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect the RC-first version marker"
   exit 1
 }
 
@@ -758,11 +1012,35 @@ assert_selector_result \
   "${selector_result}" \
   "." \
   "protected-pr-head-v2" \
-  "protected same-repo promotion may use PR-head v2 verifier scripts after provenance"
+  "protected same-repo promotion may use PR-head v2/RC-first verifier scripts after provenance"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-numbered-rc v2 \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "." \
+  "protected-pr-head-v2" \
+  "protected same-repo promotion may use PR-head v2/RC-first verifier scripts after provenance"
 
 selector_result="$(
   run_verifier_source_selector_fixture \
     v1 v2 \
+    premain "feature/arbitrary-head" \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "using trusted base verifier scripts"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-numbered-rc v2 \
     premain "feature/arbitrary-head" \
     "${repo}" "${repo}"
 )"
@@ -786,6 +1064,18 @@ assert_selector_result \
 
 selector_result="$(
   run_verifier_source_selector_fixture \
+    v2-numbered-rc v2 \
+    premain staging \
+    "${repo}" "attacker/TableTheory"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "using trusted base verifier scripts"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
     v2 v2 \
     premain staging \
     "${repo}" "${repo}"
@@ -794,7 +1084,17 @@ assert_selector_result \
   "${selector_result}" \
   "../trusted-release" \
   "trusted-base" \
-  "trusted base supports v2 single-manifest verifier markers"
+  "trusted base supports v2 single-manifest and RC-first verifier markers"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-numbered-rc v2-numbered-rc \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_failure \
+  "${selector_result}" \
+  "protected PR head lacks v2 single-manifest support or RC-first verifier support"
 
 grep -Fq "pending stable promotion accepted on queued main merge group" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene must allow queued main pending stable promotion"

--- a/scripts/test-release-verifier-policy.sh
+++ b/scripts/test-release-verifier-policy.sh
@@ -188,6 +188,10 @@ run_watch_fixture() {
 }
 
 run_branch_version_sync_fixture() {
+  local candidate_version="$1"
+  local expected_status="$2"
+  local expected_output="$3"
+
   local work remote output status
   work="$(mktemp -d)"
   remote="$(mktemp -d)"
@@ -205,7 +209,7 @@ run_branch_version_sync_fixture() {
   git -C "${work}" remote add origin "${remote}"
   git -C "${remote}" fetch -q "${work}" HEAD:refs/heads/main
 
-  write_version_files "${work}" "1.10.1-rc.1" "" "1.10.0" "1.10.0"
+  write_version_files "${work}" "${candidate_version}" "" "1.10.0" "1.10.0"
   git -C "${work}" add .
   git -C "${work}" commit -q -m "fixture premain"
 
@@ -218,19 +222,37 @@ run_branch_version_sync_fixture() {
   status=$?
   set -e
 
-  if [[ "${status}" -ne 0 ]]; then
+  if [[ "${status}" -ne "${expected_status}" ]]; then
     printf '%s\n' "${output}"
-    echo "release-verifier-policy-test: branch-version-sync fixture: expected success, got ${status}"
+    echo "release-verifier-policy-test: branch-version-sync fixture ${candidate_version}: expected ${expected_status}, got ${status}"
     exit 1
   fi
   expect_contains \
     "${output}" \
-    "branch-version-sync: PASS (main=1.10.1, candidate=1.10.1-rc.1, mode=premain)" \
-    "branch-version-sync fixture"
+    "${expected_output}" \
+    "branch-version-sync fixture ${candidate_version}"
   expect_absent "${output}" "JSONDecodeError" "branch-version-sync fixture"
 }
 
-run_branch_version_sync_fixture
+run_branch_version_sync_fixture \
+  "1.10.1-rc" \
+  0 \
+  "branch-version-sync: PASS (main=1.10.1, candidate=1.10.1-rc, mode=premain)"
+
+run_branch_version_sync_fixture \
+  "1.10.1-rc.1" \
+  0 \
+  "branch-version-sync: PASS (main=1.10.1, candidate=1.10.1-rc.1, mode=premain)"
+
+run_branch_version_sync_fixture \
+  "1.10.1-beta.1" \
+  1 \
+  "branch-version-sync: FAIL (checked-out .release-please-manifest.json has invalid version '1.10.1-beta.1')"
+
+run_branch_version_sync_fixture \
+  "1.10.1-rc." \
+  1 \
+  "branch-version-sync: FAIL (checked-out .release-please-manifest.json has invalid version '1.10.1-rc.')"
 
 for fixture in "${fixtures_dir}"/cycle-*; do
   run_cycle_fixture "${fixture}"

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -185,6 +185,23 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
   fi
 fi
 
+for workflow in \
+  ".github/workflows/typescript.yml" \
+  ".github/workflows/python.yml" \
+  ".github/workflows/unit-cover.yml"; do
+  if [[ -f "${workflow}" ]]; then
+    require_fixed "paths-ignore:" "${workflow}" \
+      "${workflow} pull_request trigger must suppress manifest/changelog-only release-please PR fan-out"
+    require_fixed '".release-please-manifest.json"' "${workflow}" \
+      "${workflow} must ignore release-please manifest-only PR changes"
+    require_fixed '"CHANGELOG.md"' "${workflow}" \
+      "${workflow} must ignore release-please changelog-only PR changes"
+    if grep -Eq '^[[:space:]]*paths:' "${workflow}"; then
+      fail "${workflow} must not replace normal PR validation with a paths allowlist"
+    fi
+  fi
+done
+
 for doc in \
   "AGENTS.md" \
   "docs/development/planning/theorydb-branch-release-policy.md" \
@@ -434,8 +451,8 @@ if [[ -f "scripts/verify-promotion-release-driver.sh" ]]; then
     "promotion release driver guard must name release-please no-op as a failed precondition"
   require_fixed "do not use tags, resets, manual manifests" "${driver}" \
     "promotion release driver guard must instruct normal PR-flow remediation"
-  require_fixed "X.Y.Z-rc.N" "${driver}" \
-    "promotion release driver guard must require numbered RC syntax"
+  require_fixed "X.Y.Z-rc or X.Y.Z-rc.N" "${driver}" \
+    "promotion release driver guard must accept release-please first RC and numbered later RC syntax"
 fi
 
 if [[ -f "scripts/verify-release-lane-provenance.sh" ]]; then
@@ -446,8 +463,8 @@ if [[ -f "scripts/verify-release-lane-provenance.sh" ]]; then
     "release-lane provenance guard must retain exact branch SHA verification for manual fallback"
   require_fixed "live ref freshness covered by merge queue" "${provenance}" \
     "release-lane provenance guard must document queue-covered live ref freshness"
-  require_fixed "-rc\\.[0-9]+" "${provenance}" \
-    "release-lane provenance guard must require numbered RC release-please PR titles"
+  require_fixed "-rc(\\.[0-9]+)?" "${provenance}" \
+    "release-lane provenance guard must accept release-please first RC and numbered later RC PR titles"
 fi
 
 if [[ -f "scripts/verify-prerelease-pr-postcondition.sh" ]]; then
@@ -456,8 +473,8 @@ if [[ -f "scripts/verify-prerelease-pr-postcondition.sh" ]]; then
     "prerelease PR postcondition must require the generated premain head branch"
   require_fixed "rc_title_re = re.compile" "${prerelease_postcondition}" \
     "prerelease PR postcondition must require RC-shaped release titles"
-  require_fixed "-rc\\.\\d+" "${prerelease_postcondition}" \
-    "prerelease PR postcondition must require numbered RC version syntax"
+  require_fixed "-rc(?:\\.\\d+)?" "${prerelease_postcondition}" \
+    "prerelease PR postcondition must accept release-please first RC and numbered later RC version syntax"
   require_fixed ".release-please-manifest.json" "${prerelease_postcondition}" \
     "prerelease PR postcondition must require the single manifest"
 fi

--- a/scripts/verify-branch-version-sync.sh
+++ b/scripts/verify-branch-version-sync.sh
@@ -143,7 +143,7 @@ import sys
 
 label = os.environ["VERSION_LABEL"]
 version = os.environ["VERSION_VALUE"]
-if not re.fullmatch(r"v?\d+\.\d+\.\d+(?:-rc\.\d+)?", version):
+if not re.fullmatch(r"v?\d+\.\d+\.\d+(?:-rc(?:\.\d+)?)?", version):
     print(f"branch-version-sync: FAIL ({label} has invalid version {version!r})")
     sys.exit(1)
 PY

--- a/scripts/verify-prerelease-pr-postcondition.sh
+++ b/scripts/verify-prerelease-pr-postcondition.sh
@@ -12,7 +12,10 @@ Options:
   --repo OWNER/REPO         GitHub repository. Defaults to $GITHUB_REPOSITORY or theory-cloud/TableTheory.
   --base BRANCH            Release PR base branch. Defaults to premain.
   --head BRANCH            Release-please PR head branch. Defaults to release-please--branches--premain.
-  --expected-version VER   Optional numbered RC version the PR must advertise, e.g. 1.9.4-rc.1.
+  --expected-version VER   Optional RC version the PR must advertise, e.g. 2.0.0-rc or 2.0.0-rc.1.
+  --open-prs-file PATH     Test-only gh pr list JSON fixture.
+  --details-file PATH      Test-only gh pr view JSON fixture for the selected PR.
+  --manifest-file PATH     Test-only .release-please-manifest.json fixture for the selected PR head.
   --dry-run                Read-only local validation mode; no GitHub state is changed.
   -h, --help               Show this help.
 
@@ -26,6 +29,9 @@ base="premain"
 head="release-please--branches--premain"
 expected_version="${PRERELEASE_PR_EXPECTED_VERSION:-}"
 dry_run=0
+open_prs_fixture=""
+details_fixture=""
+manifest_fixture=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -61,6 +67,30 @@ while [[ $# -gt 0 ]]; do
       expected_version="$2"
       shift 2
       ;;
+    --open-prs-file)
+      if [[ $# -lt 2 ]]; then
+        echo "prerelease-pr-postcondition: FAIL (--open-prs-file requires a value)" >&2
+        exit 2
+      fi
+      open_prs_fixture="$2"
+      shift 2
+      ;;
+    --details-file)
+      if [[ $# -lt 2 ]]; then
+        echo "prerelease-pr-postcondition: FAIL (--details-file requires a value)" >&2
+        exit 2
+      fi
+      details_fixture="$2"
+      shift 2
+      ;;
+    --manifest-file)
+      if [[ $# -lt 2 ]]; then
+        echo "prerelease-pr-postcondition: FAIL (--manifest-file requires a value)" >&2
+        exit 2
+      fi
+      manifest_fixture="$2"
+      shift 2
+      ;;
     --dry-run)
       dry_run=1
       shift
@@ -82,16 +112,30 @@ fail() {
   exit 1
 }
 
-if [[ -n "${expected_version}" && ! "${expected_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
-  fail "expected version must be numbered RC-shaped X.Y.Z-rc.N, got ${expected_version}"
+if [[ -n "${expected_version}" && ! "${expected_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]; then
+  fail "expected version must be RC-shaped X.Y.Z-rc or X.Y.Z-rc.N, got ${expected_version}"
 fi
 
-if ! command -v gh >/dev/null 2>&1; then
-  fail "gh is required"
+fixture_count=0
+[[ -z "${open_prs_fixture}" ]] || fixture_count=$((fixture_count + 1))
+[[ -z "${details_fixture}" ]] || fixture_count=$((fixture_count + 1))
+[[ -z "${manifest_fixture}" ]] || fixture_count=$((fixture_count + 1))
+if [[ "${fixture_count}" -ne 0 && "${fixture_count}" -ne 3 ]]; then
+  fail "--open-prs-file, --details-file, and --manifest-file must be supplied together"
 fi
 
-if ! gh auth status >/dev/null 2>&1; then
-  fail "gh is not authenticated"
+if [[ "${fixture_count}" -eq 3 ]]; then
+  for fixture in "${open_prs_fixture}" "${details_fixture}" "${manifest_fixture}"; do
+    [[ -f "${fixture}" ]] || fail "fixture file not found: ${fixture}"
+  done
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    fail "gh is required"
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    fail "gh is not authenticated"
+  fi
 fi
 
 if [[ "${dry_run}" -eq 1 ]]; then
@@ -101,16 +145,21 @@ fi
 open_prs="$(mktemp)"
 candidate_number_file="$(mktemp)"
 details="$(mktemp)"
+manifest="$(mktemp)"
 cleanup() {
-  rm -f "${open_prs}" "${candidate_number_file}" "${details}"
+  rm -f "${open_prs}" "${candidate_number_file}" "${details}" "${manifest}"
 }
 trap cleanup EXIT
 
-gh pr list \
-  --repo "${repo}" \
-  --base "${base}" \
-  --state open \
-  --json number,title,headRefName,url >"${open_prs}"
+if [[ "${fixture_count}" -eq 3 ]]; then
+  cp "${open_prs_fixture}" "${open_prs}"
+else
+  gh pr list \
+    --repo "${repo}" \
+    --base "${base}" \
+    --state open \
+    --json number,title,headRefName,url >"${open_prs}"
+fi
 
 python3 - "${open_prs}" "${expected_version}" "${base}" "${head}" >"${candidate_number_file}" <<'PY'
 import json
@@ -120,7 +169,7 @@ from pathlib import Path
 
 path, expected_version, base, head = sys.argv[1:5]
 prs = json.loads(Path(path).read_text(encoding="utf-8"))
-rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc\.\d+$")
+rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
 
 
 def fail(message: str) -> None:
@@ -140,7 +189,7 @@ if bad:
     details = ", ".join(
         f"#{pr.get('number')} {pr.get('title')} {pr.get('url')}" for pr in bad
     )
-    fail(f"generated premain release-please PR is not numbered RC-shaped: {details}")
+    fail(f"generated premain release-please PR is not RC-shaped: {details}")
 
 if expected_version:
     expected = expected_version[1:] if expected_version.startswith("v") else expected_version
@@ -169,19 +218,42 @@ PY
 
 candidate_number="$(cat "${candidate_number_file}")"
 
-gh pr view "${candidate_number}" \
-  --repo "${repo}" \
-  --json number,title,headRefName,baseRefName,url,files >"${details}"
+if [[ "${fixture_count}" -eq 3 ]]; then
+  cp "${details_fixture}" "${details}"
+  cp "${manifest_fixture}" "${manifest}"
+else
+  gh pr view "${candidate_number}" \
+    --repo "${repo}" \
+    --json number,title,headRefName,baseRefName,headRefOid,url,files >"${details}"
 
-python3 - "${details}" "${base}" "${head}" <<'PY'
+  manifest_ref="$(
+    python3 - "${details}" "${head}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, head = sys.argv[1:3]
+pr = json.loads(Path(path).read_text(encoding="utf-8"))
+print(pr.get("headRefOid") or pr.get("headRefName") or head)
+PY
+  )"
+
+  gh api -X GET "repos/${repo}/contents/.release-please-manifest.json" \
+    -f "ref=${manifest_ref}" \
+    --jq '.content' | base64 --decode >"${manifest}"
+fi
+
+python3 - "${details}" "${manifest}" "${base}" "${head}" <<'PY'
 import json
 import re
 import sys
 from pathlib import Path
 
-path, base, head = sys.argv[1:4]
-pr = json.loads(Path(path).read_text(encoding="utf-8"))
-rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release \d+\.\d+\.\d+-rc\.\d+$")
+details_path, manifest_path, base, head = sys.argv[1:5]
+pr = json.loads(Path(details_path).read_text(encoding="utf-8"))
+manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+rc_version_re = re.compile(r"^\d+\.\d+\.\d+-rc(?:\.\d+)?$")
+rc_title_re = re.compile(rf"^chore\({re.escape(base)}\): release (\d+\.\d+\.\d+-rc(?:\.\d+)?)$")
 required_paths = {
     ".release-please-manifest.json",
     "CHANGELOG.md",
@@ -199,8 +271,22 @@ if pr.get("baseRefName") != base:
 if pr.get("headRefName") != head:
     fail(f"PR #{pr.get('number')} head {pr.get('headRefName')!r} != {head!r}")
 
-if not rc_title_re.fullmatch(pr.get("title", "")):
-    fail(f"PR #{pr.get('number')} title is not numbered RC-shaped: {pr.get('title')!r}")
+title_match = rc_title_re.fullmatch(pr.get("title", ""))
+if not title_match:
+    fail(f"PR #{pr.get('number')} title is not RC-shaped: {pr.get('title')!r}")
+
+title_version = title_match.group(1)
+manifest_version = manifest.get(".") if isinstance(manifest, dict) else None
+if not isinstance(manifest_version, str) or not rc_version_re.fullmatch(manifest_version):
+    fail(
+        f"PR #{pr.get('number')} manifest version is not RC-shaped "
+        f"X.Y.Z-rc or X.Y.Z-rc.N: {manifest_version!r}"
+    )
+if manifest_version != title_version:
+    fail(
+        f"PR #{pr.get('number')} manifest version {manifest_version!r} "
+        f"does not match title release {title_version!r}"
+    )
 
 paths = {entry.get("path", "") for entry in pr.get("files", [])}
 missing = sorted(required_paths - paths)
@@ -209,6 +295,7 @@ if missing:
 
 print(
     "prerelease-pr-postcondition: PASS "
-    f"(#{pr.get('number')} {pr.get('title')}; single-manifest prerelease files present)"
+    f"(#{pr.get('number')} {pr.get('title')}; manifest {manifest_version}; "
+    "single-manifest prerelease files present)"
 )
 PY

--- a/scripts/verify-promotion-release-driver.sh
+++ b/scripts/verify-promotion-release-driver.sh
@@ -190,9 +190,9 @@ metadata_path = Path(sys.argv[1])
 base = os.environ["BASE_REF"]
 head = os.environ["HEAD_REF"]
 
-rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc\.\d+$")
+rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc(?:\.\d+)?$")
 stable_version_re = re.compile(r"^v?\d+\.\d+\.\d+$")
-rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc\.\d+$")
+rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
 stable_title_re = re.compile(r"^chore\(main\): release \d+\.\d+\.\d+$")
 any_rc_re = re.compile(r"\d+\.\d+\.\d+-rc(?:[.\-\w]*)?")
 
@@ -282,7 +282,7 @@ def pending_stable_promotion_version() -> str:
     if not isinstance(manifest, str) or not rc_version_re.match(manifest):
         fail(
             "premain -> main promotion must carry a single-manifest RC "
-            f"with numbered -rc.N syntax; .release-please-manifest.json is {manifest!r}"
+            f"with X.Y.Z-rc or X.Y.Z-rc.N syntax; .release-please-manifest.json is {manifest!r}"
         )
     return manifest
 
@@ -293,7 +293,7 @@ pr_text = "\n\n".join([title, body])
 
 if base == "premain" and head == "release-please--branches--premain":
     if not rc_title_re.fullmatch(title):
-        fail(f"generated premain release-please PR must be numbered RC-shaped, got {title!r}")
+        fail(f"generated premain release-please PR must be RC-shaped, got {title!r}")
     print(f"promotion-release-driver: PASS (generated premain RC PR {title!r})")
     raise SystemExit(0)
 
@@ -311,7 +311,7 @@ if base == "premain":
     if invalid:
         fail(
             "staging -> premain Release-As footers must be RC-shaped "
-            f"X.Y.Z-rc.N, got {', '.join(invalid)}"
+            f"X.Y.Z-rc or X.Y.Z-rc.N, got {', '.join(invalid)}"
         )
     if versions:
         print(

--- a/scripts/verify-release-created-postcondition.sh
+++ b/scripts/verify-release-created-postcondition.sh
@@ -121,7 +121,7 @@ if [[ "${kind}" == "prerelease" ]]; then
   if [[ "${commit_message}" == *"release-please--branches--premain"* ]]; then
     generated=1
   fi
-  if [[ "${commit_message}" =~ chore\(premain\):[[:space:]]release[[:space:]]([0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+) ]]; then
+  if [[ "${commit_message}" =~ chore\(premain\):[[:space:]]release[[:space:]]([0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?)([^[:alnum:].-]|$) ]]; then
     generated=1
     release_version="${BASH_REMATCH[1]}"
   fi
@@ -142,8 +142,8 @@ if [[ "${kind}" == "prerelease" ]]; then
     fail "generated RC release PR merge created a release without tag_name"
   fi
 
-  if [[ ! "${tag_name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
-    fail "generated RC release PR merge produced non-numbered-RC tag_name ${tag_name}"
+  if [[ ! "${tag_name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]; then
+    fail "generated RC release PR merge produced non-RC tag_name ${tag_name}; expected X.Y.Z-rc or X.Y.Z-rc.N"
   fi
 
   if [[ -n "${release_version}" ]]; then

--- a/scripts/verify-release-lane-provenance.sh
+++ b/scripts/verify-release-lane-provenance.sh
@@ -225,7 +225,7 @@ pr_is_merged() {
 is_premain_release_please_rc_pr() {
   [[ "${base}" == "premain" ]] &&
     [[ "${head}" == "release-please--branches--premain" ]] &&
-    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]
+    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]
 }
 
 stale_merged_rc_pr_allowed=0
@@ -260,8 +260,8 @@ if [[ "${base}" == "premain" ]]; then
   if [[ "${head}" == "staging" ]]; then
     :
   elif [[ "${head}" == "release-please--branches--premain" ]]; then
-    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]] ||
-      fail "premain release-please PR must advertise a numbered RC version, got ${title@Q}"
+    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]] ||
+      fail "premain release-please PR must advertise an RC version (X.Y.Z-rc or X.Y.Z-rc.N), got ${title@Q}"
   else
     fail "premain PR head must be staging or release-please--branches--premain, got ${head@Q}"
   fi

--- a/scripts/verify-release-package-version-assets.py
+++ b/scripts/verify-release-package-version-assets.py
@@ -12,7 +12,7 @@ from email.parser import Parser
 from pathlib import Path
 
 
-VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-rc\.\d+)?$")
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-rc(?:\.\d+)?)?$")
 
 
 def release_version(raw: str) -> str:
@@ -22,15 +22,15 @@ def release_version(raw: str) -> str:
     if not VERSION_RE.fullmatch(version):
         raise SystemExit(
             "release-package-version-assets: FAIL "
-            f"(version must be stable X.Y.Z or numbered RC X.Y.Z-rc.N, got {raw!r})"
+            f"(version must be stable X.Y.Z or RC X.Y.Z-rc or X.Y.Z-rc.N, got {raw!r})"
         )
     return version
 
 
 def pep440(version: str) -> str:
-    match = re.fullmatch(r"(\d+\.\d+\.\d+)-rc\.(\d+)", version)
+    match = re.fullmatch(r"(\d+\.\d+\.\d+)-rc(?:\.(\d+))?", version)
     if match:
-        return f"{match.group(1)}rc{match.group(2)}"
+        return f"{match.group(1)}rc{match.group(2) or '0'}"
     return version
 
 
@@ -110,7 +110,7 @@ def read_sdist_metadata(sdist: Path) -> tuple[str, str]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--tag-name", help="GitHub release tag, e.g. v1.10.1-rc.1")
+    group.add_argument("--tag-name", help="GitHub release tag, e.g. v1.10.1-rc or v1.10.1-rc.1")
     group.add_argument("--version", help="Release version without leading v")
     parser.add_argument(
         "--assets-dir",

--- a/scripts/verify-release-package-version-build.sh
+++ b/scripts/verify-release-package-version-build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"
 
-versions=("9.9.9-rc.1" "9.9.9")
+versions=("9.9.9-rc" "9.9.9-rc.1" "9.9.9")
 if [[ "$#" -gt 0 ]]; then
   versions=()
   while [[ "$#" -gt 0 ]]; do
@@ -21,7 +21,7 @@ if [[ "$#" -gt 0 ]]; then
         ;;
       -h|--help)
         cat <<'USAGE'
-Usage: bash scripts/verify-release-package-version-build.sh [--version X.Y.Z[-rc.N] ...]
+Usage: bash scripts/verify-release-package-version-build.sh [--version X.Y.Z|X.Y.Z-rc|X.Y.Z-rc.N ...]
 
 Builds local TypeScript and Python package assets with synthetic tag-derived
 versions, verifies the packed metadata, and restores tracked source version


### PR DESCRIPTION
Promote the reviewed RC release-lane fixes from `staging` to `premain` so the existing release-please RC PR #353 can be regenerated/validated without TypeScript/Python/unit-cover fan-out on manifest/changelog-only changes and without numbered-RC-only publish-lane failures.

Factory evidence:
- PR #354 merged to `staging` at `e5c26aae6e306f6c4eee068b2cdea04f07d9b080` after green checks and adversarial review.
- PR #354 review evidence: `/home/aron/.claude/tmp/delegate-claude-session/20260705T225359Z-TableTheory-602531/final.md`.
- PR #356 merged to `staging` at `e1178795dd6df7130cc6558a875b1ee4848f4701` after green checks and adversarial review.
- PR #356 review evidence: `/home/aron/.claude/tmp/delegate-claude-session/20260706T000846Z-TableTheory-738234/final.md`.
- Release Hygiene previously failed on this PR because premain trusted-base asserted numbered-RC-only verifier text; PR #356 added protected-promotion RC-first marker fallback, and the refreshed PR #355 Release Hygiene check now passes.

Release note:
This is a release-lane repair promotion only; it is not v2.0.0 release proof. The existing release-please PR #353 remains the RC PR. After this promotion lands on `premain`, the premain prerelease workflows must rerun successfully before merging #353 or cutting the RC tag.
