### PR TITLE
fix(ci): use resolved promotion verifier

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -231,23 +231,6 @@ jobs:
             echo "head=${queued_head}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Verify human promotion release driver
-        if: github.event_name == 'pull_request' && ((github.base_ref == 'premain' && github.head_ref == 'staging') || (github.base_ref == 'main' && github.head_ref == 'premain'))
-        working-directory: pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          set -euo pipefail
-
-          bash ../trusted-release/scripts/verify-promotion-release-driver.sh \
-            --repo "${GITHUB_REPOSITORY}" \
-            --base "${GITHUB_BASE_REF}" \
-            --head "${GITHUB_HEAD_REF}" \
-            --pr "${PR_NUMBER}"
-
       - name: Resolve release verifier source
         if: github.event_name == 'pull_request'
         id: verifier-source
@@ -314,6 +297,8 @@ jobs:
               "accept release-please first RC and numbered later RC version syntax" "release-please first-RC version marker" "${reasons_name}"
             add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
               "release-please v5" "release-please-action v5 policy marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-promotion-release-driver.sh" \
+              "manifest-derived stable Release-As" "manifest-derived stable promotion marker" "${reasons_name}"
           }
 
           trusted_reasons=()
@@ -345,6 +330,25 @@ jobs:
             echo "label=${verifier_label}"
           } >> "${GITHUB_OUTPUT}"
           echo "release-verifier-source: selected ${verifier_label} (${verifier_root})"
+
+      - name: Verify human promotion release driver
+        if: github.event_name == 'pull_request' && ((github.base_ref == 'premain' && github.head_ref == 'staging') || (github.base_ref == 'main' && github.head_ref == 'premain'))
+        working-directory: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          VERIFIER_ROOT: ${{ steps.verifier-source.outputs.root }}
+          VERIFIER_LABEL: ${{ steps.verifier-source.outputs.label }}
+        run: |
+          set -euo pipefail
+          echo "promotion-release-driver: using ${VERIFIER_LABEL} verifier source (${VERIFIER_ROOT})"
+          bash "${VERIFIER_ROOT}/scripts/verify-promotion-release-driver.sh" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base "${GITHUB_BASE_REF}" \
+            --head "${GITHUB_HEAD_REF}" \
+            --pr "${PR_NUMBER}"
 
       - name: Verify release cycle state
         if: github.event_name == 'pull_request'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ published requires:
 - **post-release sync**: back-merge `main` into `staging` so the next cycle starts from the latest stable baseline
 - **in-flight RC repair (exceptional)**: when `premain` already contains `staging` and RC release content must be
   reconciled back into `staging` to avoid forward merge conflicts, open a premain-derived repair PR back to `staging`.
-  This is not the normal release hop and must remain provenance-verified as a repair state.
+  Follow-up repair PRs to `staging` may preserve that already-accepted RC manifest until stable publication, but must be
+  based on current `staging` and must not change the RC baseline. This is not the normal release hop and must remain
+  provenance-verified as a repair state.
 
 The cross-framework release lane is exactly `staging -> premain -> main -> staging`. `staging` is the only branch that
 requires the full gov-infra rubric, and only on PRs targeting `staging` plus manual workflow dispatch. PRs targeting
@@ -153,7 +155,8 @@ Release watchpoints and stop conditions:
 - Stop if `main` carries an RC manifest outside explicit single-manifest pending stable promotion.
 - Stop if `.release-please-manifest.json` is an RC version on `staging`, unless the PR is a verified in-flight premain RC
   repair where `premain` already contains `staging` and the release content is being reconciled to avoid forward merge
-  conflicts. Stop if the retired `.release-please-manifest.premain.json` appears on release branches.
+  conflicts, or a verified follow-up repair that preserves the already-accepted `staging` RC manifest before stable
+  publication. Stop if the retired `.release-please-manifest.premain.json` appears on release branches.
 - Stop if `premain` release track is behind `origin/main`, or if `staging` lacks the latest stable baseline after a stable
   release.
 - Stop if SEC-2/govulncheck still observes Go `1.26.3`, COM-8 branch/version sync fails, or release-please opens a

--- a/docs/development/planning/theorydb-branch-release-policy.md
+++ b/docs/development/planning/theorydb-branch-release-policy.md
@@ -44,7 +44,9 @@ TableTheory has one release lane: `staging` -> `premain` -> `main` -> `staging` 
   receives the new baseline through the next `staging` -> `premain` promotion.
 - During an active RC, a premain-derived repair PR back to `staging` is allowed only when `premain` already contains
   `staging` and RC release content must be reconciled to avoid forward merge conflicts. This is an exceptional in-flight
-  RC repair state, not the normal release hop; ordinary RC manifest state on `staging` remains forbidden.
+  RC repair state, not the normal release hop; ordinary RC manifest state on `staging` remains forbidden. Follow-up
+  repair PRs to `staging` may preserve the already-accepted RC manifest until stable publication, but must be based on
+  current `staging` and must not change the RC baseline.
 - Hotfixes should still follow `staging` -> `premain` -> `main` so the release lane stays linear.
 
 ## Post-release backmerge (operator PR)
@@ -212,7 +214,8 @@ Run `bash scripts/watch-release-cycle.sh` during a release and rerun with `--str
 - `origin/main` carrying an RC manifest outside the explicit single-manifest pending stable-promotion window.
 - `.release-please-manifest.json` set to an RC version on `staging`, unless it is a verified in-flight premain RC repair
   where `premain` already contains `staging` and the RC release content is being reconciled to avoid forward merge
-  conflicts.
+  conflicts, or a verified follow-up repair that preserves the already-accepted `staging` RC manifest before stable
+  publication.
 - the retired `.release-please-manifest.premain.json` appearing on release branches.
 - `origin/premain` release track behind `origin/main`.
 - `origin/staging` missing the latest stable baseline after a stable release.

--- a/scripts/fixtures/release-policy/cycle-staging-rc-followup-repair-after-stable-bad/fixture.env
+++ b/scripts/fixtures/release-policy/cycle-staging-rc-followup-repair-after-stable-bad/fixture.env
@@ -1,0 +1,12 @@
+kind=cycle
+branch=staging
+head_ref=fix/from-staging
+pending_env=false
+stable=1.10.1-rc.1
+premain=
+main_stable=1.10.1
+ts=1.10.0
+py=1.10.0
+staging_rc_followup=true
+expected_exit=1
+expected_text='origin/main already carries stable baseline 1.10.1; backmerge main to staging instead'

--- a/scripts/fixtures/release-policy/cycle-staging-rc-followup-repair-good/fixture.env
+++ b/scripts/fixtures/release-policy/cycle-staging-rc-followup-repair-good/fixture.env
@@ -1,0 +1,12 @@
+kind=cycle
+branch=staging
+head_ref=fix/from-staging
+pending_env=false
+stable=1.10.1-rc.1
+premain=
+main_stable=1.10.0
+ts=1.10.0
+py=1.10.0
+staging_rc_followup=true
+expected_exit=0
+expected_text='release-cycle-state: PASS (branch=staging, mode=staging-rc-followup-repair, rc=1.10.1-rc.1, stable=1.10.1)'

--- a/scripts/lib/release-cycle-core.sh
+++ b/scripts/lib/release-cycle-core.sh
@@ -187,6 +187,27 @@ def manifest_at_ref(ref: str) -> str:
     return value if isinstance(value, str) else ""
 
 
+def stable_baseline_reached(
+    manifest_base: tuple[int, int, int],
+) -> tuple[bool, str]:
+    main_ref = "origin/main"
+    if not ref_exists(main_ref):
+        return False, ""
+    main_manifest = manifest_at_ref(main_ref)
+    if not main_manifest:
+        return False, ""
+    main_base, main_is_prerelease = version_info(
+        "origin/main .release-please-manifest.json",
+        main_manifest,
+    )
+    if not main_is_prerelease and main_base >= manifest_base:
+        return True, (
+            "origin/main already carries stable baseline "
+            f"{main_manifest}; backmerge main to staging instead"
+        )
+    return False, ""
+
+
 def verified_premain_rc_repair_to_staging(
     manifest: str,
     manifest_base: tuple[int, int, int],
@@ -215,23 +236,34 @@ def verified_premain_rc_repair_to_staging(
             f"({manifest} != {premain_manifest or 'missing'})",
         )
 
-    main_ref = "origin/main"
-    if ref_exists(main_ref):
-        main_manifest = manifest_at_ref(main_ref)
-        if main_manifest:
-            try:
-                main_base, main_is_prerelease = version_info(
-                    "origin/main .release-please-manifest.json",
-                    main_manifest,
-                )
-            except SystemExit:
-                raise
-            if not main_is_prerelease and main_base >= manifest_base:
-                return (
-                    False,
-                    "origin/main already carries stable baseline "
-                    f"{main_manifest}; backmerge main to staging instead",
-                )
+    stable_reached, stable_reason = stable_baseline_reached(manifest_base)
+    if stable_reached:
+        return False, stable_reason
+
+    return True, ""
+
+
+def verified_staging_rc_followup_repair(
+    manifest: str,
+    manifest_base: tuple[int, int, int],
+) -> tuple[bool, str]:
+    staging_ref = "origin/staging"
+    if not ref_exists(staging_ref):
+        return False, "origin/staging is not available for staging RC follow-up verification"
+    if not git_ok(["merge-base", "--is-ancestor", staging_ref, "HEAD"]):
+        return False, "origin/staging is not an ancestor of this staging follow-up candidate"
+
+    staging_manifest = manifest_at_ref(staging_ref)
+    if staging_manifest != manifest:
+        return (
+            False,
+            "staging follow-up candidate RC manifest does not match origin/staging "
+            f"({manifest} != {staging_manifest or 'missing'})",
+        )
+
+    stable_reached, stable_reason = stable_baseline_reached(manifest_base)
+    if stable_reached:
+        return False, stable_reason
 
     return True, ""
 
@@ -295,6 +327,20 @@ if current_branch == "main" and manifest_is_prerelease:
     )
 
 if current_branch == "staging" and manifest_is_prerelease:
+    followup_ok, followup_reason = verified_staging_rc_followup_repair(
+        manifest,
+        manifest_base,
+    )
+    if followup_ok:
+        print(
+            "release-cycle-state: PASS "
+            f"(branch={current_branch}, mode=staging-rc-followup-repair, "
+            f"rc={manifest}, stable={stable_base})"
+        )
+        raise SystemExit(0)
+    if followup_reason:
+        print(f"release-cycle-state: INFO ({followup_reason})")
+
     repair_ok, repair_reason = verified_premain_rc_repair_to_staging(
         manifest,
         manifest_base,

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -316,6 +316,10 @@ require_fixed "-rc(?:\\.\\d+)?" "${prerelease_postcondition}" \
 require_regex 'googleapis/release-please-action@[0-9a-fA-F]{40}.*\bv5\b' "${p}" \
   "prerelease workflow must pin release-please v5 by commit SHA"
 SH
+  cat >"${root}/scripts/verify-promotion-release-driver.sh" <<'SH'
+#!/usr/bin/env bash
+echo "manifest-derived stable Release-As"
+SH
 }
 
 write_v2_release_please_v4_verifier_fixture() {
@@ -1330,6 +1334,16 @@ grep -Fq 'bash "${VERIFIER_ROOT}/scripts/verify-branch-release-supply-chain.sh"'
   exit 1
 }
 
+grep -Fq 'bash "${VERIFIER_ROOT}/scripts/verify-promotion-release-driver.sh"' "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: promotion driver must use the resolved verifier source"
+  exit 1
+}
+
+grep -Fq "manifest-derived stable Release-As" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect the manifest-derived stable promotion marker"
+  exit 1
+}
+
 selector_result="$(
   run_verifier_source_selector_fixture \
     v1 v2 \
@@ -1481,8 +1495,8 @@ if grep -Fq 'GITHUB_HEAD_REF=premain RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTIO
   exit 1
 fi
 
-grep -Fq "../trusted-release/scripts/verify-promotion-release-driver.sh" "${repo_root}/.github/workflows/release-hygiene.yml" || {
-  echo "release-hygiene-policy-test: promotion driver must run from trusted checkout"
+grep -Fq "promotion-release-driver: using \${VERIFIER_LABEL} verifier source" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: promotion driver must log the selected verifier source"
   exit 1
 }
 

--- a/scripts/test-release-verifier-policy.sh
+++ b/scripts/test-release-verifier-policy.sh
@@ -104,13 +104,31 @@ load_fixture() {
 
 run_cycle_fixture() {
   local fixture="$1"
-  unset kind branch head_ref pending_env stable premain ts py expected_exit expected_text premain_rc_repair main_stable
+  unset kind branch head_ref pending_env stable premain ts py expected_exit expected_text premain_rc_repair staging_rc_followup main_stable
   load_fixture "${fixture}"
 
   local work output status
   work="$(mktemp -d)"
   tmpdirs+=("${work}")
-  if [[ "${premain_rc_repair:-false}" == "true" ]]; then
+  if [[ "${staging_rc_followup:-false}" == "true" ]]; then
+    git -C "${work}" init -q
+    git -C "${work}" config user.email fixture@example.com
+    git -C "${work}" config user.name "Release Fixture"
+
+    write_version_files "${work}" "${main_stable}" "" "${ts}" "${py}"
+    git -C "${work}" add .
+    git -C "${work}" commit -q -m "fixture main"
+    git -C "${work}" update-ref refs/remotes/origin/main HEAD
+    git -C "${work}" branch -M staging
+
+    write_version_files "${work}" "${stable}" "${premain}" "${ts}" "${py}"
+    git -C "${work}" add .
+    git -C "${work}" commit -q -m "fixture accepted staging rc"
+    git -C "${work}" update-ref refs/remotes/origin/staging HEAD
+
+    git -C "${work}" checkout -q -b fixture/from-staging
+    git -C "${work}" commit -q --allow-empty -m "fixture staging rc follow-up repair"
+  elif [[ "${premain_rc_repair:-false}" == "true" ]]; then
     git -C "${work}" init -q
     git -C "${work}" config user.email fixture@example.com
     git -C "${work}" config user.name "Release Fixture"

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -163,6 +163,8 @@ require_fixed "mode=premain-rc-repair" "scripts/lib/release-cycle-core.sh" \
   "release-cycle-state must expose verified in-flight premain RC repair mode"
 require_fixed "origin/premain does not contain origin/staging" "scripts/lib/release-cycle-core.sh" \
   "release-cycle-state must prove premain contains staging before accepting RC repair into staging"
+require_fixed "mode=staging-rc-followup-repair" "scripts/lib/release-cycle-core.sh" \
+  "release-cycle-state must expose verified staging RC follow-up repair mode"
 
 if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
   h=".github/workflows/release-hygiene.yml"

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -200,12 +200,16 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
     "release-hygiene must forbid RC-shaped main Release PRs"
   require_fixed "scripts/verify-promotion-release-driver.sh" "${h}" \
     "release-hygiene must verify human promotion release drivers"
+  require_fixed "manifest-derived stable Release-As" "${h}" \
+    "release-hygiene verifier selector must detect manifest-derived stable promotion driver support"
   require_fixed "github.base_ref == 'premain' && github.head_ref == 'staging'" "${h}" \
     "release-hygiene must run the release driver guard on staging -> premain PRs"
   require_fixed "github.base_ref == 'main' && github.head_ref == 'premain'" "${h}" \
     "release-hygiene must run the release driver guard on premain -> main PRs"
-  require_fixed "../trusted-release/scripts/verify-promotion-release-driver.sh" "${h}" \
-    "release-hygiene must run the promotion driver from trusted checkout"
+  require_fixed 'bash "${VERIFIER_ROOT}/scripts/verify-promotion-release-driver.sh"' "${h}" \
+    "release-hygiene must run the promotion driver from the resolved verifier source"
+  require_fixed "promotion-release-driver: using \${VERIFIER_LABEL} verifier source" "${h}" \
+    "release-hygiene must log the promotion-driver verifier source"
   require_fixed "pending stable promotion accepted on queued main merge group" "${h}" \
     "release-hygiene must allow queued main pending stable promotion validation"
   if grep -Fq "secrets.RELEASE_PLEASE_TOKEN" "${h}"; then


### PR DESCRIPTION
## What changed

- Updates Release Hygiene so the human promotion release-driver step runs after verifier-source resolution and uses `VERIFIER_ROOT` instead of always using stale trusted-base scripts.
- Adds `scripts/verify-promotion-release-driver.sh` to the verifier-source feature detection via the `manifest-derived stable Release-As` marker.
- Keeps provenance first: PR-head verifier scripts are still selected only for protected same-repo promotion pairs after release-lane provenance passes.
- Adds a narrow staging RC follow-up repair mode for PRs based on current `staging` after an accepted in-flight RC repair, preserving the existing RC manifest while `main` has not reached stable yet.

## Why

Run https://github.com/theory-cloud/TableTheory/actions/runs/28827153276 failed on PR #366 because Release Hygiene used `main`'s stale `verify-promotion-release-driver.sh` before the existing verifier-source selector could choose the updated PR-head verifier. That stale script still demanded a manual `Release-As: 2.0.1` footer.

The fix keeps the automated promotion-intent path intact: no manual footer on the normal `premain` -> `main` promotion, and no weakening of release-lane provenance.

## Validation

- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `bash scripts/test-release-verifier-policy.sh`
- `GITHUB_BASE_REF=staging GITHUB_HEAD_REF=fix/promotion-verifier-source-20260706 bash scripts/verify-release-cycle-state.sh`
- `bash scripts/verify-promotion-release-driver.sh --repo theory-cloud/TableTheory --base main --head premain --pr 366 --dry-run`
- `git diff --check`
- `GITHUB_BASE_REF=staging GITHUB_HEAD_REF=fix/promotion-verifier-source-20260706 make rubric`
