### PR TITLE
fix(contract): harden harness assertion semantics

### DIFF
--- a/contract-tests/README.md
+++ b/contract-tests/README.md
@@ -23,6 +23,11 @@ contract-tests/
   attribute `type`.
 - Set attributes (`SS`/`NS`/`BS`) must be compared **order-insensitively**.
 - Cursor fixtures must be compared **byte-for-byte** (`.cursor` string).
+- Assertion collection keys must be omitted when unused. Present-but-empty maps/lists such as `item_equals: {}`,
+  `raw_item_contains: {}`, or `items_contains: []` are invalid fixtures; use scalar assertions such as `ok: true`,
+  `error: <ErrorCode>`, `item_count: 0`, or omit the assertion key instead.
+- Item/raw-item/read assertions cannot be combined with `error`/`errors` expectations. Assertion keys that inspect
+  returned data imply a successful operation/read even when `ok: true` is omitted.
 - P0 scenarios that describe newly specified behavior before every runtime has shipped support MUST declare
   `requires_capabilities`. Runners skip capability-gated scenarios until their runtime advertises that capability; the
   follow-up runtime milestone removes the skip by adding the advertised capability and making the scenario pass.
@@ -39,7 +44,7 @@ Run the Go runner:
 
 ```bash
 cd contract-tests/runners/go
-go test ./... -v
+go test ./... -count=1 -v
 ```
 
 Run the TypeScript runner:

--- a/contract-tests/runners/go/README.md
+++ b/contract-tests/runners/go/README.md
@@ -14,12 +14,13 @@ From the repo root:
 ```bash
 docker compose -f contract-tests/docker-compose.yml up -d
 cd contract-tests/runners/go
-go test ./... -v
+go test ./... -count=1 -v
 ```
 
 ## Notes
 
 - This folder is a **nested Go module** so it won’t affect `go test ./...` from the parent repo.
+- Use `-count=1` for local contract runs. The Go runner reads shared YAML fixtures outside the nested module, so fresh
+  execution is the least-surprise policy for repeated harness runs.
 - The `go.mod` uses a local `replace` to point at the parent `theorydb` module; remove it when extracting to a standalone
   `theorydb-contract-tests` repo.
-

--- a/contract-tests/runners/go/internal/runner/runner.go
+++ b/contract-tests/runners/go/internal/runner/runner.go
@@ -371,13 +371,13 @@ func (r *Runner) assertStepResult(t require.TestingT, expect scenario.Expectatio
 	if expect.Error != "" {
 		require.Error(t, err)
 		require.Equal(t, driver.ErrorCode(expect.Error), driver.MapError(err))
-		require.False(t, hasItemAssertion, "item assertions cannot be combined with error expectations")
+		require.False(t, hasItemAssertion || hasRawAssertion, "item assertions cannot be combined with error expectations")
 		return
 	}
 	if len(expect.Errors) > 0 {
 		require.Error(t, err)
 		require.ElementsMatch(t, errorCodesFromExpectation(expect.Errors), driver.MapErrors(err))
-		require.False(t, hasItemAssertion, "item assertions cannot be combined with error expectations")
+		require.False(t, hasItemAssertion || hasRawAssertion, "item assertions cannot be combined with error expectations")
 		return
 	}
 	if hasItemAssertion {

--- a/contract-tests/runners/go/internal/runner/runner_test.go
+++ b/contract-tests/runners/go/internal/runner/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/driver"
 	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/scenario"
 	"github.com/theory-cloud/tabletheory-contract-tests/runners/go/internal/spec"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 )
 
 type requireCaptureT struct {
@@ -77,6 +78,30 @@ func TestAssertStepResult_FailsClosedWhenItemAssertionHasNoItem(t *testing.T) {
 			scenario.Expectation{ItemMissingFields: []string{"nickname"}},
 			nil,
 			nil,
+			nil,
+			model,
+		)
+	})
+}
+
+func TestAssertStepResult_RejectsRawAssertionsWithErrorExpectations(t *testing.T) {
+	r := &Runner{vars: map[string]any{}}
+	model := spec.Model{
+		Name: "User",
+		Attributes: []spec.Attribute{
+			{Attribute: "PK", Type: "S"},
+		},
+	}
+
+	requireFails(t, func(requireT *requireCaptureT) {
+		r.assertStepResult(
+			requireT,
+			scenario.Expectation{
+				Error:           string(driver.ErrItemNotFound),
+				RawItemContains: map[string]any{"PK": "USER#1"},
+			},
+			nil,
+			theorydbErrors.ErrItemNotFound,
 			nil,
 			model,
 		)

--- a/contract-tests/runners/go/internal/scenario/scenario.go
+++ b/contract-tests/runners/go/internal/scenario/scenario.go
@@ -199,7 +199,7 @@ func validateStep(label string, i int, step Step) error {
 	}
 	switch step.Op {
 	case "sleep":
-		return nil
+		return validateExpectation(prefix, step.Expect)
 	case "create", "update", "save":
 		if len(step.Item) == 0 {
 			return fmt.Errorf("%s %s: item is required", prefix, step.Op)
@@ -209,9 +209,13 @@ func validateStep(label string, i int, step Step) error {
 			return fmt.Errorf("%s %s: key is required", prefix, step.Op)
 		}
 	case "query":
-		return validateQueryReadRequest(step.Query, fmt.Sprintf("%s query", prefix))
+		if err := validateQueryReadRequest(step.Query, fmt.Sprintf("%s query", prefix)); err != nil {
+			return err
+		}
 	case "scan":
-		return validateScanReadRequest(step.Scan, fmt.Sprintf("%s scan", prefix))
+		if err := validateScanReadRequest(step.Scan, fmt.Sprintf("%s scan", prefix)); err != nil {
+			return err
+		}
 	case "count":
 		if step.Count == nil {
 			return fmt.Errorf("%s count: count is required", prefix)
@@ -222,9 +226,14 @@ func validateStep(label string, i int, step Step) error {
 			return fmt.Errorf("%s count: exactly one of count.query or count.scan is required", prefix)
 		}
 		if hasQuery {
-			return validateQueryReadRequest(step.Count.Query, fmt.Sprintf("%s count.query", prefix))
+			if err := validateQueryReadRequest(step.Count.Query, fmt.Sprintf("%s count.query", prefix)); err != nil {
+				return err
+			}
+		} else {
+			if err := validateScanReadRequest(step.Count.Scan, fmt.Sprintf("%s count.scan", prefix)); err != nil {
+				return err
+			}
 		}
-		return validateScanReadRequest(step.Count.Scan, fmt.Sprintf("%s count.scan", prefix))
 	case "transact_get":
 		if step.TransactGet == nil || len(step.TransactGet.Items) == 0 {
 			return fmt.Errorf("%s transact_get: transact_get.items are required", prefix)
@@ -280,7 +289,90 @@ func validateStep(label string, i int, step Step) error {
 	default:
 		return fmt.Errorf("%s: unsupported op %q", prefix, step.Op)
 	}
+	return validateExpectation(prefix, step.Expect)
+}
+
+func validateExpectation(prefix string, expect Expectation) error {
+	for _, field := range []struct {
+		name  string
+		value map[string]any
+	}{
+		{name: "item_contains", value: expect.ItemContains},
+		{name: "item_equals", value: expect.ItemEquals},
+		{name: "raw_item_contains", value: expect.RawItemContains},
+	} {
+		if field.value != nil && len(field.value) == 0 {
+			return fmt.Errorf("%s expect.%s must not be empty", prefix, field.name)
+		}
+	}
+	for _, field := range []struct {
+		name  string
+		value map[string]string
+	}{
+		{name: "raw_attribute_types", value: expect.RawAttributeTypes},
+		{name: "item_field_equals_var", value: expect.ItemFieldEqualsVar},
+		{name: "item_field_not_equals_var", value: expect.ItemFieldNotEqualsVar},
+	} {
+		if field.value != nil && len(field.value) == 0 {
+			return fmt.Errorf("%s expect.%s must not be empty", prefix, field.name)
+		}
+	}
+	for _, field := range []struct {
+		name  string
+		value []string
+	}{
+		{name: "errors", value: expect.Errors},
+		{name: "items_missing_fields", value: expect.ItemsMissingFields},
+		{name: "item_has_fields", value: expect.ItemHasFields},
+		{name: "item_missing_fields", value: expect.ItemMissingFields},
+	} {
+		if field.value != nil && len(field.value) == 0 {
+			return fmt.Errorf("%s expect.%s must not be empty", prefix, field.name)
+		}
+	}
+	if expect.ItemsContains != nil {
+		if len(expect.ItemsContains) == 0 {
+			return fmt.Errorf("%s expect.items_contains must not be empty", prefix)
+		}
+		for j, item := range expect.ItemsContains {
+			if len(item) == 0 {
+				return fmt.Errorf("%s expect.items_contains[%d] must not be empty", prefix, j)
+			}
+		}
+	}
+
+	hasErrorExpectation := expect.Error != "" || len(expect.Errors) > 0
+	hasDataAssertion := expectationHasItemAssertion(expect) ||
+		expectationHasRawItemAssertion(expect) ||
+		expectationHasReadAssertion(expect)
+	if hasErrorExpectation && hasDataAssertion {
+		return fmt.Errorf("%s expect: item/read assertions cannot be combined with error expectations", prefix)
+	}
 	return nil
+}
+
+func expectationHasItemAssertion(expect Expectation) bool {
+	return len(expect.ItemContains) > 0 ||
+		len(expect.ItemEquals) > 0 ||
+		len(expect.ItemHasFields) > 0 ||
+		len(expect.ItemMissingFields) > 0 ||
+		len(expect.RawAttributeTypes) > 0 ||
+		len(expect.ItemFieldEqualsVar) > 0 ||
+		len(expect.ItemFieldNotEqualsVar) > 0
+}
+
+func expectationHasRawItemAssertion(expect Expectation) bool {
+	return len(expect.ItemMissingFields) > 0 ||
+		len(expect.RawAttributeTypes) > 0 ||
+		len(expect.RawItemContains) > 0
+}
+
+func expectationHasReadAssertion(expect Expectation) bool {
+	return expect.ItemCount != nil ||
+		expect.Count != nil ||
+		len(expect.ItemsContains) > 0 ||
+		len(expect.ItemsMissingFields) > 0 ||
+		expect.CursorEquals != nil
 }
 
 func validateQueryReadRequest(req *ReadRequest, prefix string) error {

--- a/contract-tests/runners/go/internal/scenario/scenario_test.go
+++ b/contract-tests/runners/go/internal/scenario/scenario_test.go
@@ -1,0 +1,56 @@
+package scenario
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadFileRejectsEmptyAssertionMaps(t *testing.T) {
+	path := writeScenarioFixture(t, `
+name: "unit.empty_assertion"
+dms_version: "0.1"
+model: "User"
+steps:
+  - op: get
+    key: { PK: "USER#empty", SK: "PROFILE" }
+    expect:
+      item_equals: {}
+`)
+
+	_, err := LoadFile(path)
+	if err == nil || !strings.Contains(err.Error(), "expect.item_equals must not be empty") {
+		t.Fatalf("expected empty assertion error, got %v", err)
+	}
+}
+
+func TestLoadFileRejectsItemAssertionsWithErrorExpectations(t *testing.T) {
+	path := writeScenarioFixture(t, `
+name: "unit.error_with_assertion"
+dms_version: "0.1"
+model: "User"
+steps:
+  - op: get
+    key: { PK: "USER#error", SK: "PROFILE" }
+    expect:
+      error: "ErrItemNotFound"
+      item_contains:
+        PK: "USER#error"
+`)
+
+	_, err := LoadFile(path)
+	if err == nil || !strings.Contains(err.Error(), "item/read assertions cannot be combined with error expectations") {
+		t.Fatalf("expected error/assertion combination error, got %v", err)
+	}
+}
+
+func writeScenarioFixture(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "scenario.yml")
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}

--- a/contract-tests/runners/py/test_contract_p0.py
+++ b/contract-tests/runners/py/test_contract_p0.py
@@ -102,9 +102,83 @@ def _load_scenarios() -> list[dict[str, Any]]:
 
 def _load_scenarios_from(name: str) -> list[dict[str, Any]]:
     scenario_dir = _repo_root() / "contract-tests" / "scenarios" / name
-    scenarios = [_load_yaml(path) for path in sorted(scenario_dir.glob("*.yml"))]
+    scenarios = []
+    for path in sorted(scenario_dir.glob("*.yml")):
+        scenario = _load_yaml(path)
+        _validate_scenario_expectations(scenario, path)
+        scenarios.append(scenario)
     assert scenarios
     return scenarios
+
+
+_EXPECTATION_MAP_KEYS = {
+    "item_contains",
+    "item_equals",
+    "raw_item_contains",
+    "raw_attribute_types",
+    "item_field_equals_var",
+    "item_field_not_equals_var",
+}
+
+_EXPECTATION_LIST_KEYS = {
+    "errors",
+    "items_missing_fields",
+    "item_has_fields",
+    "item_missing_fields",
+}
+
+_ITEM_ASSERTION_KEYS = {
+    "item_contains",
+    "item_equals",
+    "item_has_fields",
+    "item_missing_fields",
+    "raw_attribute_types",
+    "raw_item_contains",
+    "item_field_equals_var",
+    "item_field_not_equals_var",
+}
+
+_READ_ASSERTION_KEYS = {
+    "item_count",
+    "count",
+    "items_contains",
+    "items_missing_fields",
+    "cursor_equals",
+}
+
+
+def _validate_scenario_expectations(scenario: dict[str, Any], path: Path) -> None:
+    for label in ("steps", "seed_steps", "read_steps"):
+        for index, step in enumerate(scenario.get(label, []) or []):
+            expect = step.get("expect")
+            if expect is not None:
+                _validate_expectation(expect, f"{path} {label}[{index}] expect")
+
+
+def _validate_expectation(expect: dict[str, Any], prefix: str) -> None:
+    assert isinstance(expect, dict), f"{prefix} must be a map"
+
+    for key in _EXPECTATION_MAP_KEYS:
+        if key in expect:
+            assert isinstance(expect[key], dict) and expect[key], f"{prefix}.{key} must not be empty"
+
+    for key in _EXPECTATION_LIST_KEYS:
+        if key in expect:
+            assert isinstance(expect[key], list) and expect[key], f"{prefix}.{key} must not be empty"
+
+    if "items_contains" in expect:
+        items_contains = expect["items_contains"]
+        assert isinstance(items_contains, list) and items_contains, (
+            f"{prefix}.items_contains must not be empty"
+        )
+        for index, item in enumerate(items_contains):
+            assert isinstance(item, dict) and item, f"{prefix}.items_contains[{index}] must not be empty"
+
+    has_error_expectation = bool(expect.get("error")) or bool(expect.get("errors"))
+    has_data_assertion = any(key in expect for key in _ITEM_ASSERTION_KEYS | _READ_ASSERTION_KEYS)
+    assert not (has_error_expectation and has_data_assertion), (
+        f"{prefix}: item/read assertions cannot be combined with error expectations"
+    )
 
 
 _MODEL_DEFINITIONS: dict[str, Any] = {
@@ -1048,6 +1122,33 @@ def test_assert_read_expectation_fails_closed_on_read_assertion_error_without_ok
             error=RuntimeError("read failed"),
             result={},
             model=_minimal_user_model(),
+        )
+
+
+def test_assert_expectation_rejects_raw_assertions_with_error_expectations() -> None:
+    with pytest.raises(AssertionError, match="item assertions cannot be combined with error expectations"):
+        _assert_expectation(
+            {"error": "ErrItemNotFound", "raw_item_contains": {"PK": "USER#fail-closed"}},
+            error=NotFoundError("missing seeded item"),
+            item=None,
+            raw=None,
+            model=_minimal_user_model(),
+            variables={},
+        )
+
+
+def test_validate_expectation_rejects_empty_assertion_maps() -> None:
+    with pytest.raises(AssertionError, match="expect.item_equals must not be empty"):
+        _validate_expectation({"item_equals": {}}, "unit.yml steps[0] expect")
+
+
+def test_validate_expectation_rejects_assertions_combined_with_errors() -> None:
+    with pytest.raises(
+        AssertionError, match="item/read assertions cannot be combined with error expectations"
+    ):
+        _validate_expectation(
+            {"error": "ErrItemNotFound", "item_contains": {"PK": "USER#error"}},
+            "unit.yml steps[0] expect",
         )
 
 

--- a/contract-tests/runners/ts/src/load.ts
+++ b/contract-tests/runners/ts/src/load.ts
@@ -177,6 +177,95 @@ function validateStep(
         `${filePath} ${label}[${index}]: unsupported op ${String(step.op)}`,
       );
   }
+  validateExpectation(step.expect, `${filePath} ${label}[${index}] expect`);
+}
+
+const expectationMapKeys = [
+  "item_contains",
+  "item_equals",
+  "raw_item_contains",
+  "raw_attribute_types",
+  "item_field_equals_var",
+  "item_field_not_equals_var",
+] as const;
+
+const expectationArrayKeys = [
+  "errors",
+  "items_missing_fields",
+  "item_has_fields",
+  "item_missing_fields",
+] as const;
+
+const itemAssertionKeys = [
+  "item_contains",
+  "item_equals",
+  "item_has_fields",
+  "item_missing_fields",
+  "raw_attribute_types",
+  "raw_item_contains",
+  "item_field_equals_var",
+  "item_field_not_equals_var",
+] as const;
+
+const readAssertionKeys = [
+  "item_count",
+  "count",
+  "items_contains",
+  "items_missing_fields",
+  "cursor_equals",
+] as const;
+
+function validateExpectation(
+  expect: Scenario["steps"][number]["expect"] | undefined,
+  prefix: string,
+): void {
+  if (expect === undefined) return;
+
+  for (const key of expectationMapKeys) {
+    if (!Object.hasOwn(expect, key)) continue;
+    requirePlainObject(expect[key], `${prefix}.${key} must not be empty`);
+  }
+
+  for (const key of expectationArrayKeys) {
+    if (!Object.hasOwn(expect, key)) continue;
+    const value = expect[key];
+    if (!Array.isArray(value) || value.length === 0) {
+      throw new Error(`${prefix}.${key} must not be empty`);
+    }
+  }
+
+  if (Object.hasOwn(expect, "items_contains")) {
+    const value = expect.items_contains;
+    if (!Array.isArray(value) || value.length === 0) {
+      throw new Error(`${prefix}.items_contains must not be empty`);
+    }
+    for (const [index, item] of value.entries()) {
+      requirePlainObject(
+        item,
+        `${prefix}.items_contains[${index}] must not be empty`,
+      );
+    }
+  }
+
+  const hasErrorExpectation =
+    (typeof expect.error === "string" && expect.error.length > 0) ||
+    (Array.isArray(expect.errors) && expect.errors.length > 0);
+  const hasDataAssertion = expectationHasAnyKey(expect, [
+    ...itemAssertionKeys,
+    ...readAssertionKeys,
+  ]);
+  if (hasErrorExpectation && hasDataAssertion) {
+    throw new Error(
+      `${prefix}: item/read assertions cannot be combined with error expectations`,
+    );
+  }
+}
+
+function expectationHasAnyKey(
+  expect: NonNullable<Scenario["steps"][number]["expect"]>,
+  keys: readonly (keyof NonNullable<Scenario["steps"][number]["expect"]>)[],
+): boolean {
+  return keys.some((key) => Object.hasOwn(expect, key));
 }
 
 function requireCountRequest(value: unknown, prefix: string): void {

--- a/contract-tests/runners/ts/src/runner.ts
+++ b/contract-tests/runners/ts/src/runner.ts
@@ -455,7 +455,7 @@ function assertExpectation(
     assert.ok(err, "expected error");
     assert.equal(mapError(err), expect.error);
     assert.equal(
-      hasItemAssertion,
+      hasItemAssertion || hasRawAssertion,
       false,
       "item assertions cannot be combined with error expectations",
     );
@@ -465,7 +465,7 @@ function assertExpectation(
     assert.ok(err, "expected error");
     assert.deepEqual(mapErrors(err).sort(), expect.errors.slice().sort());
     assert.equal(
-      hasItemAssertion,
+      hasItemAssertion || hasRawAssertion,
       false,
       "item assertions cannot be combined with error expectations",
     );
@@ -481,6 +481,11 @@ function assertExpectation(
     assert.ok(item, "expected item for item assertions");
   }
   if (hasRawAssertion) {
+    assert.equal(
+      err,
+      undefined,
+      "expected successful operation for raw-item assertions",
+    );
     assert.ok(raw, "expected raw item for raw assertions");
   }
 

--- a/contract-tests/runners/ts/test/fixtures.test.ts
+++ b/contract-tests/runners/ts/test/fixtures.test.ts
@@ -1,19 +1,32 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { loadModelsDir, loadScenariosDir } from "../src/load.js";
+import {
+  loadModelsDir,
+  loadScenarioFile,
+  loadScenariosDir,
+} from "../src/load.js";
 import { runScenario } from "../src/runner.js";
 import { decodeCursor, encodeCursor } from "../../../../ts/src/cursor.js";
 import { fromDynamoJson } from "../../../../ts/src/dynamo-json.js";
+import { TheorydbError } from "../../../../ts/src/errors.js";
 import type { Driver } from "../src/driver.js";
 import type { DmsModel, Scenario, Step } from "../src/types.js";
 
 function contractRoot(): string {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   return path.resolve(__dirname, "..", "..", ".."); // runners/ts/test -> contract-tests
+}
+
+async function writeScenarioFixture(content: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tabletheory-scenario-"));
+  const filePath = path.join(dir, "scenario.yml");
+  await fs.writeFile(filePath, `${content.trim()}\n`, "utf8");
+  return filePath;
 }
 
 test("loads DMS models + P0 scenarios", async () => {
@@ -127,6 +140,68 @@ test("interop read assertions fail closed on query errors without ok", async () 
         models: new Map([[userModel.name, userModel]]),
       }),
     /expected successful read for read assertions/,
+  );
+});
+
+test("error expectations reject raw item assertions", async () => {
+  await assert.rejects(
+    () =>
+      runScenario({
+        ddb: {} as never,
+        driver: stubDriver({
+          get: async () => {
+            throw new TheorydbError("ErrItemNotFound", "missing seeded item");
+          },
+        }),
+        scenario: scenarioWithReadStep({
+          op: "get",
+          key: { PK: "USER#fail-closed", SK: "PROFILE#fail-closed" },
+          expect: {
+            error: "ErrItemNotFound",
+            raw_item_contains: { PK: "USER#fail-closed" },
+          },
+        }),
+        models: new Map([[userModel.name, userModel]]),
+      }),
+    /item assertions cannot be combined with error expectations/,
+  );
+});
+
+test("scenario loading rejects empty assertion maps", async () => {
+  const filePath = await writeScenarioFixture(`
+name: "unit.empty_assertion"
+dms_version: "0.1"
+model: "User"
+steps:
+  - op: get
+    key: { PK: "USER#empty", SK: "PROFILE" }
+    expect:
+      item_equals: {}
+`);
+
+  await assert.rejects(
+    () => loadScenarioFile(filePath),
+    /expect\.item_equals must not be empty/,
+  );
+});
+
+test("scenario loading rejects assertions combined with errors", async () => {
+  const filePath = await writeScenarioFixture(`
+name: "unit.error_with_assertion"
+dms_version: "0.1"
+model: "User"
+steps:
+  - op: get
+    key: { PK: "USER#error", SK: "PROFILE" }
+    expect:
+      error: "ErrItemNotFound"
+      item_contains:
+        PK: "USER#error"
+`);
+
+  await assert.rejects(
+    () => loadScenarioFile(filePath),
+    /item\/read assertions cannot be combined with error expectations/,
   );
 });
 

--- a/docs/development/planning/theorydb-contract-tests-suite-outline.md
+++ b/docs/development/planning/theorydb-contract-tests-suite-outline.md
@@ -35,6 +35,10 @@ Contract tests run scenarios against an implementation through a **Driver** inte
 Raw DynamoDB item assertions (`item_missing_fields`, `raw_attribute_types`, and exact raw item comparisons) MUST use
 strongly consistent reads in every runner. Eventual raw reads make the harness itself a source of parity drift.
 
+Go contract-runner invocations MUST use `-count=1` in repository verification scripts and local documentation. The Go
+runner is a nested module that reads shared YAML fixtures outside its module root, so repeated harness runs must execute
+fresh instead of relying on Go's package-test cache.
+
 ## Proposed folder layout (contract repo)
 
 ```text
@@ -219,6 +223,16 @@ Minimum assertions required for v0.1:
 
 Value encoding in scenario files is “logical” (strings/numbers/bools/arrays/objects); the runner encodes based on DMS
 attribute `type`.
+
+Assertion validity rules:
+- Assertion collection keys MUST be omitted when unused. Present-but-empty maps/lists such as `item_contains: {}`,
+  `item_equals: {}`, `raw_item_contains: {}`, `raw_attribute_types: {}`, `items_contains: []`, or
+  `items_missing_fields: []` are invalid because they do not assert observable behavior consistently across runtimes.
+- `errors: []` is invalid; use `error: <ErrorCode>` for one code or a non-empty `errors: [...]` union for multi-code
+  assertions.
+- Item/raw-item/read assertions MUST NOT be combined with `error` or `errors`. Assertions that inspect returned data
+  (`item_contains`, `item_equals`, raw item assertions, `item_count`, `count`, `items_contains`, `cursor_equals`, and
+  related field-presence assertions) imply a successful operation/read even when `ok: true` is omitted.
 
 Comparison rules:
 - DynamoDB `N` values MUST be asserted as their canonical decimal strings. Runners compare the DynamoDB wire string

--- a/scripts/fuzz-smoke.sh
+++ b/scripts/fuzz-smoke.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 # targeted fuzz functions over time.
 
 failures=0
+fuzzTime="10s"
+# Keep the overall Go test timeout above the fuzz window so seed-corpus setup
+# and worker shutdown have CI margin without turning this into an unbounded gate.
+testTimeout="30s"
 
 fuzzRegex='^func[[:space:]]+Fuzz[A-Za-z0-9_]+'
 missing=()
@@ -23,11 +27,11 @@ if [[ "${#missing[@]}" -ne 0 ]]; then
   exit 1
 fi
 
-echo "fuzz-smoke: running bounded fuzz pass (10s per package group)"
+echo "fuzz-smoke: running bounded fuzz pass (${fuzzTime} fuzz window, ${testTimeout} test timeout per package group)"
 
-go test ./internal/expr -run '^$' -fuzz Fuzz -fuzztime=10s || failures=$((failures + 1))
-go test ./pkg/marshal -run '^$' -fuzz Fuzz -fuzztime=10s || failures=$((failures + 1))
-go test ./pkg/query -run '^$' -fuzz Fuzz -fuzztime=10s || failures=$((failures + 1))
+go test ./internal/expr -run '^$' -fuzz Fuzz -fuzztime="${fuzzTime}" -timeout="${testTimeout}" || failures=$((failures + 1))
+go test ./pkg/marshal -run '^$' -fuzz Fuzz -fuzztime="${fuzzTime}" -timeout="${testTimeout}" || failures=$((failures + 1))
+go test ./pkg/query -run '^$' -fuzz Fuzz -fuzztime="${fuzzTime}" -timeout="${testTimeout}" || failures=$((failures + 1))
 
 if [[ "${failures}" -ne 0 ]]; then
   echo "fuzz-smoke: FAIL (${failures} package group(s) failed)"

--- a/scripts/verify-contract-tests.sh
+++ b/scripts/verify-contract-tests.sh
@@ -26,7 +26,7 @@ export DYNAMODB_ENDPOINT="${DYNAMODB_ENDPOINT:-http://localhost:8000}"
 
 if [[ -f "contract-tests/runners/go/go.mod" ]]; then
   echo "contract-tests: go"
-  (cd contract-tests/runners/go && go test ./... -v)
+  (cd contract-tests/runners/go && go test ./... -count=1 -v)
 fi
 
 if [[ -f "contract-tests/runners/ts/package.json" ]]; then


### PR DESCRIPTION
## Summary
- document assertion/error exclusivity and invalid empty assertion collections in the contract suite outline/fixture docs
- make the main Go contract phase use `-count=1`, matching interop's fresh-execution policy
- guard empty assertion maps/lists and assertion+error combinations consistently in Go/TS/Py harness loading/runtime checks

## THE-2525 observations closed
1. Suite outline now states item/raw-item/read assertions cannot be combined with `error`/`errors` and imply success when present.
2. `scripts/verify-contract-tests.sh` now runs the main Go contract runner with `go test ./... -count=1 -v`; Go runner docs explain the fresh-execution rationale for shared YAML fixtures outside the nested module.
3. Go/TS/Py now reject present-but-empty assertion maps/lists during scenario loading so future fixtures cannot depend on absent-vs-empty runtime divergence.

## Contract impact
Harness/fixture validation only. No DMS change, no public runtime API change, no release/version work.

## Validation
- PASS: baseline `make test-unit` on `staging` before branching
- PASS: `bash -n scripts/verify-contract-tests.sh`
- PASS: `git diff --check`
- PASS: `(cd contract-tests/runners/go && go test ./internal/scenario ./internal/runner -count=1 -v)`
- PASS: `npm --prefix contract-tests/runners/ts run test:fixtures`
- PASS: `python3 -m py_compile contract-tests/runners/py/test_contract_p0.py`
- PASS: `uv --directory py run pytest -q ../contract-tests/runners/py/test_contract_p0.py -k 'validate_expectation or fail_closed or raw_assertions'`
- PASS: `make contract-tests`
- PASS: `make rubric` (36 pass / 0 fail / 0 blocked)

Closes THE-2525
