### PR TITLE
fix(ci): derive stable promotion intent

### DIFF
--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -998,9 +998,31 @@ expect_failure_contains \
       --body "Release-As: 1.10.2" \
       --dry-run
 
-expect_failure_contains \
-  "requires a stable Release-As footer" \
+expect_success_contains \
+  "manifest-derived stable Release-As" \
   run_in_pending_fixture \
+    bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
+      --base main \
+      --head premain \
+      --title "Promote premain to main" \
+      --body "" \
+      --dry-run
+
+stable_manifest_fixture="$(mktemp -d)"
+tmpdirs+=("${stable_manifest_fixture}")
+cp -R "${pending_fixture}/." "${stable_manifest_fixture}/"
+cat >"${stable_manifest_fixture}/.release-please-manifest.json" <<'JSON'
+{".":"1.10.1"}
+JSON
+
+run_in_stable_manifest_fixture() (
+  cd "${stable_manifest_fixture}"
+  "$@"
+)
+
+expect_failure_contains \
+  "must carry a single-manifest RC" \
+  run_in_stable_manifest_fixture \
     bash "${repo_root}/scripts/verify-promotion-release-driver.sh" \
       --base main \
       --head premain \

--- a/scripts/verify-promotion-release-driver.sh
+++ b/scripts/verify-promotion-release-driver.sh
@@ -355,20 +355,21 @@ if base == "main":
         fail(f"invalid Release-As footer(s): {', '.join(invalid)}")
     pending_rc = pending_stable_promotion_version()
     pending_stable = pending_rc.split("-", 1)[0]
-    if not versions:
-        fail(
-            "premain -> main promotion requires a stable Release-As footer "
-            f"matching the pending RC base {pending_stable}"
+    if versions:
+        mismatched = [version for version in versions if version != pending_stable]
+        if mismatched:
+            fail(
+                "premain -> main stable Release-As footer must match the pending "
+                f"RC base {pending_stable}, got {', '.join(mismatched)}"
+            )
+        print(
+            "promotion-release-driver: PASS "
+            f"(premain -> main pending stable promotion {pending_rc} -> {pending_stable}; explicit stable Release-As)"
         )
-    mismatched = [version for version in versions if version != pending_stable]
-    if mismatched:
-        fail(
-            "premain -> main stable Release-As footer must match the pending "
-            f"RC base {pending_stable}, got {', '.join(mismatched)}"
-        )
+        raise SystemExit(0)
     print(
         "promotion-release-driver: PASS "
-        f"(premain -> main pending stable promotion {pending_rc} -> {pending_stable})"
+        f"(premain -> main pending stable promotion {pending_rc} -> {pending_stable}; manifest-derived stable Release-As)"
     )
     raise SystemExit(0)
 


### PR DESCRIPTION
## What changed

- Updates `scripts/verify-promotion-release-driver.sh` so a normal `premain` -> `main` promotion can derive the stable release intent from an RC-shaped single manifest when no explicit `Release-As:` footer is present.
- Keeps the existing escape hatch: explicit stable `Release-As:` footers are still accepted only when they match the pending RC base.
- Keeps rejecting RC-shaped `premain` -> `main` titles/bodies and mismatched explicit footers.
- Adds release-hygiene policy coverage for the manifest-derived happy path and the non-RC manifest rejection path.

## Why

PR #366 failed because the guard required a manual `Release-As: 2.0.1` footer even though `release-pr.yml` already computes `2.0.1` from the pending `2.0.1-rc` manifest. The footer should be an abnormal recovery escape hatch, not a required release step.

## Branch note

I validated the fix against the live `premain` RC state (`2.0.1-rc -> 2.0.1`). The published PR branch is based on `staging` so the PR does not import premain's RC manifest/changelog state back into staging.

## Validation

- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/verify-branch-version-sync.sh` (SKIP in this branch context)
- `bash scripts/verify-release-cycle-state.sh`
- Temp `origin/premain` archive with patched driver: `bash scripts/verify-promotion-release-driver.sh --repo theory-cloud/TableTheory --base main --head premain --pr 366 --dry-run`
- Temp `origin/premain` archive: `GITHUB_BASE_REF=main GITHUB_HEAD_REF=premain RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=true bash scripts/verify-release-cycle-state.sh`
- `git diff --check`
