### PR TITLE
fix(ci): bootstrap direct PR verifiers

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -170,8 +170,9 @@ jobs:
 
             # These markers distinguish the current single-manifest release lane from
             # older trusted verifier shapes that either required the retired premain
-            # manifest/helper/Python path, still assumed numbered-only RC syntax, or
-            # had not moved the release-please-action policy from v4 to v5.
+            # manifest/helper/Python path, still assumed numbered-only RC syntax,
+            # had not moved the release-please-action policy from v4 to v5, or still
+            # enforced the retired merge-queue lane.
             add_v2_marker_reason "${root}" "scripts/verify-release-cycle-state.sh" \
               "scripts/prepare-release-package-versions.py" "package-version stamping marker" "${reasons_name}"
             add_v2_marker_reason "${root}" "scripts/verify-release-cycle-state.sh" \
@@ -198,6 +199,9 @@ jobs:
             add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
               "scripts/create-stable-release-pr.py" \
               "deterministic stable Release PR marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
+              "must not use the prohibited merge-queue event" \
+              "direct protected-PR verifier marker" "${reasons_name}"
           }
 
           trusted_reasons=()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bug Fixes
 
+* **ci:** select direct-PR verifier scripts while a promotion base still contains the retired queue-era policy
 * **ci:** retire merge queues and restore direct protected-PR merges with strict live-ref provenance
 * **security:** document the expiring AWS CDK bundled `brace-expansion` exception and fail its policy check once AWS
   publishes a fixed bundle

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -321,11 +321,33 @@ require_fixed "release-hygiene must run the promotion driver from the resolved v
   "release-hygiene supply-chain verifier must require resolved promotion verifier source"
 require_fixed "scripts/create-stable-release-pr.py" "${rp}" \
   "release-pr workflow must create the stable Release PR deterministically"
+forbid_fixed "merge_group:" "${h}" \
+  "release-hygiene must not use the prohibited merge-queue event"
 SH
   cat >"${root}/scripts/verify-promotion-release-driver.sh" <<'SH'
 #!/usr/bin/env bash
 echo "manifest-derived stable Release-As"
 SH
+}
+
+write_v2_merge_queue_verifier_fixture() {
+  local root="$1"
+
+  write_v2_verifier_fixture "${root}"
+  python3 - "${root}/scripts/verify-branch-release-supply-chain.sh" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    'forbid_fixed "merge_group:" "${h}" \\\n'
+    '  "release-hygiene must not use the prohibited merge-queue event"\n',
+    'require_fixed "merge_group:" "${h}" \\\n'
+    '  "release-hygiene must run on merge_group for premain/main queues"\n',
+)
+path.write_text(text, encoding="utf-8")
+PY
 }
 
 write_v2_legacy_promotion_source_verifier_fixture() {
@@ -411,6 +433,7 @@ run_verifier_source_selector_fixture() {
     v2-release-please-v4) write_v2_release_please_v4_verifier_fixture "${fixture}/trusted-release" ;;
     v2-numbered-rc) write_v2_numbered_rc_verifier_fixture "${fixture}/trusted-release" ;;
     v2-legacy-promotion-source) write_v2_legacy_promotion_source_verifier_fixture "${fixture}/trusted-release" ;;
+    v2-merge-queue) write_v2_merge_queue_verifier_fixture "${fixture}/trusted-release" ;;
     v2) write_v2_verifier_fixture "${fixture}/trusted-release" ;;
     *) echo "release-hygiene-policy-test: unknown trusted fixture ${trusted_shape}" >&2; exit 1 ;;
   esac
@@ -419,6 +442,7 @@ run_verifier_source_selector_fixture() {
     v2-release-please-v4) write_v2_release_please_v4_verifier_fixture "${fixture}/pr" ;;
     v2-numbered-rc) write_v2_numbered_rc_verifier_fixture "${fixture}/pr" ;;
     v2-legacy-promotion-source) write_v2_legacy_promotion_source_verifier_fixture "${fixture}/pr" ;;
+    v2-merge-queue) write_v2_merge_queue_verifier_fixture "${fixture}/pr" ;;
     v2) write_v2_verifier_fixture "${fixture}/pr" ;;
     *) echo "release-hygiene-policy-test: unknown head fixture ${head_shape}" >&2; exit 1 ;;
   esac
@@ -1309,6 +1333,11 @@ grep -Fq "resolved promotion-driver supply-chain marker" "${repo_root}/.github/w
   exit 1
 }
 
+grep -Fq "direct protected-PR verifier marker" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must detect direct protected-PR support"
+  exit 1
+}
+
 selector_result="$(
   run_verifier_source_selector_fixture \
     v1 v2 \
@@ -1320,6 +1349,30 @@ assert_selector_result \
   "." \
   "protected-pr-head-v2" \
   "protected same-repo promotion may use PR-head v2/RC-first/release-please-v5/deterministic-stable verifier scripts after provenance"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-merge-queue v2 \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "." \
+  "protected-pr-head-v2" \
+  "scripts/verify-branch-release-supply-chain.sh lacks direct protected-PR verifier marker"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-merge-queue v2 \
+    main premain \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "." \
+  "protected-pr-head-v2" \
+  "scripts/verify-branch-release-supply-chain.sh lacks direct protected-PR verifier marker"
 
 selector_result="$(
   run_verifier_source_selector_fixture \

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -230,6 +230,8 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
     "release-hygiene verifier selector must detect resolved promotion-driver supply-chain support"
   require_fixed "deterministic stable Release PR marker" "${h}" \
     "release-hygiene verifier selector must detect deterministic stable Release PR support"
+  require_fixed "direct protected-PR verifier marker" "${h}" \
+    "release-hygiene verifier selector must detect direct protected-PR support"
   require_fixed "Go semantic import verifier marker" "${h}" \
     "release-hygiene verifier selector must detect Go semantic import verifier support"
   require_fixed "Go semantic import supply-chain marker" "${h}" \


### PR DESCRIPTION
## Summary

- distinguish queue-era release verifiers from the current direct protected-PR verifier contract
- select verified PR-head scripts during the one-time `staging → premain` or `premain → main` bootstrap when the protected base still carries the retired queue policy
- add regression coverage for both protected promotion hops

## Root cause

PR #422 used the updated direct-PR workflow but selected `premain`'s trusted-base supply-chain verifier. The existing compatibility markers covered single-manifest and release-please evolution, but not the queue-to-direct-PR transition, so the queue-era verifier was incorrectly classified as compatible and demanded five retired merge-queue requirements.

## Validation

- real-ref simulation with current `origin/premain` and the repair head selected `protected-pr-head-v2`
- `bash scripts/test-release-hygiene-policy.sh` — PASS
- `bash scripts/verify-branch-release-supply-chain.sh` — PASS
- `NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS=true make rubric` — PASS (36 passed, 0 failed, 0 blocked)

No repository setting, merge queue, auto-merge, admin bypass, PR recreation, or operator fallback is required. Once this reaches `staging`, PR #422 updates and reruns Release Hygiene.