### PR TITLE
fix(go): record Go 1.26.5 release driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bug Fixes
 
+* **go:** pin the repository and example Go toolchains to go1.26.5 for reproducible CI and local security checks
 * add first-class legacy DynamORM naming support for uppercase `PK`/`SK` plus camelCase non-key attributes
 * align Go, TypeScript, Python, and DMS `json` field semantics around native structured storage plus legacy string compatibility
 * harden npm audit allowlist handling so audit service errors fail closed


### PR DESCRIPTION
## Summary
- record the Go 1.26.5 toolchain pin in the unreleased changelog
- add a release-eligible staging commit so the staging -> premain promotion has a valid release driver

## Validation
- bash scripts/verify-promotion-release-driver.sh --repo theory-cloud/TableTheory --base premain --head staging --commit-message "$(git log -1 --format=%B)" --dry-run
- bash scripts/verify-release-cycle-state.sh
- bash scripts/verify-branch-release-supply-chain.sh
- bash scripts/verify-branch-version-sync.sh
- make rubric

## Release hygiene
This intentionally repairs PR #396 through staging, not by mutating the promotion PR metadata.