### PR TITLE
fix(ci): harden post-v2 release hygiene gates

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -45,11 +45,6 @@ jobs:
           cache: npm
           cache-dependency-path: ts/package-lock.json
 
-      - name: Install uv (pinned)
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv==0.9.26
-
       - name: Install tooling (pinned)
         run: |
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
@@ -60,6 +55,66 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ripgrep
+
+      - name: Set up Python 3.12 compatibility
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Run Python 3.12 pre-merge compatibility
+        env:
+          AWS_REGION: us-east-1
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+          DYNAMODB_ENDPOINT: http://localhost:8000
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install uv==0.9.26
+          uv --directory py sync --frozen --all-extras
+          uv --directory py run ruff format --check .
+          uv --directory py run ruff check .
+          uv --directory py run mypy src
+          uv --directory py run python -m build
+          uv --directory py run pytest -q tests/unit tests/integration
+          rm -rf py/.venv py/build py/dist
+          find py/src -maxdepth 1 -type d -name "*.egg-info" -prune -exec rm -rf {} +
+
+      - name: Set up Node 20 compatibility
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ts/package-lock.json
+
+      - name: Run Node 20 pre-merge compatibility
+        env:
+          AWS_REGION: us-east-1
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+          DYNAMODB_ENDPOINT: http://localhost:8000
+        run: |
+          npm --prefix ts ci
+          npm --prefix ts run check
+          npm --prefix ts run test:integration
+
+      - name: Restore Python 3.14 for rubric
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+
+      - name: Install uv for rubric (pinned)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install uv==0.9.26
+
+      - name: Restore Node 24 for rubric
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: ts/package-lock.json
 
       - name: Run rubric
         env:

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -76,7 +76,8 @@ jobs:
           uv --directory py run ruff check .
           uv --directory py run mypy src
           uv --directory py run python -m build
-          uv --directory py run pytest -q tests/unit tests/integration
+          uv --directory py run pytest -q tests/unit
+          uv --directory py run pytest -q tests/integration
           rm -rf py/.venv py/build py/dist
           find py/src -maxdepth 1 -type d -name "*.egg-info" -prune -exec rm -rf {} +
 

--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -112,24 +112,109 @@ jobs:
       - name: Resolve release hygiene target branch
         if: github.event_name != 'pull_request'
         id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           target="${GITHUB_REF_NAME}"
+          queued_head=""
           if [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
-            target="$(
+            resolved="$(
               python3 - <<'PY'
           import json
           import os
+          import re
+          import subprocess
           from pathlib import Path
 
+
+          def strip_heads_prefix(value: str) -> str:
+              return value.removeprefix("refs/heads/")
+
+
+          def get_path(obj, *parts):
+              value = obj
+              for part in parts:
+                  if isinstance(value, dict):
+                      value = value.get(part)
+                  elif isinstance(value, list) and isinstance(part, int) and 0 <= part < len(value):
+                      value = value[part]
+                  else:
+                      return ""
+              return value if isinstance(value, str) else ""
+
+
+          def is_queue_ref(value: str) -> bool:
+              stripped = strip_heads_prefix(value)
+              return stripped.startswith("gh-readonly-queue/")
+
+
+          def first_payload_head_ref(merge_group: dict) -> tuple[str, str]:
+              candidates = [
+                  ("merge_group.pull_request.head.ref", get_path(merge_group, "pull_request", "head", "ref")),
+                  ("merge_group.pull_request.headRefName", get_path(merge_group, "pull_request", "headRefName")),
+                  ("merge_group.pull_requests[0].head.ref", get_path(merge_group, "pull_requests", 0, "head", "ref")),
+                  ("merge_group.pull_requests[0].headRefName", get_path(merge_group, "pull_requests", 0, "headRefName")),
+                  ("merge_group.pull_requests[0].head_branch", get_path(merge_group, "pull_requests", 0, "head_branch")),
+                  ("merge_group.source_ref", get_path(merge_group, "source_ref")),
+              ]
+              for source, value in candidates:
+                  value = strip_heads_prefix(str(value or ""))
+                  if value and not is_queue_ref(value):
+                      return value, source
+
+              head_ref = strip_heads_prefix(str(merge_group.get("head_ref") or ""))
+              if head_ref and not is_queue_ref(head_ref):
+                  return head_ref, "merge_group.head_ref"
+
+              return "", ""
+
+
+          def pr_number_from_queue_ref(merge_group: dict) -> str:
+              for value in (str(merge_group.get("head_ref") or ""), os.environ.get("GITHUB_REF", "")):
+                  match = re.search(r"(?:^|/)pr-(\d+)(?:[-/]|$)", value)
+                  if match:
+                      return match.group(1)
+              return ""
+
+
+          def head_ref_from_pr(number: str) -> tuple[str, str]:
+              repo = os.environ.get("GITHUB_REPOSITORY", "")
+              if not number or not repo or not os.environ.get("GH_TOKEN"):
+                  return "", ""
+              try:
+                  completed = subprocess.run(
+                      ["gh", "pr", "view", number, "--repo", repo, "--json", "headRefName"],
+                      check=True,
+                      text=True,
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.DEVNULL,
+                  )
+                  data = json.loads(completed.stdout)
+              except Exception:
+                  return "", ""
+              head_ref = strip_heads_prefix(str(data.get("headRefName") or ""))
+              return (head_ref, f"gh pr view {number}") if head_ref else ("", "")
+
+
           event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
-          base_ref = str(event.get("merge_group", {}).get("base_ref", ""))
-          if base_ref.startswith("refs/heads/"):
-              base_ref = base_ref.removeprefix("refs/heads/")
-          print(base_ref)
+          merge_group = event.get("merge_group", {})
+          base_ref = strip_heads_prefix(str(merge_group.get("base_ref") or ""))
+          head_ref, head_source = first_payload_head_ref(merge_group)
+          if not head_ref:
+              head_ref, head_source = head_ref_from_pr(pr_number_from_queue_ref(merge_group))
+          print(json.dumps({"branch": base_ref, "head": head_ref, "head_source": head_source}, separators=(",", ":")))
           PY
             )"
+            target="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("branch", ""))' <<<"${resolved}")"
+            queued_head="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("head", ""))' <<<"${resolved}")"
+            queued_head_source="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("head_source", ""))' <<<"${resolved}")"
+            if [[ -n "${queued_head}" ]]; then
+              echo "release-hygiene: merge_group source head ${queued_head} (${queued_head_source})"
+            else
+              echo "release-hygiene: merge_group source head unavailable from payload/API"
+            fi
           fi
 
           case "${target}" in
@@ -141,7 +226,10 @@ jobs:
               ;;
           esac
 
-          echo "branch=${target}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "branch=${target}"
+            echo "head=${queued_head}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Verify human promotion release driver
         if: github.event_name == 'pull_request' && ((github.base_ref == 'premain' && github.head_ref == 'staging') || (github.base_ref == 'main' && github.head_ref == 'premain'))
@@ -272,6 +360,7 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           TARGET_BRANCH: ${{ steps.target.outputs.branch }}
+          QUEUE_HEAD_REF: ${{ steps.target.outputs.head }}
         run: |
           set -euo pipefail
 
@@ -289,11 +378,16 @@ jobs:
           fi
 
           if [[ "${TARGET_BRANCH}" == "main" ]] && \
-            GITHUB_BASE_REF=main GITHUB_HEAD_REF=premain RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true \
+            [[ -n "${QUEUE_HEAD_REF}" ]] && \
+            GITHUB_BASE_REF=main GITHUB_HEAD_REF="${QUEUE_HEAD_REF}" RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true \
               bash scripts/verify-release-cycle-state.sh >"${pending_log}" 2>&1; then
             cat "${pending_log}"
-            echo "release-hygiene: pending stable promotion accepted on queued main merge group"
+            echo "release-hygiene: pending stable promotion accepted on queued main merge group from ${QUEUE_HEAD_REF}"
             exit 0
+          fi
+
+          if [[ "${TARGET_BRANCH}" == "main" && -z "${QUEUE_HEAD_REF}" ]]; then
+            echo "release-hygiene: FAIL (queued main pending stable promotion could not derive merge_group PR head)" >>"${pending_log}"
           fi
 
           cat "${strict_log}"

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -551,6 +551,34 @@ expect_failure_contains \
     --ref "refs/heads/premain=${base_sha}" \
     --ref "refs/heads/release-please--branches--premain=${head_sha}"
 
+expect_failure_contains \
+  "main PR must not advertise an RC version" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base main \
+    --head release-please--branches--main \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "chore(main): release 2.0.0-rc" \
+    --ref "refs/heads/main=${base_sha}" \
+    --ref "refs/heads/release-please--branches--main=${head_sha}"
+
+expect_failure_contains \
+  "main PR must not advertise an RC version" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base main \
+    --head premain \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "Promote 2.0.0-rc.1 to main" \
+    --ref "refs/heads/main=${base_sha}" \
+    --ref "refs/heads/premain=${head_sha}"
+
 expect_success_contains \
   "stale merged premain release-please RC PR" \
   bash "${checker}" \

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -51,6 +51,18 @@ expect_failure_contains() {
   fi
 }
 
+expect_contains() {
+  local output="$1"
+  local expected="$2"
+  local context="$3"
+
+  if [[ -n "${expected}" ]] && ! grep -Fq "${expected}" <<<"${output}"; then
+    printf '%s\n' "${output}"
+    echo "release-hygiene-policy-test: ${context}: expected output to contain: ${expected}"
+    exit 1
+  fi
+}
+
 write_prerelease_postcondition_fixture() {
   local root="$1"
   local version="$2"
@@ -205,16 +217,21 @@ PY
 
 extract_workflow_step_run() {
   local step_name="$1"
+  local occurrence="${2:-1}"
 
-  python3 - "${repo_root}/.github/workflows/release-hygiene.yml" "${step_name}" <<'PY'
+  python3 - "${repo_root}/.github/workflows/release-hygiene.yml" "${step_name}" "${occurrence}" <<'PY'
 import re
 import sys
 
-workflow_path, step_name = sys.argv[1], sys.argv[2]
+workflow_path, step_name, occurrence = sys.argv[1], sys.argv[2], int(sys.argv[3])
 lines = open(workflow_path, "r", encoding="utf-8").read().splitlines()
+seen = 0
 
 for idx, line in enumerate(lines):
     if not re.match(r"\s*-\s+name:\s*" + re.escape(step_name) + r"\s*$", line):
+        continue
+    seen += 1
+    if seen != occurrence:
         continue
 
     search_idx = idx + 1
@@ -434,6 +451,150 @@ assert_selector_failure() {
     echo "release-hygiene-policy-test: selector failure output missing: ${expected_output}"
     exit 1
   fi
+}
+
+run_merge_group_target_fixture() {
+  local target_branch="$1"
+  local source_head="$2"
+
+  local fixture
+  fixture="$(mktemp -d)"
+  tmpdirs+=("${fixture}")
+
+  python3 - "${fixture}/event.json" "${target_branch}" "${source_head}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+target_branch = sys.argv[2]
+source_head = sys.argv[3]
+path.write_text(
+    json.dumps(
+        {
+            "merge_group": {
+                "base_ref": f"refs/heads/{target_branch}",
+                "head_ref": f"refs/heads/gh-readonly-queue/{target_branch}/pr-123-deadbeef",
+                "pull_requests": [
+                    {
+                        "number": 123,
+                        "base": {"ref": target_branch},
+                        "head": {"ref": source_head},
+                    }
+                ],
+            }
+        }
+    ),
+    encoding="utf-8",
+)
+PY
+
+  local resolver_script="${fixture}/target.sh"
+  extract_workflow_step_run "Resolve release hygiene target branch" >"${resolver_script}"
+
+  local output_file="${fixture}/target.out"
+  local github_output="${fixture}/github-output"
+  set +e
+  env \
+    GITHUB_EVENT_NAME=merge_group \
+    GITHUB_EVENT_PATH="${fixture}/event.json" \
+    GITHUB_REF="refs/heads/gh-readonly-queue/${target_branch}/pr-123-deadbeef" \
+    GITHUB_REF_NAME="gh-readonly-queue/${target_branch}/pr-123-deadbeef" \
+    GITHUB_REPOSITORY="${repo}" \
+    GITHUB_OUTPUT="${github_output}" \
+    bash "${resolver_script}" >"${output_file}" 2>&1
+  local status=$?
+  set -e
+
+  printf '%s\n' "${output_file}:${github_output}:${status}"
+}
+
+assert_target_result() {
+  local output_pair="$1"
+  local expected_branch="$2"
+  local expected_head="$3"
+
+  local output_file="${output_pair%%:*}"
+  local remainder="${output_pair#*:}"
+  local github_output="${remainder%%:*}"
+  local status="${remainder#*:}"
+
+  if [[ "${status}" -ne 0 ]]; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: target resolver expected success, got ${status}"
+    exit 1
+  fi
+  if ! grep -Fxq "branch=${expected_branch}" "${github_output}"; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: target branch mismatch; expected ${expected_branch}"
+    exit 1
+  fi
+  if ! grep -Fxq "head=${expected_head}" "${github_output}"; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: queued head mismatch; expected ${expected_head}"
+    exit 1
+  fi
+  if ! grep -Fq "merge_group source head ${expected_head}" "${output_file}"; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: target resolver output missing derived head ${expected_head}"
+    exit 1
+  fi
+}
+
+run_queued_main_cycle_step_fixture() {
+  local queue_head="$1"
+  local expected_status="$2"
+  local expected_text="$3"
+
+  local fixture
+  fixture="$(mktemp -d)"
+  tmpdirs+=("${fixture}")
+
+  mkdir -p \
+    "${fixture}/.github/workflows" \
+    "${fixture}/scripts/lib" \
+    "${fixture}/ts" \
+    "${fixture}/py/src/tabletheory_py"
+  cp "${repo_root}/scripts/verify-release-cycle-state.sh" "${fixture}/scripts/verify-release-cycle-state.sh"
+  cp "${repo_root}/scripts/lib/release-cycle-core.sh" "${fixture}/scripts/lib/release-cycle-core.sh"
+  cat >"${fixture}/.release-please-manifest.json" <<'JSON'
+{".":"1.10.1-rc.1"}
+JSON
+  cat >"${fixture}/ts/package.json" <<'JSON'
+{"version":"1.10.0"}
+JSON
+  cat >"${fixture}/ts/package-lock.json" <<'JSON'
+{"version":"1.10.0","packages":{"":{"version":"1.10.0"}}}
+JSON
+  cat >"${fixture}/py/src/tabletheory_py/version.json" <<'JSON'
+{"version":"1.10.0"}
+JSON
+  touch \
+    "${fixture}/.github/workflows/release-hygiene.yml" \
+    "${fixture}/scripts/prepare-release-package-versions.py" \
+    "${fixture}/scripts/verify-release-package-version-assets.py" \
+    "${fixture}/scripts/watch-release-cycle.sh"
+
+  local cycle_script="${fixture}/cycle-step.sh"
+  extract_workflow_step_run "Verify release cycle state" 2 >"${cycle_script}"
+
+  local output status
+  set +e
+  output="$(
+    cd "${fixture}"
+    TARGET_BRANCH=main QUEUE_HEAD_REF="${queue_head}" bash "${cycle_script}" 2>&1
+  )"
+  status=$?
+  set -e
+
+  if [[ "${status}" -ne "${expected_status}" ]]; then
+    printf '%s\n' "${output}"
+    echo "release-hygiene-policy-test: queued main cycle step ${queue_head}: expected ${expected_status}, got ${status}"
+    exit 1
+  fi
+  expect_contains "${output}" "${expected_text}" "queued main cycle step ${queue_head}"
 }
 
 common_args=(
@@ -1124,10 +1285,36 @@ assert_selector_failure \
   "${selector_result}" \
   "protected PR head lacks v2 single-manifest support or RC-first verifier support"
 
+target_result="$(run_merge_group_target_fixture main premain)"
+assert_target_result "${target_result}" main premain
+
+target_result="$(run_merge_group_target_fixture main "feature/not-premain")"
+assert_target_result "${target_result}" main "feature/not-premain"
+
+run_queued_main_cycle_step_fixture \
+  premain \
+  0 \
+  "pending stable promotion accepted on queued main merge group from premain"
+
+run_queued_main_cycle_step_fixture \
+  "feature/not-premain" \
+  1 \
+  "pending stable promotion mode is only allowed for premain -> main (head branch: feature/not-premain)"
+
 grep -Fq "pending stable promotion accepted on queued main merge group" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene must allow queued main pending stable promotion"
   exit 1
 }
+
+grep -Fq 'GITHUB_HEAD_REF="${QUEUE_HEAD_REF}"' "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: queued main pending fallback must use the derived merge_group head"
+  exit 1
+}
+
+if grep -Fq 'GITHUB_HEAD_REF=premain RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true' "${repo_root}/.github/workflows/release-hygiene.yml"; then
+  echo "release-hygiene-policy-test: queued main pending fallback must not fabricate GITHUB_HEAD_REF=premain"
+  exit 1
+fi
 
 grep -Fq "../trusted-release/scripts/verify-promotion-release-driver.sh" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: promotion driver must run from trusted checkout"

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -456,12 +456,13 @@ assert_selector_failure() {
 run_merge_group_target_fixture() {
   local target_branch="$1"
   local source_head="$2"
+  local payload_shape="${3:-payload-head}"
 
   local fixture
   fixture="$(mktemp -d)"
   tmpdirs+=("${fixture}")
 
-  python3 - "${fixture}/event.json" "${target_branch}" "${source_head}" <<'PY'
+  python3 - "${fixture}/event.json" "${target_branch}" "${source_head}" "${payload_shape}" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -469,22 +470,21 @@ from pathlib import Path
 path = Path(sys.argv[1])
 target_branch = sys.argv[2]
 source_head = sys.argv[3]
-path.write_text(
-    json.dumps(
+payload_shape = sys.argv[4]
+merge_group = {
+    "base_ref": f"refs/heads/{target_branch}",
+    "head_ref": f"refs/heads/gh-readonly-queue/{target_branch}/pr-123-deadbeef",
+}
+if payload_shape == "payload-head":
+    merge_group["pull_requests"] = [
         {
-            "merge_group": {
-                "base_ref": f"refs/heads/{target_branch}",
-                "head_ref": f"refs/heads/gh-readonly-queue/{target_branch}/pr-123-deadbeef",
-                "pull_requests": [
-                    {
-                        "number": 123,
-                        "base": {"ref": target_branch},
-                        "head": {"ref": source_head},
-                    }
-                ],
-            }
+            "number": 123,
+            "base": {"ref": target_branch},
+            "head": {"ref": source_head},
         }
-    ),
+    ]
+path.write_text(
+    json.dumps({"merge_group": merge_group}),
     encoding="utf-8",
 )
 PY
@@ -494,15 +494,39 @@ PY
 
   local output_file="${fixture}/target.out"
   local github_output="${fixture}/github-output"
+  local -a env_args=(
+    GITHUB_EVENT_NAME=merge_group
+    GITHUB_EVENT_PATH="${fixture}/event.json"
+    GITHUB_REF="refs/heads/gh-readonly-queue/${target_branch}/pr-123-deadbeef"
+    GITHUB_REF_NAME="gh-readonly-queue/${target_branch}/pr-123-deadbeef"
+    GITHUB_REPOSITORY="${repo}"
+    GITHUB_OUTPUT="${github_output}"
+  )
+
+  if [[ "${payload_shape}" == "api-head" ]]; then
+    mkdir -p "${fixture}/bin"
+    cat >"${fixture}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -eq 7 && "$1" == "pr" && "$2" == "view" && "$3" == "123" && "$4" == "--repo" && "$6" == "--json" && "$7" == "headRefName" ]]; then
+  printf '{"headRefName":"%s"}\n' "${STUB_GH_HEAD_REF:-}"
+  exit 0
+fi
+
+echo "unexpected gh arguments: $*" >&2
+exit 1
+SH
+    chmod +x "${fixture}/bin/gh"
+    env_args+=(
+      GH_TOKEN=stub-token
+      PATH="${fixture}/bin:${PATH}"
+      STUB_GH_HEAD_REF="${source_head}"
+    )
+  fi
+
   set +e
-  env \
-    GITHUB_EVENT_NAME=merge_group \
-    GITHUB_EVENT_PATH="${fixture}/event.json" \
-    GITHUB_REF="refs/heads/gh-readonly-queue/${target_branch}/pr-123-deadbeef" \
-    GITHUB_REF_NAME="gh-readonly-queue/${target_branch}/pr-123-deadbeef" \
-    GITHUB_REPOSITORY="${repo}" \
-    GITHUB_OUTPUT="${github_output}" \
-    bash "${resolver_script}" >"${output_file}" 2>&1
+  env "${env_args[@]}" bash "${resolver_script}" >"${output_file}" 2>&1
   local status=$?
   set -e
 
@@ -513,6 +537,7 @@ assert_target_result() {
   local output_pair="$1"
   local expected_branch="$2"
   local expected_head="$3"
+  local expected_source="${4:-}"
 
   local output_file="${output_pair%%:*}"
   local remainder="${output_pair#*:}"
@@ -539,6 +564,44 @@ assert_target_result() {
   if ! grep -Fq "merge_group source head ${expected_head}" "${output_file}"; then
     cat "${output_file}"
     echo "release-hygiene-policy-test: target resolver output missing derived head ${expected_head}"
+    exit 1
+  fi
+  if [[ -n "${expected_source}" ]] && ! grep -Fq "(${expected_source})" "${output_file}"; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: target resolver output missing source ${expected_source}"
+    exit 1
+  fi
+}
+
+assert_target_empty_head_result() {
+  local output_pair="$1"
+  local expected_branch="$2"
+
+  local output_file="${output_pair%%:*}"
+  local remainder="${output_pair#*:}"
+  local github_output="${remainder%%:*}"
+  local status="${remainder#*:}"
+
+  if [[ "${status}" -ne 0 ]]; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: target resolver expected success, got ${status}"
+    exit 1
+  fi
+  if ! grep -Fxq "branch=${expected_branch}" "${github_output}"; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: target branch mismatch; expected ${expected_branch}"
+    exit 1
+  fi
+  if ! grep -Fxq "head=" "${github_output}"; then
+    cat "${output_file}"
+    cat "${github_output}"
+    echo "release-hygiene-policy-test: queued head should remain empty"
+    exit 1
+  fi
+  if ! grep -Fq "merge_group source head unavailable from payload/API" "${output_file}"; then
+    cat "${output_file}"
+    echo "release-hygiene-policy-test: target resolver output missing empty-head diagnostic"
     exit 1
   fi
 }
@@ -723,6 +786,20 @@ expect_failure_contains \
     --base-sha "${base_sha}" \
     --head-sha "${head_sha}" \
     --title "chore(main): release 2.0.0-rc" \
+    --ref "refs/heads/main=${base_sha}" \
+    --ref "refs/heads/release-please--branches--main=${head_sha}"
+
+expect_success_contains \
+  "release-lane-provenance: PASS" \
+  bash "${checker}" \
+    --repo "${repo}" \
+    --base main \
+    --head release-please--branches--main \
+    --base-repo "${repo}" \
+    --head-repo "${repo}" \
+    --base-sha "${base_sha}" \
+    --head-sha "${head_sha}" \
+    --title "chore(main): release 2.0.0" \
     --ref "refs/heads/main=${base_sha}" \
     --ref "refs/heads/release-please--branches--main=${head_sha}"
 
@@ -1291,6 +1368,15 @@ assert_target_result "${target_result}" main premain
 target_result="$(run_merge_group_target_fixture main "feature/not-premain")"
 assert_target_result "${target_result}" main "feature/not-premain"
 
+target_result="$(run_merge_group_target_fixture main premain api-head)"
+assert_target_result "${target_result}" main premain "gh pr view 123"
+
+target_result="$(run_merge_group_target_fixture main "feature/not-premain" api-head)"
+assert_target_result "${target_result}" main "feature/not-premain" "gh pr view 123"
+
+target_result="$(run_merge_group_target_fixture main "" api-head)"
+assert_target_empty_head_result "${target_result}" main
+
 run_queued_main_cycle_step_fixture \
   premain \
   0 \
@@ -1300,6 +1386,11 @@ run_queued_main_cycle_step_fixture \
   "feature/not-premain" \
   1 \
   "pending stable promotion mode is only allowed for premain -> main (head branch: feature/not-premain)"
+
+run_queued_main_cycle_step_fixture \
+  "" \
+  1 \
+  "queued main pending stable promotion could not derive merge_group PR head"
 
 grep -Fq "pending stable promotion accepted on queued main merge group" "${repo_root}/.github/workflows/release-hygiene.yml" || {
   echo "release-hygiene-policy-test: release hygiene must allow queued main pending stable promotion"

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -120,8 +120,10 @@ if [[ -f ".github/workflows/quality-gates.yml" ]]; then
     "quality-gates must cover Python 3.12 before staging merge"
   require_fixed "Run Python 3.12 pre-merge compatibility" "${q}" \
     "quality-gates must name the Python 3.12 pre-merge compatibility step"
-  require_fixed "uv --directory py run pytest -q tests/unit tests/integration" "${q}" \
-    "quality-gates Python 3.12 check must include unit and integration tests"
+  require_fixed "uv --directory py run pytest -q tests/unit" "${q}" \
+    "quality-gates Python 3.12 check must include unit tests"
+  require_fixed "uv --directory py run pytest -q tests/integration" "${q}" \
+    "quality-gates Python 3.12 check must include integration tests"
   require_fixed 'node-version: "20"' "${q}" \
     "quality-gates must cover Node 20 before staging merge"
   require_fixed "Run Node 20 pre-merge compatibility" "${q}" \

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -116,6 +116,22 @@ if [[ -f ".github/workflows/quality-gates.yml" ]]; then
     "quality-gates must support workflow_dispatch"
   require_fixed "run: make rubric" "${q}" \
     "quality-gates must run the full rubric"
+  require_fixed 'python-version: "3.12"' "${q}" \
+    "quality-gates must cover Python 3.12 before staging merge"
+  require_fixed "Run Python 3.12 pre-merge compatibility" "${q}" \
+    "quality-gates must name the Python 3.12 pre-merge compatibility step"
+  require_fixed "uv --directory py run pytest -q tests/unit tests/integration" "${q}" \
+    "quality-gates Python 3.12 check must include unit and integration tests"
+  require_fixed 'node-version: "20"' "${q}" \
+    "quality-gates must cover Node 20 before staging merge"
+  require_fixed "Run Node 20 pre-merge compatibility" "${q}" \
+    "quality-gates must name the Node 20 pre-merge compatibility step"
+  require_fixed "npm --prefix ts run test:integration" "${q}" \
+    "quality-gates Node 20 check must include integration tests"
+  require_fixed "Restore Python 3.14 for rubric" "${q}" \
+    "quality-gates must restore Python 3.14 before make rubric"
+  require_fixed "Restore Node 24 for rubric" "${q}" \
+    "quality-gates must restore Node 24 before make rubric"
   require_fixed "gov-infra/evidence" "${q}" \
     "quality-gates must upload gov-infra evidence artifacts"
   legacy_evidence_path="hgm""-infra/evidence"

--- a/scripts/verify-ci-rubric-enforced.sh
+++ b/scripts/verify-ci-rubric-enforced.sh
@@ -124,6 +124,21 @@ else
   failures=$((failures + 1))
 fi
 
+# Staging PRs no longer run the standalone TS/Python PR matrices; require the
+# Quality Gates job itself to exercise the lower supported runtimes before merge.
+grep -Eq 'node-version:[[:space:]]*["'"'"']?20(\\.x)?["'"'"']?' "${wf}" || {
+  echo "ci-rubric: ${wf}: staging Quality Gates must include Node 20 compatibility"
+  failures=$((failures + 1))
+}
+grep -Fq 'Run Node 20 pre-merge compatibility' "${wf}" || {
+  echo "ci-rubric: ${wf}: missing Node 20 pre-merge compatibility step"
+  failures=$((failures + 1))
+}
+grep -Fq 'npm --prefix ts run test:integration' "${wf}" || {
+  echo "ci-rubric: ${wf}: Node 20 compatibility must include TypeScript integration tests"
+  failures=$((failures + 1))
+}
+
 # Rubric includes Python checks; require Python setup (pinned).
 if grep -Eq '^[[:space:]]*uses:[[:space:]]*actions/setup-python@' "${wf}"; then
   grep -Ev '^[[:space:]]*#' "${wf}" | grep -Eq 'python-version:[[:space:]]*"?3[.]14([.]x)?"?' || {
@@ -134,6 +149,27 @@ else
   echo "ci-rubric: ${wf}: missing actions/setup-python step"
   failures=$((failures + 1))
 fi
+
+grep -Eq 'python-version:[[:space:]]*"?3[.]12([.]x)?"?' "${wf}" || {
+  echo "ci-rubric: ${wf}: staging Quality Gates must include Python 3.12 compatibility"
+  failures=$((failures + 1))
+}
+grep -Fq 'Run Python 3.12 pre-merge compatibility' "${wf}" || {
+  echo "ci-rubric: ${wf}: missing Python 3.12 pre-merge compatibility step"
+  failures=$((failures + 1))
+}
+grep -Fq 'uv --directory py run pytest -q tests/unit tests/integration' "${wf}" || {
+  echo "ci-rubric: ${wf}: Python 3.12 compatibility must include unit and integration tests"
+  failures=$((failures + 1))
+}
+grep -Fq 'Restore Python 3.14 for rubric' "${wf}" || {
+  echo "ci-rubric: ${wf}: must restore Python 3.14 before make rubric"
+  failures=$((failures + 1))
+}
+grep -Fq 'Restore Node 24 for rubric' "${wf}" || {
+  echo "ci-rubric: ${wf}: must restore Node 24 before make rubric"
+  failures=$((failures + 1))
+}
 
 # Ensure pinned tooling installs (no @latest; additional pinning is checked by scripts/verify-ci-toolchain.sh).
 if grep -Eq 'go install .*@latest' "${wf}"; then

--- a/scripts/verify-ci-rubric-enforced.sh
+++ b/scripts/verify-ci-rubric-enforced.sh
@@ -158,8 +158,12 @@ grep -Fq 'Run Python 3.12 pre-merge compatibility' "${wf}" || {
   echo "ci-rubric: ${wf}: missing Python 3.12 pre-merge compatibility step"
   failures=$((failures + 1))
 }
-grep -Fq 'uv --directory py run pytest -q tests/unit tests/integration' "${wf}" || {
-  echo "ci-rubric: ${wf}: Python 3.12 compatibility must include unit and integration tests"
+grep -Fq 'uv --directory py run pytest -q tests/unit' "${wf}" || {
+  echo "ci-rubric: ${wf}: Python 3.12 compatibility must include unit tests"
+  failures=$((failures + 1))
+}
+grep -Fq 'uv --directory py run pytest -q tests/integration' "${wf}" || {
+  echo "ci-rubric: ${wf}: Python 3.12 compatibility must include integration tests"
   failures=$((failures + 1))
 }
 grep -Fq 'Restore Python 3.14 for rubric' "${wf}" || {

--- a/scripts/verify-release-lane-provenance.sh
+++ b/scripts/verify-release-lane-provenance.sh
@@ -228,6 +228,19 @@ is_premain_release_please_rc_pr() {
     [[ "${title}" =~ ^chore\(premain\):[[:space:]]release[[:space:]][0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]
 }
 
+main_title_advertises_rc_version() {
+  python3 - "${title}" <<'PY'
+import re
+import sys
+
+title = sys.argv[1]
+rc_version = re.compile(
+    r"(^|[^0-9A-Za-z.])v?[0-9]+\.[0-9]+\.[0-9]+-rc(?:[0-9A-Za-z.-]*)([^0-9A-Za-z.]|$)"
+)
+raise SystemExit(0 if rc_version.search(title) else 1)
+PY
+}
+
 stale_merged_rc_pr_allowed=0
 allow_stale_merged_rc_pr() {
   if [[ "${stale_merged_rc_pr_allowed}" -eq 1 ]]; then
@@ -266,7 +279,7 @@ if [[ "${base}" == "premain" ]]; then
     fail "premain PR head must be staging or release-please--branches--premain, got ${head@Q}"
   fi
 elif [[ "${base}" == "main" ]]; then
-  if [[ "${title}" =~ [0-9]+\.[0-9]+\.[0-9]+-rc([.\-[:alnum:]])* ]]; then
+  if main_title_advertises_rc_version; then
     fail "main PR must not advertise an RC version, got ${title@Q}"
   fi
   if [[ "${head}" == "premain" ]]; then


### PR DESCRIPTION
## Summary
- Fixes the release-lane provenance guard so RC-shaped `main` PR titles fail deterministically.
- Derives queued-main pending-stable `GITHUB_HEAD_REF` from the `merge_group` payload/API instead of fabricating `premain`, with allowed/disallowed coverage.
- Adds Python 3.12 and Node 20 compatibility checks into the existing staging Quality Gates job before `make rubric`, then restores Python 3.14 / Node 24 for the canonical rubric run.

Closes THE-2558; Closes THE-2559; Closes THE-2523

## Affected surface
- CI / release-lane workflow hygiene only.
- No runtime package/source behavior changes.
- No release execution or protected-branch/ruleset mutation.

## Validation
- Baseline on `staging@e0513772cf261d7751c20044beb369135ec9ebac`: `make test-unit` PASS; `make rubric` PASS (36/0/0).
- `bash -n scripts/verify-release-lane-provenance.sh scripts/test-release-hygiene-policy.sh scripts/verify-ci-rubric-enforced.sh scripts/verify-branch-release-supply-chain.sh` PASS.
- `bash scripts/test-release-hygiene-policy.sh` PASS.
- `bash scripts/verify-ci-rubric-enforced.sh` PASS.
- `bash scripts/verify-ci-toolchain.sh` PASS.
- `bash scripts/verify-branch-release-supply-chain.sh` PASS.
- `bash scripts/verify-release-cycle-state.sh` PASS.
- `git diff --check` PASS.
- `git diff --check origin/staging...HEAD` PASS.
- `make rubric` PASS (36/0/0).

## Notes
- The lower-runtime Quality Gates path runs Python 3.12 unit+integration checks and Node 20 unit/build+integration checks in the existing required `rubric` job, then restores the canonical Python 3.14 / Node 24 environment before `make rubric`.