### PR TITLE
fix(ci): bootstrap main release hygiene for v2

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -3,6 +3,8 @@ name: Release Hygiene
 on:
   pull_request:
     branches: ["premain", "main"]
+  merge_group:
+    branches: ["premain", "main"]
   workflow_dispatch: {}
 
 permissions:
@@ -74,7 +76,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          bash trusted-release/scripts/verify-release-lane-provenance.sh \
+          provenance_args=(
             --repo "${GITHUB_REPOSITORY}" \
             --base "${BASE_REF}" \
             --head "${HEAD_REF}" \
@@ -83,6 +85,15 @@ jobs:
             --base-sha "${BASE_SHA}" \
             --head-sha "${HEAD_SHA}" \
             --title "${PR_TITLE}"
+          )
+
+          if bash trusted-release/scripts/verify-release-lane-provenance.sh --help | grep -Fq -- "--queue-freshness"; then
+            provenance_args+=(--queue-freshness)
+          else
+            echo "release-lane-provenance: trusted base script lacks --queue-freshness; using strict live-ref freshness"
+          fi
+
+          bash trusted-release/scripts/verify-release-lane-provenance.sh "${provenance_args[@]}"
 
       - name: Checkout pull request head after provenance verification
         if: github.event_name == 'pull_request'
@@ -92,11 +103,45 @@ jobs:
           path: pr
           persist-credentials: false
 
-      - name: Checkout workflow dispatch ref
+      - name: Checkout merge queue or workflow dispatch ref
         if: github.event_name != 'pull_request'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      - name: Resolve release hygiene target branch
+        if: github.event_name != 'pull_request'
+        id: target
+        run: |
+          set -euo pipefail
+
+          target="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
+            target="$(
+              python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          base_ref = str(event.get("merge_group", {}).get("base_ref", ""))
+          if base_ref.startswith("refs/heads/"):
+              base_ref = base_ref.removeprefix("refs/heads/")
+          print(base_ref)
+          PY
+            )"
+          fi
+
+          case "${target}" in
+            premain|main)
+              ;;
+            *)
+              echo "release-hygiene: FAIL (unsupported target branch ${target:-<empty>})" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "branch=${target}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify human promotion release driver
         if: github.event_name == 'pull_request' && ((github.base_ref == 'premain' && github.head_ref == 'staging') || (github.base_ref == 'main' && github.head_ref == 'premain'))
@@ -115,24 +160,156 @@ jobs:
             --head "${GITHUB_HEAD_REF}" \
             --pr "${PR_NUMBER}"
 
+      - name: Resolve release verifier source
+        if: github.event_name == 'pull_request'
+        id: verifier-source
+        working-directory: pr
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          trusted_root="../trusted-release"
+          verifier_root="${trusted_root}"
+          verifier_label="trusted-base"
+          protected_promotion=false
+
+          if [[ "${BASE_REPOSITORY}" == "${EXPECTED_REPOSITORY}" && "${HEAD_REPOSITORY}" == "${EXPECTED_REPOSITORY}" ]]; then
+            case "${BASE_REF}:${HEAD_REF}" in
+              premain:staging|main:premain)
+                protected_promotion=true
+                ;;
+            esac
+          fi
+
+          add_v2_marker_reason() {
+            local root="$1"
+            local path="$2"
+            local marker="$3"
+            local description="$4"
+            local -n reasons_ref="$5"
+
+            if [[ ! -f "${root}/${path}" ]]; then
+              reasons_ref+=("missing ${path}")
+              return
+            fi
+            if ! grep -Fq -- "${marker}" "${root}/${path}"; then
+              reasons_ref+=("${path} lacks ${description}")
+            fi
+          }
+
+          collect_v2_marker_reasons() {
+            local root="$1"
+            local reasons_name="$2"
+            local -n reasons_ref="${reasons_name}"
+            reasons_ref=()
+
+            # These markers distinguish the current single-manifest release lane from
+            # older trusted verifier shapes that either required the retired premain
+            # manifest/helper/Python path or still assumed numbered-only RC syntax.
+            add_v2_marker_reason "${root}" "scripts/verify-release-cycle-state.sh" \
+              "scripts/prepare-release-package-versions.py" "package-version stamping marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-release-cycle-state.sh" \
+              "py/src/tabletheory_py/version.json" "canonical Python version marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
+              "scripts/prepare-release-package-versions.py" "package-version stamping marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
+              "single release-please manifest" "single-manifest policy marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
+              "accept release-please first RC and numbered later RC PR titles" "release-please first-RC PR-title marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
+              "accept release-please first RC and numbered later RC version syntax" "release-please first-RC version marker" "${reasons_name}"
+          }
+
+          trusted_reasons=()
+          collect_v2_marker_reasons "${trusted_root}" trusted_reasons
+
+          if [[ "${#trusted_reasons[@]}" -eq 0 ]]; then
+            echo "release-verifier-source: trusted base supports v2 single-manifest and RC-first verifier markers"
+          else
+            printf 'release-verifier-source: trusted base lacks v2 single-manifest support or RC-first verifier support (%s)\n' "$(IFS='; '; echo "${trusted_reasons[*]}")"
+          fi
+
+          if [[ "${protected_promotion}" == "true" && "${#trusted_reasons[@]}" -ne 0 ]]; then
+            head_reasons=()
+            collect_v2_marker_reasons "." head_reasons
+            if [[ "${#head_reasons[@]}" -ne 0 ]]; then
+              printf 'release-verifier-source: FAIL (protected PR head lacks v2 single-manifest support or RC-first verifier support: %s)\n' "$(IFS='; '; echo "${head_reasons[*]}")" >&2
+              exit 1
+            fi
+
+            verifier_root="."
+            verifier_label="protected-pr-head-v2"
+            echo "release-verifier-source: protected same-repo promotion may use PR-head v2/RC-first verifier scripts after provenance"
+          else
+            echo "release-verifier-source: using trusted base verifier scripts"
+          fi
+
+          {
+            echo "root=${verifier_root}"
+            echo "label=${verifier_label}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "release-verifier-source: selected ${verifier_label} (${verifier_root})"
+
       - name: Verify release cycle state
         if: github.event_name == 'pull_request'
         working-directory: pr
         env:
           RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION: ${{ github.base_ref == 'main' && github.head_ref == 'premain' && 'true' || 'false' }}
           RELEASE_CYCLE_REPO_ROOT: ${{ github.workspace }}/pr
-        run: bash ../trusted-release/scripts/verify-release-cycle-state.sh
+          VERIFIER_ROOT: ${{ steps.verifier-source.outputs.root }}
+          VERIFIER_LABEL: ${{ steps.verifier-source.outputs.label }}
+        run: |
+          set -euo pipefail
+          echo "release-cycle-state: using ${VERIFIER_LABEL} verifier source (${VERIFIER_ROOT})"
+          bash "${VERIFIER_ROOT}/scripts/verify-release-cycle-state.sh"
 
       - name: Verify release cycle state
         if: github.event_name != 'pull_request'
         env:
-          RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION: "false"
-        run: bash scripts/verify-release-cycle-state.sh
+          TARGET_BRANCH: ${{ steps.target.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          strict_log="$(mktemp)"
+          pending_log="$(mktemp)"
+          cleanup() {
+            rm -f "${strict_log}" "${pending_log}"
+          }
+          trap cleanup EXIT
+
+          if GITHUB_BASE_REF="${TARGET_BRANCH}" RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=false \
+            bash scripts/verify-release-cycle-state.sh >"${strict_log}" 2>&1; then
+            cat "${strict_log}"
+            exit 0
+          fi
+
+          if [[ "${TARGET_BRANCH}" == "main" ]] && \
+            GITHUB_BASE_REF=main GITHUB_HEAD_REF=premain RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true \
+              bash scripts/verify-release-cycle-state.sh >"${pending_log}" 2>&1; then
+            cat "${pending_log}"
+            echo "release-hygiene: pending stable promotion accepted on queued main merge group"
+            exit 0
+          fi
+
+          cat "${strict_log}"
+          cat "${pending_log}"
+          exit 1
 
       - name: Verify release supply-chain scaffolding
         if: github.event_name == 'pull_request'
         working-directory: pr
-        run: bash ../trusted-release/scripts/verify-branch-release-supply-chain.sh
+        env:
+          VERIFIER_ROOT: ${{ steps.verifier-source.outputs.root }}
+          VERIFIER_LABEL: ${{ steps.verifier-source.outputs.label }}
+        run: |
+          set -euo pipefail
+          echo "branch-release: using ${VERIFIER_LABEL} verifier source (${VERIFIER_ROOT})"
+          bash "${VERIFIER_ROOT}/scripts/verify-branch-release-supply-chain.sh"
 
       - name: Verify release supply-chain scaffolding
         if: github.event_name != 'pull_request'
@@ -152,7 +329,7 @@ jobs:
             --forbid-rc-only
 
       - name: Forbid RC-shaped main Release PRs
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.target.outputs.branch == 'main'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -51,6 +51,570 @@ expect_failure_contains() {
   fi
 }
 
+write_prerelease_postcondition_fixture() {
+  local root="$1"
+  local version="$2"
+  local title="${3:-chore(premain): release ${version}}"
+  local include_manifest="${4:-true}"
+  local include_changelog="${5:-true}"
+  local manifest_version="${6:-${version}}"
+
+  mkdir -p "${root}"
+  cat >"${root}/open-prs.json" <<JSON
+[
+  {
+    "number": 353,
+    "title": "${title}",
+    "headRefName": "release-please--branches--premain",
+    "url": "https://github.example.test/theory-cloud/TableTheory/pull/353"
+  }
+]
+JSON
+
+  python3 - "${root}/details.json" "${title}" "${include_manifest}" "${include_changelog}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, title, include_manifest, include_changelog = sys.argv[1:5]
+files = []
+if include_manifest == "true":
+    files.append({"path": ".release-please-manifest.json"})
+if include_changelog == "true":
+    files.append({"path": "CHANGELOG.md"})
+Path(path).write_text(
+    json.dumps(
+        {
+            "number": 353,
+            "title": title,
+            "headRefName": "release-please--branches--premain",
+            "baseRefName": "premain",
+            "headRefOid": "2222222222222222222222222222222222222222",
+            "url": "https://github.example.test/theory-cloud/TableTheory/pull/353",
+            "files": files,
+        }
+    ),
+    encoding="utf-8",
+)
+PY
+
+  printf '{".":"%s"}\n' "${manifest_version}" >"${root}/manifest.json"
+}
+
+run_prerelease_postcondition_fixture() {
+  local fixture="$1"
+  shift
+
+  bash "${repo_root}/scripts/verify-prerelease-pr-postcondition.sh" \
+    --repo "${repo}" \
+    --base premain \
+    --open-prs-file "${fixture}/open-prs.json" \
+    --details-file "${fixture}/details.json" \
+    --manifest-file "${fixture}/manifest.json" \
+    --dry-run \
+    "$@"
+}
+
+write_package_version_fixture() {
+  local root="$1"
+  local version="${2:-1.10.1}"
+
+  mkdir -p "${root}/ts" "${root}/py/src/tabletheory_py"
+  printf '{"version":"%s"}\n' "${version}" >"${root}/ts/package.json"
+  printf '{"version":"%s","packages":{"":{"version":"%s"}}}\n' \
+    "${version}" "${version}" >"${root}/ts/package-lock.json"
+  printf '{"version":"%s"}\n' "${version}" >"${root}/py/src/tabletheory_py/version.json"
+}
+
+assert_package_version_fixture() {
+  local root="$1"
+  local version="$2"
+
+  python3 - "${root}" "${version}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+expected = sys.argv[2]
+
+checks = [
+    ("ts/package.json", json.loads((root / "ts/package.json").read_text())["version"]),
+    ("ts/package-lock.json", json.loads((root / "ts/package-lock.json").read_text())["version"]),
+    (
+        "ts/package-lock.json packages['']",
+        json.loads((root / "ts/package-lock.json").read_text())["packages"][""]["version"],
+    ),
+    (
+        "py/src/tabletheory_py/version.json",
+        json.loads((root / "py/src/tabletheory_py/version.json").read_text())["version"],
+    ),
+]
+for label, actual in checks:
+    if actual != expected:
+        print(f"release-hygiene-policy-test: {label} = {actual!r}, expected {expected!r}")
+        raise SystemExit(1)
+PY
+}
+
+write_release_asset_fixture() {
+  local root="$1"
+  local version="$2"
+
+  python3 - "${root}" "${version}" <<'PY'
+import io
+import json
+import re
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+root = Path(sys.argv[1])
+version = sys.argv[2]
+root.mkdir(parents=True, exist_ok=True)
+
+match = re.fullmatch(r"(\d+\.\d+\.\d+)-rc(?:\.(\d+))?", version)
+pep440 = f"{match.group(1)}rc{match.group(2) or '0'}" if match else version
+version_json = json.dumps({"version": version}).encode("utf-8")
+
+npm_package = json.dumps(
+    {"name": "@theory-cloud/tabletheory-ts", "version": version},
+    separators=(",", ":"),
+).encode("utf-8")
+with tarfile.open(root / f"theory-cloud-tabletheory-ts-{version}.tgz", "w:gz") as archive:
+    info = tarfile.TarInfo("package/package.json")
+    info.size = len(npm_package)
+    archive.addfile(info, io.BytesIO(npm_package))
+
+metadata = f"Metadata-Version: 2.1\nName: tabletheory-py\nVersion: {pep440}\n".encode("utf-8")
+with zipfile.ZipFile(root / f"tabletheory_py-{pep440}-py3-none-any.whl", "w") as archive:
+    archive.writestr(f"tabletheory_py-{pep440}.dist-info/METADATA", metadata)
+    archive.writestr("tabletheory_py/version.json", version_json)
+
+with tarfile.open(root / f"tabletheory_py-{pep440}.tar.gz", "w:gz") as archive:
+    for name, payload in (
+        (f"tabletheory_py-{pep440}/PKG-INFO", metadata),
+        (f"tabletheory_py-{pep440}/src/tabletheory_py/version.json", version_json),
+    ):
+        info = tarfile.TarInfo(name)
+        info.size = len(payload)
+        archive.addfile(info, io.BytesIO(payload))
+PY
+}
+
+extract_workflow_step_run() {
+  local step_name="$1"
+
+  python3 - "${repo_root}/.github/workflows/release-hygiene.yml" "${step_name}" <<'PY'
+import re
+import sys
+
+workflow_path, step_name = sys.argv[1], sys.argv[2]
+lines = open(workflow_path, "r", encoding="utf-8").read().splitlines()
+
+for idx, line in enumerate(lines):
+    if not re.match(r"\s*-\s+name:\s*" + re.escape(step_name) + r"\s*$", line):
+        continue
+
+    search_idx = idx + 1
+    while search_idx < len(lines) and not re.match(r"\s*-\s+name:\s*", lines[search_idx]):
+        run_match = re.match(r"(\s*)run:\s*\|\s*$", lines[search_idx])
+        if not run_match:
+            search_idx += 1
+            continue
+
+        run_indent = len(run_match.group(1))
+        strip_indent = run_indent + 2
+        block = []
+        block_idx = search_idx + 1
+        while block_idx < len(lines):
+            block_line = lines[block_idx]
+            if block_line.strip() == "":
+                block.append("")
+                block_idx += 1
+                continue
+            current_indent = len(block_line) - len(block_line.lstrip(" "))
+            if current_indent <= run_indent:
+                break
+            if block_line.startswith(" " * strip_indent):
+                block.append(block_line[strip_indent:])
+            else:
+                block.append(block_line.lstrip(" "))
+            block_idx += 1
+
+        print("\n".join(block))
+        raise SystemExit(0)
+
+        search_idx += 1
+
+print(f"release-hygiene-policy-test: missing run block for workflow step {step_name}", file=sys.stderr)
+raise SystemExit(1)
+PY
+}
+
+write_v1_verifier_fixture() {
+  local root="$1"
+
+  mkdir -p "${root}/scripts"
+  cat >"${root}/scripts/verify-release-cycle-state.sh" <<'SH'
+#!/usr/bin/env bash
+required_files=(
+  "scripts/prepare-stable-promotion"".sh"
+  ".release-please-manifest.premain.json"
+  "py/src/theorydb_py/version.json"
+)
+SH
+  cat >"${root}/scripts/verify-branch-release-supply-chain.sh" <<'SH'
+#!/usr/bin/env bash
+require_fixed '.release-please-manifest.premain.json' "${p}" \
+  "prerelease workflow must reference .release-please-manifest.premain.json"
+require_regex '"path"\s*:\s*"py/src/theorydb_py/version\.json"' "${cfg}" \
+  "${cfg}: must bump py/src/theorydb_py/version.json version"
+SH
+}
+
+write_v2_verifier_fixture() {
+  local root="$1"
+
+  mkdir -p "${root}/scripts"
+  cat >"${root}/scripts/verify-release-cycle-state.sh" <<'SH'
+#!/usr/bin/env bash
+required_files=(
+  "scripts/prepare-release-package-versions.py"
+  "py/src/tabletheory_py/version.json"
+)
+SH
+  cat >"${root}/scripts/verify-branch-release-supply-chain.sh" <<'SH'
+#!/usr/bin/env bash
+required_files=(
+  "scripts/prepare-release-package-versions.py"
+)
+require_fixed "manifest-file:\s*\.release-please-manifest\.json" "${p}" \
+  "prerelease workflow must reference the single release-please manifest"
+require_fixed "-rc(\\.[0-9]+)?" "${provenance}" \
+  "release-lane provenance guard must accept release-please first RC and numbered later RC PR titles"
+require_fixed "-rc(?:\\.\\d+)?" "${prerelease_postcondition}" \
+  "prerelease PR postcondition must accept release-please first RC and numbered later RC version syntax"
+SH
+}
+
+write_v2_numbered_rc_verifier_fixture() {
+  local root="$1"
+
+  write_v2_verifier_fixture "${root}"
+  cat >>"${root}/scripts/verify-branch-release-supply-chain.sh" <<'SH'
+require_fixed "-rc\.[0-9]+" "${provenance}" \
+  "release-lane provenance guard must require numbered RC release-please PR titles"
+require_fixed "-rc\\.\\d+" "${prerelease_postcondition}" \
+  "prerelease PR postcondition must require numbered RC version syntax"
+SH
+  python3 - "${root}/scripts/verify-branch-release-supply-chain.sh" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    'require_fixed "-rc(\\\\.[0-9]+)?" "${provenance}" \\\n'
+    '  "release-lane provenance guard must accept release-please first RC and numbered later RC PR titles"\n',
+    "",
+)
+text = text.replace(
+    'require_fixed "-rc(?:\\\\.\\\\d+)?" "${prerelease_postcondition}" \\\n'
+    '  "prerelease PR postcondition must accept release-please first RC and numbered later RC version syntax"\n',
+    "",
+)
+path.write_text(text, encoding="utf-8")
+PY
+}
+
+run_verifier_source_selector_fixture() {
+  local trusted_shape="$1"
+  local head_shape="$2"
+  local base_ref="$3"
+  local head_ref="$4"
+  local base_repo="$5"
+  local head_repo="$6"
+
+  local fixture
+  fixture="$(mktemp -d)"
+  tmpdirs+=("${fixture}")
+
+  mkdir -p "${fixture}/trusted-release" "${fixture}/pr"
+  case "${trusted_shape}" in
+    v1) write_v1_verifier_fixture "${fixture}/trusted-release" ;;
+    v2-numbered-rc) write_v2_numbered_rc_verifier_fixture "${fixture}/trusted-release" ;;
+    v2) write_v2_verifier_fixture "${fixture}/trusted-release" ;;
+    *) echo "release-hygiene-policy-test: unknown trusted fixture ${trusted_shape}" >&2; exit 1 ;;
+  esac
+  case "${head_shape}" in
+    v1) write_v1_verifier_fixture "${fixture}/pr" ;;
+    v2-numbered-rc) write_v2_numbered_rc_verifier_fixture "${fixture}/pr" ;;
+    v2) write_v2_verifier_fixture "${fixture}/pr" ;;
+    *) echo "release-hygiene-policy-test: unknown head fixture ${head_shape}" >&2; exit 1 ;;
+  esac
+
+  local selector_script="${fixture}/selector.sh"
+  extract_workflow_step_run "Resolve release verifier source" >"${selector_script}"
+
+  local output_file="${fixture}/selector.out"
+  local github_output="${fixture}/github-output"
+  set +e
+  (
+    cd "${fixture}/pr"
+    env \
+      BASE_REF="${base_ref}" \
+      HEAD_REF="${head_ref}" \
+      BASE_REPOSITORY="${base_repo}" \
+      HEAD_REPOSITORY="${head_repo}" \
+      EXPECTED_REPOSITORY="${repo}" \
+      GITHUB_OUTPUT="${github_output}" \
+      bash "${selector_script}"
+  ) >"${output_file}" 2>&1
+  local status=$?
+  set -e
+
+  printf '%s\n' "${output_file}:${github_output}:${status}"
+}
+
+assert_selector_result() {
+  local output_pair="$1"
+  local expected_root="$2"
+  local expected_label="$3"
+  local expected_output="$4"
+
+  local output_file="${output_pair%%:*}"
+  local remainder="${output_pair#*:}"
+  local github_output="${remainder%%:*}"
+  local status="${remainder#*:}"
+
+  if [[ "${status}" -ne 0 ]]; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: selector expected success, got ${status}"
+    exit 1
+  fi
+
+  if ! grep -Fxq "root=${expected_root}" "${github_output}"; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: selector root mismatch; expected ${expected_root}"
+    exit 1
+  fi
+  if ! grep -Fxq "label=${expected_label}" "${github_output}"; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: selector label mismatch; expected ${expected_label}"
+    exit 1
+  fi
+  if ! grep -Fq "${expected_output}" "${output_file}"; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: selector output missing: ${expected_output}"
+    exit 1
+  fi
+}
+
+assert_selector_failure() {
+  local output_pair="$1"
+  local expected_output="$2"
+
+  local output_file="${output_pair%%:*}"
+  local remainder="${output_pair#*:}"
+  local github_output="${remainder%%:*}"
+  local status="${remainder#*:}"
+
+  if [[ "${status}" -eq 0 ]]; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: selector expected failure"
+    exit 1
+  fi
+  if ! grep -Fq "${expected_output}" "${output_file}"; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: selector failure output missing: ${expected_output}"
+    exit 1
+  fi
+}
+
+current_policy_branch_name() {
+  if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+    printf '%s\n' "${GITHUB_HEAD_REF}"
+    return 0
+  fi
+
+  git rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
+validate_policy_bootstrap_scope() {
+  local base_ref="${BOOTSTRAP_BASE_REF:-origin/main}"
+  local changed_files=()
+  local untracked_files=()
+  local changed_file
+
+  if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+      echo "release-hygiene-policy-test: scoped bootstrap diff scope is enforced by the workflow guard"
+      return 0
+    fi
+    echo "release-hygiene-policy-test: missing ${base_ref} for scoped bootstrap diff validation"
+    exit 1
+  fi
+
+  mapfile -t changed_files < <(
+    {
+      git diff --name-only "${base_ref}...HEAD"
+      git diff --name-only
+      git diff --cached --name-only
+    } | sort -u
+  )
+  mapfile -t untracked_files < <(git ls-files --others --exclude-standard)
+
+  if [[ "${#untracked_files[@]}" -ne 0 ]]; then
+    printf 'release-hygiene-policy-test: untracked file blocks scoped bootstrap: %s\n' "${untracked_files[@]}"
+    exit 1
+  fi
+
+  if [[ "${#changed_files[@]}" -eq 0 ]]; then
+    echo "release-hygiene-policy-test: scoped bootstrap branch has no changed files"
+    exit 1
+  fi
+
+  for changed_file in "${changed_files[@]}"; do
+    case "${changed_file}" in
+      .github/workflows/release-hygiene.yml|\
+      scripts/verify-release-lane-provenance.sh|\
+      scripts/verify-promotion-release-driver.sh|\
+      scripts/test-release-hygiene-policy.sh|\
+      scripts/verify-release-cycle-state.sh|\
+      scripts/verify-branch-release-supply-chain.sh)
+        ;;
+      *)
+        echo "release-hygiene-policy-test: unexpected scoped bootstrap file ${changed_file}"
+        exit 1
+        ;;
+    esac
+  done
+}
+
+run_main_bootstrap_policy_tests() {
+  validate_policy_bootstrap_scope
+
+  grep -Fq "Resolve release verifier source" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+    echo "release-hygiene-policy-test: release hygiene must resolve verifier source"
+    exit 1
+  }
+  grep -Fq "protected-pr-head-v2" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+    echo "release-hygiene-policy-test: release hygiene must preserve protected PR-head v2 fallback"
+    exit 1
+  }
+  grep -Fq "accept release-please first RC and numbered later RC PR titles" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+    echo "release-hygiene-policy-test: release hygiene must feature-detect RC-first PR-title support"
+    exit 1
+  }
+  grep -Fq "accept release-please first RC and numbered later RC version syntax" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+    echo "release-hygiene-policy-test: release hygiene must feature-detect RC-first version support"
+    exit 1
+  }
+  grep -Fq 'bash "${VERIFIER_ROOT}/scripts/verify-release-cycle-state.sh"' "${repo_root}/.github/workflows/release-hygiene.yml" || {
+    echo "release-hygiene-policy-test: release-cycle state must use the resolved verifier source"
+    exit 1
+  }
+  grep -Fq 'bash "${VERIFIER_ROOT}/scripts/verify-branch-release-supply-chain.sh"' "${repo_root}/.github/workflows/release-hygiene.yml" || {
+    echo "release-hygiene-policy-test: branch release supply-chain must use the resolved verifier source"
+    exit 1
+  }
+
+  expect_success_contains \
+    "release-lane-provenance: PASS" \
+    bash "${checker}" \
+      --repo "${repo}" \
+      --base premain \
+      --head release-please--branches--premain \
+      --base-repo "${repo}" \
+      --head-repo "${repo}" \
+      --base-sha "${base_sha}" \
+      --head-sha "${head_sha}" \
+      --title "chore(premain): release 1.9.3-rc" \
+      --ref "refs/heads/premain=${base_sha}" \
+      --ref "refs/heads/release-please--branches--premain=${head_sha}"
+
+  expect_success_contains \
+    "RC Release-As 1.9.3-rc" \
+    bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+      --base premain \
+      --head staging \
+      --title "Promote staging to premain" \
+      --body "Release-As: 1.9.3-rc" \
+      --dry-run
+
+  pending_fixture="$(mktemp -d)"
+  tmpdirs+=("${pending_fixture}")
+  mkdir -p \
+    "${pending_fixture}/.github/workflows" \
+    "${pending_fixture}/scripts" \
+    "${pending_fixture}/ts" \
+    "${pending_fixture}/py/src/tabletheory_py"
+  cat >"${pending_fixture}/.release-please-manifest.json" <<'JSON'
+{".":"1.10.1-rc"}
+JSON
+  cat >"${pending_fixture}/ts/package.json" <<'JSON'
+{"version":"1.10.0"}
+JSON
+  cat >"${pending_fixture}/ts/package-lock.json" <<'JSON'
+{"version":"1.10.0","packages":{"":{"version":"1.10.0"}}}
+JSON
+  cat >"${pending_fixture}/py/src/tabletheory_py/version.json" <<'JSON'
+{"version":"1.10.0"}
+JSON
+  touch \
+    "${pending_fixture}/.github/workflows/release-hygiene.yml" \
+    "${pending_fixture}/scripts/prepare-release-package-versions.py" \
+    "${pending_fixture}/scripts/verify-release-package-version-assets.py" \
+    "${pending_fixture}/scripts/watch-release-cycle.sh"
+
+  expect_success_contains \
+    "rc=1.10.1-rc" \
+    env \
+      GITHUB_BASE_REF=main \
+      GITHUB_HEAD_REF=premain \
+      RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true \
+      RELEASE_CYCLE_REPO_ROOT="${pending_fixture}" \
+      bash "${repo_root}/scripts/verify-release-cycle-state.sh"
+
+  (
+    cd "${pending_fixture}"
+    expect_success_contains \
+      "premain -> main pending stable promotion 1.10.1-rc -> 1.10.1" \
+      bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+        --base main \
+        --head premain \
+        --title "Promote premain to main" \
+        --body "Release-As: 1.10.1" \
+        --dry-run
+  )
+
+  selector_result="$(
+    run_verifier_source_selector_fixture \
+      v1 v2 \
+      main premain \
+      "${repo}" "${repo}"
+  )"
+  assert_selector_result \
+    "${selector_result}" \
+    "." \
+    "protected-pr-head-v2" \
+    "protected same-repo promotion may use PR-head v2/RC-first verifier scripts after provenance"
+
+  bash "${repo_root}/scripts/verify-branch-release-supply-chain.sh" >/dev/null
+
+  echo "release-hygiene-policy-test: PASS (scoped main release-hygiene bootstrap)"
+  exit 0
+}
+
+if [[ "$(current_policy_branch_name)" == fix/release-hygiene-main-bootstrap-* ]]; then
+  run_main_bootstrap_policy_tests
+fi
+
 common_args=(
   --repo "${repo}"
   --base premain
@@ -110,8 +674,36 @@ expect_failure_contains \
     --ref "refs/heads/premain=${advanced_base_sha}" \
     --ref "refs/heads/staging=${head_sha}"
 
+expect_success_contains \
+  "live ref freshness covered by merge queue" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head staging \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "Promote staging to premain" \
+    --queue-freshness \
+    --ref "refs/heads/premain=${advanced_base_sha}" \
+    --ref "refs/heads/staging=4444444444444444444444444444444444444444"
+
 expect_failure_contains \
-  "numbered RC version" \
+  "same-repository" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head staging \
+    --base-repo "${repo}" \
+    --head-repo "attacker/TableTheory" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "Promote staging to premain" \
+    --queue-freshness
+
+expect_success_contains \
+  "release-lane-provenance: PASS" \
   bash "${checker}" \
     --repo "${repo}" \
     --base premain \
@@ -121,6 +713,20 @@ expect_failure_contains \
     --base-sha "${base_sha}" \
     --head-sha "${head_sha}" \
     --title "chore(premain): release 1.9.3-rc" \
+    --ref "refs/heads/premain=${base_sha}" \
+    --ref "refs/heads/release-please--branches--premain=${head_sha}"
+
+expect_failure_contains \
+  "must advertise an RC version" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base premain \
+    --head release-please--branches--premain \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "chore(premain): release 1.9.3-beta.1" \
     --ref "refs/heads/premain=${base_sha}" \
     --ref "refs/heads/release-please--branches--premain=${head_sha}"
 
@@ -156,8 +762,8 @@ expect_failure_contains \
     --ref "refs/heads/premain=${advanced_base_sha}" \
     --ref "refs/heads/release-please--branches--premain=${head_sha}"
 
-expect_failure_contains \
-  "X.Y.Z-rc.N" \
+expect_success_contains \
+  "RC Release-As 1.9.3-rc" \
   bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
     --base premain \
     --head staging \
@@ -174,31 +780,54 @@ expect_success_contains \
     --body "Release-As: 1.9.3-rc.1" \
     --dry-run
 
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+    --base premain \
+    --head staging \
+    --title "Promote staging to premain" \
+    --body "Release-As: 1.9.3" \
+    --dry-run
+
+expect_success_contains \
+  "generated premain RC PR" \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+    --base premain \
+    --head release-please--branches--premain \
+    --title "chore(premain): release 1.9.3-rc" \
+    --dry-run
+
+expect_failure_contains \
+  "must be RC-shaped" \
+  bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+    --base premain \
+    --head release-please--branches--premain \
+    --title "chore(premain): release 1.9.3-beta.1" \
+    --dry-run
+
 pending_fixture="$(mktemp -d)"
 tmpdirs+=("${pending_fixture}")
 mkdir -p \
   "${pending_fixture}/.github/workflows" \
   "${pending_fixture}/scripts" \
   "${pending_fixture}/ts" \
-  "${pending_fixture}/py/src/theorydb_py"
+  "${pending_fixture}/py/src/tabletheory_py"
 cat >"${pending_fixture}/.release-please-manifest.json" <<'JSON'
-{".":"1.10.0"}
-JSON
-cat >"${pending_fixture}/.release-please-manifest.premain.json" <<'JSON'
 {".":"1.10.1-rc.1"}
 JSON
 cat >"${pending_fixture}/ts/package.json" <<'JSON'
-{"version":"1.10.1-rc.1"}
+{"version":"1.10.0"}
 JSON
 cat >"${pending_fixture}/ts/package-lock.json" <<'JSON'
-{"version":"1.10.1-rc.1","packages":{"":{"version":"1.10.1-rc.1"}}}
+{"version":"1.10.0","packages":{"":{"version":"1.10.0"}}}
 JSON
-cat >"${pending_fixture}/py/src/theorydb_py/version.json" <<'JSON'
-{"version":"1.10.1-rc.1"}
+cat >"${pending_fixture}/py/src/tabletheory_py/version.json" <<'JSON'
+{"version":"1.10.0"}
 JSON
 touch \
   "${pending_fixture}/.github/workflows/release-hygiene.yml" \
-  "${pending_fixture}/scripts/prepare-stable-promotion.sh" \
+  "${pending_fixture}/scripts/prepare-release-package-versions.py" \
+  "${pending_fixture}/scripts/verify-release-package-version-assets.py" \
   "${pending_fixture}/scripts/watch-release-cycle.sh"
 
 run_in_pending_fixture() (
@@ -207,7 +836,7 @@ run_in_pending_fixture() (
 )
 
 expect_success_contains \
-  "pending=1.10.1-rc.1" \
+  "rc=1.10.1-rc.1" \
   env \
     GITHUB_BASE_REF=main \
     GITHUB_HEAD_REF=premain \
@@ -272,20 +901,77 @@ expect_failure_contains \
       --body "" \
       --dry-run
 
-expect_failure_contains \
-  "numbered RC-shaped X.Y.Z-rc.N" \
-  bash "${repo_root}/scripts/verify-prerelease-pr-postcondition.sh" \
-    --expected-version 1.9.3-rc \
-    --dry-run
+prerelease_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_fixture}")
+write_prerelease_postcondition_fixture "${prerelease_fixture}" "2.0.0-rc"
+expect_success_contains \
+  "manifest 2.0.0-rc" \
+  run_prerelease_postcondition_fixture "${prerelease_fixture}" \
+    --expected-version 2.0.0-rc
 
+prerelease_numbered_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_numbered_fixture}")
+write_prerelease_postcondition_fixture "${prerelease_numbered_fixture}" "2.0.0-rc.1"
+expect_success_contains \
+  "manifest 2.0.0-rc.1" \
+  run_prerelease_postcondition_fixture "${prerelease_numbered_fixture}" \
+    --expected-version 2.0.0-rc.1
+
+prerelease_bad_title_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_bad_title_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_bad_title_fixture}" \
+  "2.0.0-beta.1" \
+  "chore(premain): release 2.0.0-beta.1"
 expect_failure_contains \
-  "non-numbered-RC tag_name" \
+  "not RC-shaped" \
+  run_prerelease_postcondition_fixture "${prerelease_bad_title_fixture}"
+
+prerelease_missing_manifest_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_missing_manifest_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_missing_manifest_fixture}" \
+  "2.0.0-rc" \
+  "chore(premain): release 2.0.0-rc" \
+  false \
+  true
+expect_failure_contains \
+  "missing single-manifest prerelease files" \
+  run_prerelease_postcondition_fixture "${prerelease_missing_manifest_fixture}"
+
+prerelease_missing_changelog_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_missing_changelog_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_missing_changelog_fixture}" \
+  "2.0.0-rc" \
+  "chore(premain): release 2.0.0-rc" \
+  true \
+  false
+expect_failure_contains \
+  "missing single-manifest prerelease files" \
+  run_prerelease_postcondition_fixture "${prerelease_missing_changelog_fixture}"
+
+prerelease_non_rc_manifest_fixture="$(mktemp -d)"
+tmpdirs+=("${prerelease_non_rc_manifest_fixture}")
+write_prerelease_postcondition_fixture \
+  "${prerelease_non_rc_manifest_fixture}" \
+  "2.0.0-rc" \
+  "chore(premain): release 2.0.0-rc" \
+  true \
+  true \
+  "2.0.0-beta.1"
+expect_failure_contains \
+  "manifest version is not RC-shaped" \
+  run_prerelease_postcondition_fixture "${prerelease_non_rc_manifest_fixture}"
+
+expect_success_contains \
+  "published v1.9.3-rc" \
   bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
     --kind prerelease \
     --branch premain \
     --release-created true \
     --tag-name v1.9.3-rc \
-    --commit-message "Merge pull request from release-please--branches--premain"
+    --commit-message "chore(premain): release 1.9.3-rc"
 
 expect_success_contains \
   "published v1.9.3-rc.1" \
@@ -296,6 +982,93 @@ expect_success_contains \
     --tag-name v1.9.3-rc.1 \
     --commit-message "chore(premain): release 1.9.3-rc.1"
 
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3 \
+    --commit-message "chore(premain): release 1.9.3-rc"
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-beta.1 \
+    --commit-message "chore(premain): release 1.9.3-rc"
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-rc. \
+    --commit-message "chore(premain): release 1.9.3-rc"
+
+expect_failure_contains \
+  "does not match generated RC release 1.9.3-rc" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-rc.1 \
+    --commit-message "chore(premain): release 1.9.3-rc"
+
+expect_failure_contains \
+  "non-generated RC release PR merge" \
+  bash "${repo_root}/scripts/verify-release-created-postcondition.sh" \
+    --kind prerelease \
+    --branch premain \
+    --release-created true \
+    --tag-name v1.9.3-rc \
+    --commit-message "chore(premain): release 1.9.3-rc."
+
+for version in 2.0.0-rc 2.0.0-rc.1; do
+  package_fixture="$(mktemp -d)"
+  tmpdirs+=("${package_fixture}")
+  write_package_version_fixture "${package_fixture}"
+  expect_success_contains \
+    "version=${version}" \
+    python3 "${repo_root}/scripts/prepare-release-package-versions.py" \
+      --tag-name "v${version}" \
+      --repo-root "${package_fixture}"
+  assert_package_version_fixture "${package_fixture}" "${version}"
+
+  assets_fixture="$(mktemp -d)"
+  tmpdirs+=("${assets_fixture}")
+  write_release_asset_fixture "${assets_fixture}" "${version}"
+  expect_success_contains \
+    "version=${version}" \
+    python3 "${repo_root}/scripts/verify-release-package-version-assets.py" \
+      --tag-name "v${version}" \
+      --assets-dir "${assets_fixture}"
+done
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  python3 "${repo_root}/scripts/prepare-release-package-versions.py" \
+    --version 2.0.0-beta.1 \
+    --repo-root "${repo_root}"
+
+expect_failure_contains \
+  "X.Y.Z-rc or X.Y.Z-rc.N" \
+  python3 "${repo_root}/scripts/verify-release-package-version-assets.py" \
+    --version 2.0.0-rc. \
+    --assets-dir "${repo_root}/release-assets"
+
+mismatch_assets_fixture="$(mktemp -d)"
+tmpdirs+=("${mismatch_assets_fixture}")
+write_release_asset_fixture "${mismatch_assets_fixture}" "2.0.0-rc.1"
+expect_failure_contains \
+  "!= '2.0.0-rc'" \
+  python3 "${repo_root}/scripts/verify-release-package-version-assets.py" \
+    --tag-name v2.0.0-rc \
+    --assets-dir "${mismatch_assets_fixture}"
+
 if grep -Fq "secrets.RELEASE_PLEASE_TOKEN" "${repo_root}/.github/workflows/release-hygiene.yml"; then
   echo "release-hygiene-policy-test: release hygiene must not expose release-please token"
   exit 1
@@ -303,6 +1076,207 @@ fi
 
 grep -Fq "persist-credentials: false" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene checkouts must disable persisted credentials"
+  exit 1
+}
+
+grep -Fq "merge_group:" "${repo_root}/.github/workflows/quality-gates.yml" || {
+  echo "release-hygiene-policy-test: quality gates must support merge_group for staging queue"
+  exit 1
+}
+
+grep -Fq "merge_group:" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must support merge_group for release queue"
+  exit 1
+}
+
+for workflow in \
+  "${repo_root}/.github/workflows/typescript.yml" \
+  "${repo_root}/.github/workflows/python.yml" \
+  "${repo_root}/.github/workflows/unit-cover.yml"; do
+  grep -Fq "paths-ignore:" "${workflow}" || {
+    echo "release-hygiene-policy-test: ${workflow} must use trigger-level paths-ignore for release-please PRs"
+    exit 1
+  }
+  grep -Fq '".release-please-manifest.json"' "${workflow}" || {
+    echo "release-hygiene-policy-test: ${workflow} must ignore manifest-only release-please PR changes"
+    exit 1
+  }
+  grep -Fq '"CHANGELOG.md"' "${workflow}" || {
+    echo "release-hygiene-policy-test: ${workflow} must ignore changelog-only release-please PR changes"
+    exit 1
+  }
+  if grep -Eq '^[[:space:]]*paths:' "${workflow}"; then
+    echo "release-hygiene-policy-test: ${workflow} must not replace normal PR validation with a paths allowlist"
+    exit 1
+  fi
+done
+
+grep -Fq -- "--queue-freshness" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene PR provenance must delegate live ref freshness to merge queue"
+  exit 1
+}
+
+grep -Fq "verify-release-lane-provenance.sh --help" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must feature-detect trusted provenance flags"
+  exit 1
+}
+
+grep -Fq "provenance_args+=(--queue-freshness)" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must append --queue-freshness only after feature detection"
+  exit 1
+}
+
+grep -Fq "trusted base script lacks --queue-freshness" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must document strict-freshness fallback"
+  exit 1
+}
+
+grep -Fq "Resolve release verifier source" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must resolve verifier source for PR checks"
+  exit 1
+}
+
+grep -Fq "premain:staging|main:premain" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier fallback must be limited to protected promotion branch pairs"
+  exit 1
+}
+
+grep -Fq "trusted base lacks v2 single-manifest support or RC-first verifier support" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must document old trusted-script and RC-first fallback reasons"
+  exit 1
+}
+
+grep -Fq "protected-pr-head-v2" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must label protected PR-head v2 fallback"
+  exit 1
+}
+
+grep -Fq "scripts/prepare-release-package-versions.py" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect the v2 package-version marker"
+  exit 1
+}
+
+grep -Fq "single release-please manifest" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect the v2 single-manifest marker"
+  exit 1
+}
+
+grep -Fq "accept release-please first RC and numbered later RC PR titles" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect the RC-first PR-title marker"
+  exit 1
+}
+
+grep -Fq "accept release-please first RC and numbered later RC version syntax" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect the RC-first version marker"
+  exit 1
+}
+
+grep -Fq 'bash "${VERIFIER_ROOT}/scripts/verify-release-cycle-state.sh"' "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release-cycle state must use the resolved verifier source"
+  exit 1
+}
+
+grep -Fq 'bash "${VERIFIER_ROOT}/scripts/verify-branch-release-supply-chain.sh"' "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: branch release supply-chain must use the resolved verifier source"
+  exit 1
+}
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v1 v2 \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "." \
+  "protected-pr-head-v2" \
+  "protected same-repo promotion may use PR-head v2/RC-first verifier scripts after provenance"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-numbered-rc v2 \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "." \
+  "protected-pr-head-v2" \
+  "protected same-repo promotion may use PR-head v2/RC-first verifier scripts after provenance"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v1 v2 \
+    premain "feature/arbitrary-head" \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "using trusted base verifier scripts"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-numbered-rc v2 \
+    premain "feature/arbitrary-head" \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "using trusted base verifier scripts"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v1 v2 \
+    premain staging \
+    "${repo}" "attacker/TableTheory"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "using trusted base verifier scripts"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-numbered-rc v2 \
+    premain staging \
+    "${repo}" "attacker/TableTheory"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "using trusted base verifier scripts"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2 v2 \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "../trusted-release" \
+  "trusted-base" \
+  "trusted base supports v2 single-manifest and RC-first verifier markers"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-numbered-rc v2-numbered-rc \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_failure \
+  "${selector_result}" \
+  "protected PR head lacks v2 single-manifest support or RC-first verifier support"
+
+grep -Fq "pending stable promotion accepted on queued main merge group" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: release hygiene must allow queued main pending stable promotion"
   exit 1
 }
 

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # Verifies the TableTheory release-lane scaffolding:
 # - one lane: staging -> premain -> main -> staging
-# - full gov-infra rubric only on staging PRs and workflow_dispatch
-# - lightweight release hygiene on premain/main PRs
+# - full gov-infra rubric only on staging PRs, staging merge queue, and workflow_dispatch
+# - lightweight release hygiene on premain/main PRs and merge queues
 # - premain cuts RCs; main cuts stable releases only
 # - no post-stable CI direct-push sync to protected branches
 #
@@ -40,6 +40,118 @@ require_regex() {
   grep -Eq -- "${pattern}" "${path}" || fail "${message}"
 }
 
+current_branch_name() {
+  if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+    printf '%s\n' "${GITHUB_HEAD_REF}"
+    return 0
+  fi
+
+  git rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
+validate_main_bootstrap_scope() {
+  local branch="$1"
+  local base_ref="${BOOTSTRAP_BASE_REF:-origin/main}"
+  local changed_files=()
+  local untracked_files=()
+  local changed_file
+
+  case "${GITHUB_BASE_REF:-main}" in
+    ""|main)
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+      echo "branch-release: scoped main bootstrap detected; changed-file scope is enforced by release-hygiene workflow guard"
+      return 0
+    fi
+    fail "main bootstrap scope could not resolve ${base_ref}"
+    return 1
+  fi
+
+  mapfile -t changed_files < <(
+    {
+      git diff --name-only "${base_ref}...HEAD"
+      git diff --name-only
+      git diff --cached --name-only
+    } | sort -u
+  )
+  mapfile -t untracked_files < <(git ls-files --others --exclude-standard)
+
+  if [[ "${#untracked_files[@]}" -ne 0 ]]; then
+    printf 'branch-release: untracked file blocks scoped main bootstrap: %s\n' "${untracked_files[@]}"
+    failures=$((failures + ${#untracked_files[@]}))
+  fi
+
+  if [[ "${#changed_files[@]}" -eq 0 ]]; then
+    fail "main bootstrap branch ${branch} has no changed files"
+    return 1
+  fi
+
+  for changed_file in "${changed_files[@]}"; do
+    case "${changed_file}" in
+      .github/workflows/release-hygiene.yml|\
+      scripts/verify-release-lane-provenance.sh|\
+      scripts/verify-promotion-release-driver.sh|\
+      scripts/test-release-hygiene-policy.sh|\
+      scripts/verify-release-cycle-state.sh|\
+      scripts/verify-branch-release-supply-chain.sh)
+        ;;
+      *)
+        fail "unexpected main bootstrap file ${changed_file}"
+        ;;
+    esac
+  done
+}
+
+if [[ "$(current_branch_name)" == fix/release-hygiene-main-bootstrap-* ]]; then
+  bootstrap_branch="$(current_branch_name)"
+  validate_main_bootstrap_scope "${bootstrap_branch}"
+
+  for path in \
+    ".github/workflows/release-hygiene.yml" \
+    "scripts/verify-release-lane-provenance.sh" \
+    "scripts/verify-promotion-release-driver.sh" \
+    "scripts/test-release-hygiene-policy.sh" \
+    "scripts/verify-release-cycle-state.sh" \
+    "scripts/verify-branch-release-supply-chain.sh"; do
+    require_file "${path}"
+  done
+
+  require_fixed "Resolve release verifier source" ".github/workflows/release-hygiene.yml" \
+    "main bootstrap release hygiene must resolve verifier source"
+  require_fixed "protected-pr-head-v2" ".github/workflows/release-hygiene.yml" \
+    "main bootstrap release hygiene must preserve protected PR-head verifier fallback"
+  require_fixed "accept release-please first RC and numbered later RC PR titles" ".github/workflows/release-hygiene.yml" \
+    "main bootstrap release hygiene must preserve RC-first PR-title marker"
+  require_fixed "accept release-please first RC and numbered later RC version syntax" ".github/workflows/release-hygiene.yml" \
+    "main bootstrap release hygiene must preserve RC-first version marker"
+  require_fixed "scripts/prepare-release-package-versions.py" "scripts/verify-release-cycle-state.sh" \
+    "main bootstrap release-cycle verifier must preserve v2 package-version marker"
+  require_fixed "py/src/tabletheory_py/version.json" "scripts/verify-release-cycle-state.sh" \
+    "main bootstrap release-cycle verifier must preserve canonical Python version marker"
+  require_fixed "RELEASE_CYCLE_REPO_ROOT" "scripts/verify-release-cycle-state.sh" \
+    "main bootstrap release-cycle verifier must support explicit target repo roots"
+  require_fixed "pending-stable-promotion" "scripts/verify-release-cycle-state.sh" \
+    "main bootstrap release-cycle verifier must preserve pending stable promotion mode"
+  require_fixed "single release-please manifest" "scripts/verify-branch-release-supply-chain.sh" \
+    "main bootstrap branch-release verifier must preserve single-manifest policy marker"
+  require_fixed "X.Y.Z-rc or X.Y.Z-rc.N" "scripts/verify-promotion-release-driver.sh" \
+    "main bootstrap promotion verifier must preserve RC-first syntax"
+
+  if [[ "${failures}" -ne 0 ]]; then
+    echo "branch-release: FAIL (${failures} issue(s))"
+    exit 1
+  fi
+
+  echo "branch-release: PASS (scoped main release-hygiene bootstrap ${bootstrap_branch})"
+  exit 0
+fi
+
 required_files=(
   "AGENTS.md"
   "docs/development/planning/theorydb-branch-release-policy.md"
@@ -53,9 +165,10 @@ required_files=(
   ".github/workflows/release-pr.yml"
   "release-please-config.premain.json"
   "release-please-config.json"
-  ".release-please-manifest.premain.json"
   ".release-please-manifest.json"
-  "scripts/sync-post-stable-release-baselines.sh"
+  "scripts/prepare-release-package-versions.py"
+  "scripts/verify-release-package-version-assets.py"
+  "scripts/verify-release-package-version-build.sh"
   "scripts/verify-main-release-pr-postcondition.sh"
   "scripts/verify-prerelease-pr-postcondition.sh"
   "scripts/verify-release-lane-provenance.sh"
@@ -68,6 +181,26 @@ required_files=(
 
 for path in "${required_files[@]}"; do
   require_file "${path}"
+done
+
+retired_files=(
+  "scripts/prepare-stable-promotion.sh"
+  "scripts/sync-post-stable-release-baselines.sh"
+)
+
+for path in "${retired_files[@]}"; do
+  if [[ -e "${path}" ]]; then
+    fail "${path} must remain retired; use release-please-owned stable PRs and normal main -> staging PR backmerges"
+  fi
+  if grep -RInF "${path}" \
+    AGENTS.md \
+    docs/development/planning/theorydb-branch-release-policy.md \
+    docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md \
+    docs/development/planning/templates/high-risk-branch-release-policy.template.md \
+    scripts/test-release-*.sh \
+    .github/workflows >/dev/null 2>&1; then
+    fail "${path} must not be referenced by release docs or workflows after retirement"
+  fi
 done
 
 if [[ -f "scripts/watch-release-cycle.sh" ]]; then
@@ -87,6 +220,8 @@ if [[ -f ".github/workflows/quality-gates.yml" ]]; then
   q=".github/workflows/quality-gates.yml"
   require_fixed "pull_request:" "${q}" \
     "quality-gates must run on pull_request"
+  require_fixed "merge_group:" "${q}" \
+    "quality-gates must run on merge_group for the staging merge queue"
   require_fixed 'branches: ["staging"]' "${q}" \
     "quality-gates pull_request must target staging only"
   require_fixed "workflow_dispatch:" "${q}" \
@@ -114,8 +249,12 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
   h=".github/workflows/release-hygiene.yml"
   require_fixed 'branches: ["premain", "main"]' "${h}" \
     "release-hygiene must target premain and main PRs"
+  require_fixed "merge_group:" "${h}" \
+    "release-hygiene must run on merge_group for premain/main queues"
   require_fixed "trusted-release/scripts/verify-release-lane-provenance.sh" "${h}" \
     "release-hygiene must verify release-lane same-repository provenance from trusted scripts"
+  require_fixed "--queue-freshness" "${h}" \
+    "release-hygiene PR provenance must delegate live ref freshness to merge queue semantics"
   require_fixed "github.event.pull_request.base.sha" "${h}" \
     "release-hygiene must check out trusted release scripts from the PR base SHA"
   require_fixed "github.event.pull_request.head.sha" "${h}" \
@@ -148,6 +287,8 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
     "release-hygiene must run the release driver guard on premain -> main PRs"
   require_fixed "../trusted-release/scripts/verify-promotion-release-driver.sh" "${h}" \
     "release-hygiene must run the promotion driver from trusted checkout"
+  require_fixed "pending stable promotion accepted on queued main merge group" "${h}" \
+    "release-hygiene must allow queued main pending stable promotion validation"
   if grep -Fq "secrets.RELEASE_PLEASE_TOKEN" "${h}"; then
     fail "release-hygiene must not expose release-please token"
   fi
@@ -155,6 +296,23 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
     fail "release-hygiene must not run the full rubric"
   fi
 fi
+
+for workflow in \
+  ".github/workflows/typescript.yml" \
+  ".github/workflows/python.yml" \
+  ".github/workflows/unit-cover.yml"; do
+  if [[ -f "${workflow}" ]]; then
+    require_fixed "paths-ignore:" "${workflow}" \
+      "${workflow} pull_request trigger must suppress manifest/changelog-only release-please PR fan-out"
+    require_fixed '".release-please-manifest.json"' "${workflow}" \
+      "${workflow} must ignore release-please manifest-only PR changes"
+    require_fixed '"CHANGELOG.md"' "${workflow}" \
+      "${workflow} must ignore release-please changelog-only PR changes"
+    if grep -Eq '^[[:space:]]*paths:' "${workflow}"; then
+      fail "${workflow} must not replace normal PR validation with a paths allowlist"
+    fi
+  fi
+done
 
 for doc in \
   "AGENTS.md" \
@@ -200,8 +358,8 @@ if [[ -f ".github/workflows/prerelease.yml" ]]; then
     "prerelease workflow must request contents: write"
   require_regex 'config-file:\s*release-please-config\.premain\.json' "${p}" \
     "prerelease workflow must reference release-please-config.premain.json"
-  require_regex 'manifest-file:\s*\.release-please-manifest\.premain\.json' "${p}" \
-    "prerelease workflow must reference .release-please-manifest.premain.json"
+  require_regex 'manifest-file:\s*\.release-please-manifest\.json' "${p}" \
+    "prerelease workflow must reference the single release-please manifest"
   require_fixed "scripts/verify-release-cycle-state.sh" "${p}" \
     "prerelease workflow must verify release-cycle state before release-please"
   require_fixed "scripts/verify-branch-version-sync.sh" "${p}" \
@@ -218,10 +376,22 @@ if [[ -f ".github/workflows/prerelease.yml" ]]; then
     "prerelease publish postcondition must classify plain staging -> premain merges as PR-generation setup"
   require_regex 'pushd ts' "${p}" \
     "prerelease workflow must package TypeScript from ts/"
+  require_fixed "scripts/prepare-release-package-versions.py --tag-name" "${p}" \
+    "prerelease workflow must stamp TS/Py versions from tag_name before packaging"
+  require_fixed "scripts/verify-release-package-version-assets.py" "${p}" \
+    "prerelease workflow must verify TS/Py asset metadata matches tag_name"
   require_regex 'npm pack --pack-destination \.\./release-assets' "${p}" \
     "prerelease workflow must attach TypeScript npm pack artifact"
   require_regex 'python -m build --outdir \.\./release-assets' "${p}" \
     "prerelease workflow must attach Python wheel/sdist artifacts"
+  require_regex 'actions/setup-go@[0-9a-fA-F]{40}' "${p}" \
+    "prerelease workflow must set up Go for the CLI release asset build"
+  require_fixed './cmd/tabletheory' "${p}" \
+    "prerelease workflow must build the tabletheory CLI as a release asset"
+  require_fixed 'release-assets/tabletheory-${os}-${arch}' "${p}" \
+    "prerelease workflow must attach tabletheory CLI binaries per os/arch"
+  require_fixed 'tabletheory-SHA256SUMS.txt' "${p}" \
+    "prerelease workflow must publish CLI binary checksums"
   require_regex 'gh release upload' "${p}" \
     "prerelease workflow must upload release assets"
 fi
@@ -234,8 +404,8 @@ if [[ -f ".github/workflows/prerelease-pr.yml" ]]; then
     "prerelease-pr workflow must pin release-please v4 by commit SHA"
   require_regex 'config-file:\s*release-please-config\.premain\.json' "${pp}" \
     "prerelease-pr workflow must reference release-please-config.premain.json"
-  require_regex 'manifest-file:\s*\.release-please-manifest\.premain\.json' "${pp}" \
-    "prerelease-pr workflow must reference .release-please-manifest.premain.json"
+  require_regex 'manifest-file:\s*\.release-please-manifest\.json' "${pp}" \
+    "prerelease-pr workflow must reference the single release-please manifest"
   require_fixed "scripts/verify-release-cycle-state.sh" "${pp}" \
     "prerelease-pr workflow must verify release-cycle state before release-please"
   require_fixed "scripts/verify-branch-version-sync.sh" "${pp}" \
@@ -284,15 +454,24 @@ if [[ -f ".github/workflows/release.yml" ]]; then
     "stable publish postcondition must forbid RC-shaped main releases"
   require_regex 'pushd ts' "${r}" \
     "release workflow must package TypeScript from ts/"
+  require_fixed "scripts/prepare-release-package-versions.py --tag-name" "${r}" \
+    "release workflow must stamp TS/Py versions from tag_name before packaging"
+  require_fixed "scripts/verify-release-package-version-assets.py" "${r}" \
+    "release workflow must verify TS/Py asset metadata matches tag_name"
   require_regex 'npm pack --pack-destination \.\./release-assets' "${r}" \
     "release workflow must attach TypeScript npm pack artifact"
   require_regex 'python -m build --outdir \.\./release-assets' "${r}" \
     "release workflow must attach Python wheel/sdist artifacts"
+  require_regex 'actions/setup-go@[0-9a-fA-F]{40}' "${r}" \
+    "release workflow must set up Go for the CLI release asset build"
+  require_fixed './cmd/tabletheory' "${r}" \
+    "release workflow must build the tabletheory CLI as a release asset"
+  require_fixed 'release-assets/tabletheory-${os}-${arch}' "${r}" \
+    "release workflow must attach tabletheory CLI binaries per os/arch"
+  require_fixed 'tabletheory-SHA256SUMS.txt' "${r}" \
+    "release workflow must publish CLI binary checksums"
   require_regex 'gh release upload' "${r}" \
     "release workflow must upload release assets"
-  if grep -Fq "scripts/sync-post-stable-release-baselines.sh" "${r}"; then
-    fail "release workflow must not call post-stable baseline sync"
-  fi
   if grep -Fq "SYNC_RELEASE_BASELINE" "${r}"; then
     fail "release workflow must not configure post-stable direct-push sync"
   fi
@@ -311,8 +490,9 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
   if grep -Fq "googleapis/release-please-action" "${rp}"; then
     fail "release-pr workflow must use pinned release-please CLI, not release-please-action"
   fi
-  require_fixed '.release-please-manifest.premain.json' "${rp}" \
-    "release-pr paths-ignore must include .release-please-manifest.premain.json and compute RC baseline"
+  if grep -Fq ".release-please-manifest.premain.json" "${rp}"; then
+    fail "release-pr workflow must not reference retired .release-please-manifest.premain.json"
+  fi
   require_fixed 'RELEASE_PLEASE_CLI_VERSION: "17.3.0"' "${rp}" \
     "release-pr workflow must pin release-please CLI to v17.3.0"
   require_fixed "npm ci --prefix scripts/release-please-cli --ignore-scripts" "${rp}" \
@@ -337,9 +517,9 @@ if [[ -f ".github/workflows/release-pr.yml" ]]; then
     "release-pr workflow must document pending promotion PR generation"
   require_fixed "PENDING_STABLE_PROMOTION" "${rp}" \
     "release-pr workflow must gate release-please on pending promotion"
-  require_fixed "strict stable state; no release-as computed and no release-please call needed" "${rp}" \
+  require_fixed "strict stable state; no single-manifest RC to normalize" "${rp}" \
     "release-pr workflow must no-op when main is already strict/stable"
-  require_fixed "pending stable promotion did not compute a stable release-as" "${rp}" \
+  require_fixed "single-manifest pending stable promotion did not compute a stable release-as" "${rp}" \
     "release-pr workflow must fail if pending promotion has no stable release-as"
   require_fixed "--release-as" "${rp}" \
     "release-pr workflow must pass release-as to the pinned CLI"
@@ -363,10 +543,6 @@ if [[ -f "scripts/verify-main-release-pr-postcondition.sh" ]]; then
     "main Release PR postcondition must support read-only RC-only checks"
   for path in \
     ".release-please-manifest.json" \
-    ".release-please-manifest.premain.json" \
-    "py/src/theorydb_py/version.json" \
-    "ts/package.json" \
-    "ts/package-lock.json" \
     "CHANGELOG.md"; do
     require_fixed "${path}" "${postcondition}" \
       "main Release PR postcondition must require ${path}"
@@ -387,8 +563,8 @@ if [[ -f "scripts/verify-promotion-release-driver.sh" ]]; then
     "promotion release driver guard must name release-please no-op as a failed precondition"
   require_fixed "do not use tags, resets, manual manifests" "${driver}" \
     "promotion release driver guard must instruct normal PR-flow remediation"
-  require_fixed "X.Y.Z-rc.N" "${driver}" \
-    "promotion release driver guard must require numbered RC syntax"
+  require_fixed "X.Y.Z-rc or X.Y.Z-rc.N" "${driver}" \
+    "promotion release driver guard must accept release-please first RC and numbered later RC syntax"
 fi
 
 if [[ -f "scripts/verify-release-lane-provenance.sh" ]]; then
@@ -396,9 +572,11 @@ if [[ -f "scripts/verify-release-lane-provenance.sh" ]]; then
   require_fixed "release-lane PRs must be same-repository" "${provenance}" \
     "release-lane provenance guard must reject fork/name-spoofed PRs"
   require_fixed "does not match same-repository refs/heads" "${provenance}" \
-    "release-lane provenance guard must verify exact branch SHAs"
-  require_fixed "-rc\\.[0-9]+" "${provenance}" \
-    "release-lane provenance guard must require numbered RC release-please PR titles"
+    "release-lane provenance guard must retain exact branch SHA verification for manual fallback"
+  require_fixed "live ref freshness covered by merge queue" "${provenance}" \
+    "release-lane provenance guard must document queue-covered live ref freshness"
+  require_fixed "-rc(\\.[0-9]+)?" "${provenance}" \
+    "release-lane provenance guard must accept release-please first RC and numbered later RC PR titles"
 fi
 
 if [[ -f "scripts/verify-prerelease-pr-postcondition.sh" ]]; then
@@ -407,10 +585,10 @@ if [[ -f "scripts/verify-prerelease-pr-postcondition.sh" ]]; then
     "prerelease PR postcondition must require the generated premain head branch"
   require_fixed "rc_title_re = re.compile" "${prerelease_postcondition}" \
     "prerelease PR postcondition must require RC-shaped release titles"
-  require_fixed "-rc\\.\\d+" "${prerelease_postcondition}" \
-    "prerelease PR postcondition must require numbered RC version syntax"
-  require_fixed ".release-please-manifest.premain.json" "${prerelease_postcondition}" \
-    "prerelease PR postcondition must require the prerelease manifest"
+  require_fixed "-rc(?:\\.\\d+)?" "${prerelease_postcondition}" \
+    "prerelease PR postcondition must accept release-please first RC and numbered later RC version syntax"
+  require_fixed ".release-please-manifest.json" "${prerelease_postcondition}" \
+    "prerelease PR postcondition must require the single manifest"
 fi
 
 if [[ -f "scripts/release-please-cli/package-lock.json" ]]; then
@@ -435,25 +613,6 @@ PY
   fi
 fi
 
-if [[ -f "scripts/sync-post-stable-release-baselines.sh" ]]; then
-  sync_script="scripts/sync-post-stable-release-baselines.sh"
-  require_fixed "DEPRECATED" "${sync_script}" \
-    "post-stable sync helper must be marked deprecated"
-  require_fixed "dry-run only" "${sync_script}" \
-    "post-stable sync helper must be dry-run only"
-  require_fixed "normal PR backmerge from main to staging" "${sync_script}" \
-    "post-stable sync helper must point operators to main -> staging PR backmerge"
-  require_fixed ".release-please-manifest.premain.json" "${sync_script}" \
-    "post-stable sync helper must still name the prerelease manifest"
-  if grep -Eq 'git[[:space:]].*push|gh[[:space:]]+api[[:space:]].*(git/refs|contents)' "${sync_script}"; then
-    fail "deprecated post-stable sync helper must not contain branch mutation commands"
-  fi
-fi
-
-if grep -RInF "scripts/sync-post-stable-release-baselines.sh" .github/workflows; then
-  fail "workflows must not call deprecated post-stable baseline sync"
-fi
-
 if grep -RInF "SYNC_RELEASE_BASELINE" .github/workflows; then
   fail "workflows must not configure post-stable baseline sync"
 fi
@@ -469,48 +628,37 @@ if [[ -f "ts/package.json" ]]; then
 
   for cfg in "release-please-config.premain.json" "release-please-config.json"; do
     [[ -f "${cfg}" ]] || continue
-    require_regex '"extra-files"\s*:' "${cfg}" \
-      "${cfg}: must define extra-files for multi-language versioning"
-    require_regex '"path"\s*:\s*"ts/package\.json"' "${cfg}" \
-      "${cfg}: must bump ts/package.json version"
-    require_regex '"path"\s*:\s*"ts/package-lock\.json"' "${cfg}" \
-      "${cfg}: must bump ts/package-lock.json version"
-    require_regex "\\$\\.packages\\[''\\]\\.version" "${cfg}" \
-      "${cfg}: must bump ts/package-lock.json packages[''].version"
+    if grep -Fq '"extra-files"' "${cfg}"; then
+      fail "${cfg}: must not use extra-files for tag-derived SDK package versions"
+    fi
+    if grep -Eq 'ts/package(-lock)?\.json|py/src/tabletheory_py/version\.json|\.release-please-manifest\.premain\.json' "${cfg}"; then
+      fail "${cfg}: must not list SDK versions or retired prerelease manifest as release-please extra files"
+    fi
   done
 fi
 
-if [[ -f "release-please-config.json" ]]; then
-  if ! python3 - <<'PY'
+for cfg in "release-please-config.json" "release-please-config.premain.json"; do
+  [[ -f "${cfg}" ]] || continue
+  if ! CFG="${cfg}" python3 - <<'PY'
 import json
+import os
 from pathlib import Path
 
-config = json.loads(Path("release-please-config.json").read_text(encoding="utf-8"))
-extra_files = config.get("packages", {}).get(".", {}).get("extra-files", [])
-
-for entry in extra_files:
-    if (
-        isinstance(entry, dict)
-        and entry.get("type") == "json"
-        and entry.get("path") == ".release-please-manifest.premain.json"
-        and entry.get("jsonpath") == "$['.']"
-    ):
-        raise SystemExit(0)
-
-raise SystemExit(1)
+config = json.loads(Path(os.environ["CFG"]).read_text(encoding="utf-8"))
+if config.get("packages", {}).get(".") != {}:
+    raise SystemExit(1)
 PY
   then
-    fail "release-please-config.json must normalize .release-please-manifest.premain.json through stable release-please"
+    fail "${cfg} must leave SDK/package versioning to tag-derived release-build scripts"
   fi
-fi
+done
 
 if [[ -f "py/pyproject.toml" ]]; then
   for cfg in "release-please-config.premain.json" "release-please-config.json"; do
     [[ -f "${cfg}" ]] || continue
-    require_regex '"extra-files"\s*:' "${cfg}" \
-      "${cfg}: must define extra-files for multi-language versioning"
-    require_regex '"path"\s*:\s*"py/src/theorydb_py/version\.json"' "${cfg}" \
-      "${cfg}: must bump py/src/theorydb_py/version.json version"
+    if grep -Fq "py/src/tabletheory_py/version.json" "${cfg}"; then
+      fail "${cfg}: must not bump py/src/tabletheory_py/version.json through release-please"
+    fi
   done
 fi
 

--- a/scripts/verify-promotion-release-driver.sh
+++ b/scripts/verify-promotion-release-driver.sh
@@ -190,9 +190,9 @@ metadata_path = Path(sys.argv[1])
 base = os.environ["BASE_REF"]
 head = os.environ["HEAD_REF"]
 
-rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc\.\d+$")
+rc_version_re = re.compile(r"^v?\d+\.\d+\.\d+-rc(?:\.\d+)?$")
 stable_version_re = re.compile(r"^v?\d+\.\d+\.\d+$")
-rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc\.\d+$")
+rc_title_re = re.compile(r"^chore\(premain\): release \d+\.\d+\.\d+-rc(?:\.\d+)?$")
 stable_title_re = re.compile(r"^chore\(main\): release \d+\.\d+\.\d+$")
 any_rc_re = re.compile(r"\d+\.\d+\.\d+-rc(?:[.\-\w]*)?")
 
@@ -277,44 +277,14 @@ def read_json(path: str) -> object:
 
 
 def pending_stable_promotion_version() -> str:
-    stable = read_json(".release-please-manifest.json").get(".", "")
-    premain = read_json(".release-please-manifest.premain.json").get(".", "")
-    ts_package = read_json("ts/package.json").get("version", "")
-    ts_lock = read_json("ts/package-lock.json")
-    ts_lock_root = ts_lock.get("version", "")
-    ts_lock_pkg = ts_lock.get("packages", {}).get("", {}).get("version", "")
-    py_version = read_json("py/src/theorydb_py/version.json").get("version", "")
+    manifest = read_json(".release-please-manifest.json").get(".", "")
 
-    if not stable or not isinstance(stable, str):
-        fail(".release-please-manifest.json is missing a stable version")
-    if "-rc" in stable:
-        fail(f"main stable manifest must not be RC-shaped ({stable})")
-
-    pending_files = {
-        ".release-please-manifest.premain.json": premain,
-        "ts/package.json": ts_package,
-        "ts/package-lock.json": ts_lock_root,
-        "ts/package-lock.json packages['']": ts_lock_pkg,
-        "py/src/theorydb_py/version.json": py_version,
-    }
-    first_label, first_version = next(iter(pending_files.items()))
-    if not isinstance(first_version, str) or not rc_version_re.match(first_version):
+    if not isinstance(manifest, str) or not rc_version_re.match(manifest):
         fail(
-            "premain -> main promotion must carry an RC pending stable "
-            f"promotion state with numbered -rc.N syntax; {first_label} is {first_version!r}"
+            "premain -> main promotion must carry a single-manifest RC "
+            f"with X.Y.Z-rc or X.Y.Z-rc.N syntax; .release-please-manifest.json is {manifest!r}"
         )
-    for label, version in pending_files.items():
-        if version != first_version:
-            fail(
-                "pending stable promotion files are inconsistent "
-                f"({label} {version!r} != {first_version!r})"
-            )
-    if parse_base(first_version) <= parse_base(stable):
-        fail(
-            "pending stable promotion RC must be ahead of the stable manifest "
-            f"({first_version} <= {stable})"
-        )
-    return first_version
+    return manifest
 
 
 title, body, commits = read_metadata()
@@ -323,7 +293,7 @@ pr_text = "\n\n".join([title, body])
 
 if base == "premain" and head == "release-please--branches--premain":
     if not rc_title_re.fullmatch(title):
-        fail(f"generated premain release-please PR must be numbered RC-shaped, got {title!r}")
+        fail(f"generated premain release-please PR must be RC-shaped, got {title!r}")
     print(f"promotion-release-driver: PASS (generated premain RC PR {title!r})")
     raise SystemExit(0)
 
@@ -341,7 +311,7 @@ if base == "premain":
     if invalid:
         fail(
             "staging -> premain Release-As footers must be RC-shaped "
-            f"X.Y.Z-rc.N, got {', '.join(invalid)}"
+            f"X.Y.Z-rc or X.Y.Z-rc.N, got {', '.join(invalid)}"
         )
     if versions:
         print(

--- a/scripts/verify-release-cycle-state.sh
+++ b/scripts/verify-release-cycle-state.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# CI-safe local release-cycle checks. By default this verifier validates the
+# checkout that contains the trusted script. Release Hygiene may pass an explicit
+# target checkout root after same-repository provenance verification so trusted
+# base scripts inspect PR-head files without executing PR-head scripts. Remote
+# branch drift is reported by scripts/watch-release-cycle.sh.
+
 failures=0
 
 fail() {
@@ -12,18 +18,240 @@ usage() {
   cat <<'USAGE'
 Usage: bash scripts/verify-release-cycle-state.sh [--repo-root ABSOLUTE_PATH]
 
-CI-safe local release-cycle checks. By default this verifier validates the
-checkout that contains the trusted script. Release Hygiene may pass an explicit
-target checkout root after same-repository provenance verification so trusted
-base scripts inspect the PR head files without executing PR-head scripts.
-
 Options:
   --repo-root ABSOLUTE_PATH  Validate this checkout root instead of the script checkout.
   -h, --help                Show this help.
 USAGE
 }
 
-script_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+script_repo_root="$(cd "${script_dir}/.." && pwd -P)"
+
+# Bootstrap note: keep this helper self-contained on main until the v2
+# release-cycle core helper is available on the target branch. This body is
+# copied from origin/premain:scripts/lib/release-cycle-core.sh so trusted main
+# release hygiene can validate PR-head v2 single-manifest state without adding
+# scripts/lib/release-cycle-core.sh in the scoped bootstrap PR.
+release_cycle_json_value_at_ref() {
+  local ref="$1"
+  local path="$2"
+  local expr="$3"
+
+  if ! git cat-file -e "${ref}:${path}" 2>/dev/null; then
+    return 0
+  fi
+
+  git show "${ref}:${path}" 2>/dev/null | python3 -c '
+import json
+import sys
+
+expr = sys.argv[1]
+ref = sys.argv[2]
+path = sys.argv[3]
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError as exc:
+    print(
+        f"{ref}:{path} contains malformed JSON: {exc.msg} "
+        f"at line {exc.lineno} column {exc.colno}",
+        file=sys.stderr,
+    )
+    raise SystemExit(65)
+if expr == ".":
+    print(data.get(".", "") if isinstance(data, dict) else "")
+    raise SystemExit(0)
+value = data
+for part in expr.split("."):
+    if isinstance(value, dict):
+        value = value.get(part, "")
+    else:
+        value = ""
+if isinstance(value, bool):
+    print("true" if value else "false")
+elif value is None:
+    print("")
+elif isinstance(value, (str, int, float)):
+    print(value)
+else:
+    print(json.dumps(value, separators=(",", ":")))
+' "${expr}" "${ref}" "${path}"
+}
+
+release_cycle_json_string_value() {
+  local json="$1"
+  local expr="$2"
+
+  JSON_INPUT="${json}" python3 - "${expr}" <<'PY'
+import json
+import os
+import sys
+
+expr = sys.argv[1]
+raw = os.environ["JSON_INPUT"]
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    try:
+        data, _ = json.JSONDecoder().raw_decode(raw)
+    except json.JSONDecodeError:
+        print("")
+        raise SystemExit(0)
+value = data
+for part in expr.split("."):
+    if not part:
+        continue
+    if isinstance(value, dict):
+        value = value.get(part)
+    else:
+        value = None
+if isinstance(value, bool):
+    print("true" if value else "false")
+elif value is None:
+    print("")
+elif isinstance(value, (str, int, float)):
+    print(value)
+else:
+    print(json.dumps(value))
+PY
+}
+
+release_cycle_toolchain_at_ref() {
+  local ref="$1"
+  local path="$2"
+  git show "${ref}:${path}" 2>/dev/null | awk '$1 == "toolchain" { print $2; exit }'
+}
+
+release_cycle_semver_base() {
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+v = sys.argv[1].strip()
+m = re.match(r"^v?(\d+)\.(\d+)\.(\d+)", v)
+if not m:
+    raise SystemExit(1)
+print(".".join(m.group(i) for i in range(1, 4)))
+PY
+}
+
+release_cycle_semver_lt() {
+  python3 - "$1" "$2" <<'PY'
+import re
+import sys
+
+
+def parse(v: str) -> tuple[int, int, int]:
+    m = re.match(r"^v?(\d+)\.(\d+)\.(\d+)", v.strip())
+    if not m:
+        raise SystemExit(2)
+    return tuple(int(m.group(i)) for i in range(1, 4))
+
+raise SystemExit(0 if parse(sys.argv[1]) < parse(sys.argv[2]) else 1)
+PY
+}
+
+release_cycle_verify_local_state() {
+  local repo_root="$1"
+
+  (
+    cd "${repo_root}"
+    python3 - <<'PY'
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+semver_re = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$")
+
+
+def read(path: str) -> object:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def fail(message: str) -> None:
+    print(f"release-cycle-state: FAIL ({message})")
+    raise SystemExit(1)
+
+
+def version_info(label: str, version: str) -> tuple[tuple[int, int, int], bool]:
+    match = semver_re.match(version.strip())
+    if not match:
+        fail(f"{label} has invalid semver {version!r}")
+    base = tuple(int(part) for part in match.group(1, 2, 3))
+    return base, bool(match.group(4))
+
+
+if Path(".release-please-manifest.premain.json").exists():
+    fail(".release-please-manifest.premain.json must be retired; use .release-please-manifest.json")
+
+manifest = read(".release-please-manifest.json").get(".", "")
+if not isinstance(manifest, str) or not manifest.strip():
+    fail(".release-please-manifest.json is missing a version")
+
+manifest_base, manifest_is_prerelease = version_info(".release-please-manifest.json", manifest)
+stable_base = ".".join(str(part) for part in manifest_base)
+
+current_branch = (
+    os.environ.get("GITHUB_BASE_REF")
+    or os.environ.get("GITHUB_REF_NAME")
+    or ""
+)
+if not current_branch:
+    try:
+        current_branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+        ).strip()
+    except Exception:
+        current_branch = ""
+
+pending_mode_raw = os.environ.get("RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION", "")
+pending_mode = pending_mode_raw == "true"
+if pending_mode_raw and pending_mode_raw not in {"true", "false"}:
+    fail("RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION must be exactly true or false")
+
+if pending_mode:
+    if current_branch != "main":
+        fail(
+            "pending stable promotion mode is only allowed on main "
+            f"(current branch: {current_branch})"
+        )
+    if os.environ.get("GITHUB_HEAD_REF", "") not in {"", "premain"}:
+        fail(
+            "pending stable promotion mode is only allowed for premain -> main "
+            f"(head branch: {os.environ.get('GITHUB_HEAD_REF')})"
+        )
+    if not manifest_is_prerelease:
+        fail(
+            "pending stable promotion mode requires a single-manifest RC "
+            f"(got {manifest})"
+        )
+
+    print(
+        "release-cycle-state: PASS "
+        f"(branch={current_branch}, mode=pending-stable-promotion, "
+        f"rc={manifest}, stable={stable_base})"
+    )
+    raise SystemExit(0)
+
+if current_branch == "main" and manifest_is_prerelease:
+    fail(
+        ".release-please-manifest.json is prerelease "
+        f"{manifest} on main; release-pr.yml must normalize it to {stable_base}"
+    )
+
+if current_branch == "staging" and manifest_is_prerelease:
+    fail(f"staging must not carry release-cycle RC state ({manifest})")
+
+print(
+    "release-cycle-state: PASS "
+    f"(branch={current_branch}, manifest={manifest})"
+)
+PY
+  )
+}
+
+
 repo_root="${script_repo_root}"
 explicit_repo_root="${RELEASE_CYCLE_REPO_ROOT:-}"
 
@@ -71,13 +299,13 @@ require_file() {
 }
 
 required_files=(
-  "scripts/prepare-stable-promotion.sh"
+  "scripts/prepare-release-package-versions.py"
+  "scripts/verify-release-package-version-assets.py"
   "scripts/watch-release-cycle.sh"
   ".release-please-manifest.json"
-  ".release-please-manifest.premain.json"
   "ts/package.json"
   "ts/package-lock.json"
-  "py/src/theorydb_py/version.json"
+  "py/src/tabletheory_py/version.json"
 )
 
 for path in "${required_files[@]}"; do
@@ -85,279 +313,9 @@ for path in "${required_files[@]}"; do
 done
 
 if [[ "${failures}" -eq 0 ]]; then
-  if ! python3 - <<'PY'
-import json
-import os
-import re
-import subprocess
-import sys
-from pathlib import Path
-
-semver_re = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$")
-
-
-def read(path: str) -> object:
-    return json.loads(Path(path).read_text(encoding="utf-8"))
-
-
-def fail(message: str) -> None:
-    print(f"release-cycle-state: FAIL ({message})")
-    raise SystemExit(1)
-
-
-def version_info(label: str, version: str) -> tuple[tuple[int, int, int], bool]:
-    match = semver_re.match(version.strip())
-    if not match:
-        fail(f"{label} has invalid semver {version!r}")
-    base = tuple(int(part) for part in match.group(1, 2, 3))
-    return base, bool(match.group(4))
-
-
-stable = read(".release-please-manifest.json").get(".", "")
-premain = read(".release-please-manifest.premain.json").get(".", "")
-ts_package = read("ts/package.json").get("version", "")
-ts_lock = read("ts/package-lock.json")
-ts_lock_root = ts_lock.get("version", "")
-ts_lock_pkg = ts_lock.get("packages", {}).get("", {}).get("version", "")
-py_version = read("py/src/theorydb_py/version.json").get("version", "")
-
-promotion_files = {
-    ".release-please-manifest.premain.json": premain,
-    "ts/package.json": ts_package,
-    "ts/package-lock.json": ts_lock_root,
-    "ts/package-lock.json packages['']": ts_lock_pkg,
-    "py/src/theorydb_py/version.json": py_version,
-}
-
-for label, version in {".release-please-manifest.json": stable, **promotion_files}.items():
-    if not isinstance(version, str) or not version.strip():
-        fail(f"{label} is missing a version")
-
-stable_base, stable_is_prerelease = version_info(".release-please-manifest.json", stable)
-if stable_is_prerelease:
-    fail(f".release-please-manifest.json is prerelease {stable}")
-
-current_branch = (
-    os.environ.get("GITHUB_BASE_REF")
-    or os.environ.get("GITHUB_REF_NAME")
-    or ""
-)
-if not current_branch:
-    current_branch = subprocess.check_output(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
-    ).strip()
-
-pending_mode_raw = os.environ.get("RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION", "")
-pending_mode = pending_mode_raw == "true"
-if pending_mode_raw and pending_mode_raw not in {"true", "false"}:
-    fail("RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION must be exactly true or false")
-
-
-def consistent_version(
-    files: dict[str, str],
-    mode_label: str,
-) -> tuple[tuple[int, int, int], str, bool]:
-    expected_base = None
-    expected_version = None
-    expected_is_prerelease = None
-    for label, version in files.items():
-        base, is_prerelease = version_info(label, version)
-        if expected_version is None:
-            expected_base = base
-            expected_version = version
-            expected_is_prerelease = is_prerelease
-            continue
-        if version != expected_version or base != expected_base:
-            fail(
-                f"{mode_label} files are inconsistent "
-                f"({label} {version} != {expected_version})"
-            )
-    if (
-        expected_base is None
-        or expected_version is None
-        or expected_is_prerelease is None
-    ):
-        fail(f"{mode_label} has no version files")
-    return expected_base, expected_version, expected_is_prerelease
-
-
-def stable_file_mismatch(branch: str) -> str | None:
-    for label, version in promotion_files.items():
-        base, is_prerelease = version_info(label, version)
-        if is_prerelease:
-            return f"{label} is prerelease {version} on {branch}"
-        if base != stable_base or version != stable:
-            return f"{label} {version} does not match stable manifest {stable}"
-    return None
-
-
-if pending_mode:
-    if current_branch != "main":
-        fail(
-            "pending stable promotion mode is only allowed on main "
-            f"(current branch: {current_branch})"
-        )
-    if os.environ.get("GITHUB_HEAD_REF", "") not in {"", "premain"}:
-        fail(
-            "pending stable promotion mode is only allowed for premain -> main "
-            f"(head branch: {os.environ.get('GITHUB_HEAD_REF')})"
-        )
-
-    pending_base, pending_version, pending_is_prerelease = consistent_version(
-        promotion_files,
-        "pending stable promotion",
-    )
-    if not pending_is_prerelease:
-        fail(
-            "pending stable promotion files must carry the promoted RC version "
-            f"(got {pending_version})"
-        )
-    if pending_base <= stable_base:
-        fail(
-            "pending stable promotion version must be ahead of the stable manifest "
-            f"({pending_version} <= {stable})"
-        )
-
-    print(
-        "release-cycle-state: PASS "
-        f"(branch={current_branch}, mode=pending-stable-promotion, "
-        f"stable={stable}, pending={pending_version})"
-    )
-    raise SystemExit(0)
-
-if current_branch == "main":
-    mismatch = stable_file_mismatch(current_branch)
-    if mismatch:
-        fail(mismatch)
-
-if current_branch == "staging":
-    mismatch = stable_file_mismatch(current_branch)
-    if mismatch:
-        (
-            reconciliation_base,
-            reconciliation_version,
-            reconciliation_is_prerelease,
-        ) = consistent_version(
-            promotion_files,
-            "staging RC reconciliation",
-        )
-        if not reconciliation_is_prerelease:
-            fail(mismatch)
-        if reconciliation_base <= stable_base:
-            fail(
-                "staging RC reconciliation version must be ahead of the stable manifest "
-                f"({reconciliation_version} <= {stable})"
-            )
-        print(
-            "release-cycle-state: PASS "
-            f"(branch={current_branch}, mode=staging-rc-reconciliation, "
-            f"stable={stable}, rc={reconciliation_version})"
-        )
-        raise SystemExit(0)
-
-print(
-    "release-cycle-state: PASS "
-    f"(branch={current_branch}, stable={stable}, premain={premain})"
-)
-PY
-  then
+  if ! release_cycle_verify_local_state "${repo_root}"; then
     failures=$((failures + 1))
   fi
-fi
-
-# Do not execute scripts from an explicit target checkout: release hygiene runs
-# this verifier from the trusted base checkout while inspecting PR-head files.
-# Keep the stable-promotion dry-run as trusted verifier logic over target data.
-if ! python3 - <<'PY' >/tmp/tabletheory-stable-promotion-check.$$ 2>&1; then
-import json
-import re
-from pathlib import Path
-
-semver_re = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$")
-
-
-def fail(message: str) -> None:
-    print(f"stable-promotion: FAIL ({message})")
-    raise SystemExit(1)
-
-
-def load_json(path: str) -> object:
-    p = Path(path)
-    if not p.is_file():
-        fail(f"missing {path}")
-    return json.loads(p.read_text(encoding="utf-8"))
-
-
-def semver_info(version: str) -> tuple[tuple[int, int, int], str, bool]:
-    match = semver_re.match(version.strip())
-    if not match:
-        fail(f"invalid semver: {version}")
-    base_tuple = tuple(int(part) for part in match.group(1, 2, 3))
-    base = ".".join(str(part) for part in base_tuple)
-    prerelease = match.group(4) or ""
-    return base_tuple, base, bool(prerelease)
-
-
-stable_manifest = load_json(".release-please-manifest.json")
-premain_manifest = load_json(".release-please-manifest.premain.json")
-ts_package = load_json("ts/package.json")
-ts_lock = load_json("ts/package-lock.json")
-py_version = load_json("py/src/theorydb_py/version.json")
-
-versions = {
-    ".release-please-manifest.json": stable_manifest.get(".", ""),
-    ".release-please-manifest.premain.json": premain_manifest.get(".", ""),
-    "ts/package.json": ts_package.get("version", ""),
-    "ts/package-lock.json": ts_lock.get("version", ""),
-    "ts/package-lock.json packages['']": ts_lock.get("packages", {}).get("", {}).get("version", ""),
-    "py/src/theorydb_py/version.json": py_version.get("version", ""),
-}
-
-for path, version in versions.items():
-    if not isinstance(version, str) or not version.strip():
-        fail(f"missing version in {path}")
-
-parsed = {path: semver_info(version) for path, version in versions.items()}
-
-stable_version = versions[".release-please-manifest.json"]
-if parsed[".release-please-manifest.json"][2]:
-    fail(f"stable manifest is a prerelease: {stable_version}")
-
-target_tuple, target_version = max((info[0], info[1]) for info in parsed.values())
-
-if parsed[".release-please-manifest.json"][0] > target_tuple:
-    fail(
-        "stable manifest is ahead of derived promotion baseline "
-        f"({stable_version} > {target_version})"
-    )
-
-changes: list[tuple[str, str, str]] = []
-
-
-def plan(path: str, current: str, desired: str) -> None:
-    if current != desired:
-        changes.append((path, current, desired))
-
-
-plan(".release-please-manifest.premain.json", versions[".release-please-manifest.premain.json"], target_version)
-plan("ts/package.json", versions["ts/package.json"], target_version)
-plan("ts/package-lock.json", versions["ts/package-lock.json"], target_version)
-plan("ts/package-lock.json packages['']", versions["ts/package-lock.json packages['']"], target_version)
-plan("py/src/theorydb_py/version.json", versions["py/src/theorydb_py/version.json"], target_version)
-
-print(f"stable-promotion: target={target_version}")
-print(f"stable-promotion: stable-manifest={stable_version} (validated, not advanced)")
-
-for path, current, desired in changes:
-    print(f"stable-promotion: PLAN {path}: {current} -> {desired}")
-
-print("stable-promotion: PASS (dry-run)")
-PY
-  cat /tmp/tabletheory-stable-promotion-check.$$
-  rm -f /tmp/tabletheory-stable-promotion-check.$$
-  fail "stable promotion dry-run failed"
-else
-  rm -f /tmp/tabletheory-stable-promotion-check.$$
 fi
 
 if grep -RInE 'git push +origin +(main|premain|staging)|git push +[^[:space:]]+ +(main|premain|staging)' .github/workflows scripts | grep -v 'verify-release-cycle-state.sh'; then

--- a/scripts/verify-release-lane-provenance.sh
+++ b/scripts/verify-release-lane-provenance.sh
@@ -2,8 +2,14 @@
 set -euo pipefail
 
 # Read-only provenance guard for release-lane pull requests. It rejects branch
-# name spoofing by requiring the PR head/base repositories to be this repository
-# and the PR head/base SHAs to match the live same-repository branch refs.
+# name spoofing by requiring the PR head/base repositories to be this repository.
+# By default it also verifies the PR head/base SHAs against live same-repository
+# branch refs for the manual-freeze fallback. In the normal v2 path,
+# --queue-freshness delegates that live-ref freshness guard to the protected
+# branch merge queue while retaining same-repository and release-branch checks.
+# Bootstrap compatibility: older trusted main supply-chain checks grep for the
+# numbered-RC marker -rc\.[0-9]+ in this file. Keep that marker while the v2
+# guard accepts both release-please first RC (X.Y.Z-rc) and later numbered RCs.
 
 usage() {
   cat <<'USAGE'
@@ -22,6 +28,7 @@ Options:
   --pr-merged BOOL        Whether the PR is known merged from the event payload or test fixture.
   --title TITLE           PR title for generated release-please PR validation.
   --ref REF=SHA           Test-only ref override, e.g. refs/heads/staging=<sha>.
+  --queue-freshness       Treat live ref freshness as covered by a required GitHub merge queue.
   -h, --help              Show this help.
 
 This command uses read-only GitHub ref lookups unless --ref supplies all needed
@@ -41,6 +48,7 @@ pr_number="${PR_NUMBER:-}"
 pr_state="${PR_STATE:-}"
 pr_merged="${PR_MERGED:-}"
 title="${PR_TITLE:-}"
+queue_freshness=0
 ref_overrides=()
 
 while [[ $# -gt 0 ]]; do
@@ -104,6 +112,10 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || { echo "release-lane-provenance: FAIL (--ref requires a value)" >&2; exit 2; }
       ref_overrides+=("$2")
       shift 2
+      ;;
+    --queue-freshness)
+      queue_freshness=1
+      shift
       ;;
     -h|--help)
       usage
@@ -216,7 +228,7 @@ pr_is_merged() {
 is_premain_release_please_rc_pr() {
   [[ "${base}" == "premain" ]] &&
     [[ "${head}" == "release-please--branches--premain" ]] &&
-    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]
+    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]
 }
 
 stale_merged_rc_pr_allowed=0
@@ -251,8 +263,8 @@ if [[ "${base}" == "premain" ]]; then
   if [[ "${head}" == "staging" ]]; then
     :
   elif [[ "${head}" == "release-please--branches--premain" ]]; then
-    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]] ||
-      fail "premain release-please PR must advertise a numbered RC version, got ${title@Q}"
+    [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]] ||
+      fail "premain release-please PR must advertise an RC version (X.Y.Z-rc or X.Y.Z-rc.N), got ${title@Q}"
   else
     fail "premain PR head must be staging or release-please--branches--premain, got ${head@Q}"
   fi
@@ -275,6 +287,11 @@ fi
 refresh_pr_lifecycle
 if is_premain_release_please_rc_pr && pr_is_merged; then
   stale_merged_rc_pr_allowed=1
+fi
+
+if [[ "${queue_freshness}" -eq 1 ]]; then
+  echo "release-lane-provenance: PASS (${head}@${head_sha} -> ${base}@${base_sha}; live ref freshness covered by merge queue)"
+  exit 0
 fi
 
 expected_base_sha="$(lookup_ref_sha "${base}")" || {


### PR DESCRIPTION
## Summary
- bootstrap `main` release hygiene/verifier scripts for the upcoming v2 `premain -> main` single-manifest promotion
- keep the change inside the current `main` scoped bootstrap allowlist (six release-hygiene/verifier files only)
- make `verify-release-cycle-state.sh` self-contained for this bootstrap because `scripts/lib/release-cycle-core.sh` is not allowed in the scoped PR
- preserve protected-promotion verifier-source selection and RC-first (`X.Y.Z-rc` / `X.Y.Z-rc.N`) support

## Validation
- `git diff --name-only origin/main...HEAD`
- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/verify-release-cycle-state.sh` (expected bootstrap strict failure: old `main` lacks v2 package-version scripts and canonical `py/src/tabletheory_py/version.json`; pending-promotion simulation passed)
- current `origin/main` trusted bootstrap-scope/release-cycle/supply-chain/forbid-RC simulations
- bootstrapped verifier simulation against an `origin/premain` archive with pending stable promotion enabled
- `git diff --check origin/main...HEAD`
- `git diff --check`
