### PR TITLE
fix(transaction): preserve nested empty collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bug Fixes
 
+* **transaction:** preserve non-nil empty collections in nested Go structs unless `omitempty` is explicit
 * **ci:** select direct-PR verifier scripts while a promotion base still contains the retired queue-era policy
 * **ci:** retire merge queues and restore direct protected-PR merges with strict live-ref provenance
 * **security:** document the expiring AWS CDK bundled `brace-expansion` exception and fail its policy check once AWS

--- a/contract-tests/scenarios/p2/04-transact-write-empty-collections.yml
+++ b/contract-tests/scenarios/p2/04-transact-write-empty-collections.yml
@@ -1,0 +1,44 @@
+name: "p2.transact_write_empty_collections"
+dms_version: "0.1"
+requires_capabilities: ["transact.write", "release_state.write_policy"]
+model: "ReleaseStateEvent"
+table:
+  name: "release_state_contract"
+steps:
+  - op: transact_write
+    transact_write:
+      actions:
+        - kind: "create"
+          item:
+            PK: "RELEASE#TX-EMPTY"
+            SK: "EVENT#TX-EMPTY"
+            releaseId: "rel_tx_empty"
+            eventType: "contract"
+            provenance:
+              source: "contract"
+              emptyList: []
+              emptyMap: {}
+    expect: { ok: true }
+
+  - op: get
+    key:
+      PK: "RELEASE#TX-EMPTY"
+      SK: "EVENT#TX-EMPTY"
+    expect:
+      ok: true
+      item_contains:
+        PK: "RELEASE#TX-EMPTY"
+        SK: "EVENT#TX-EMPTY"
+        releaseId: "rel_tx_empty"
+        eventType: "contract"
+        provenance:
+          source: "contract"
+          emptyList: []
+          emptyMap: {}
+      raw_attribute_types:
+        provenance: "M"
+      raw_item_contains:
+        provenance:
+          source: "contract"
+          emptyList: []
+          emptyMap: {}

--- a/docs/features/crud.md
+++ b/docs/features/crud.md
@@ -103,6 +103,8 @@ table.delete("USER#1", "NOTE#welcome")
 Without `omit_empty`, **zero values are written**: `""`, `0`, `False`/`false`, empty slices, empty maps. With `omit_empty`, the attribute is *omitted entirely* from the DynamoDB item.
 
 This matters because DynamoDB distinguishes "attribute present with empty string" from "attribute absent" in queries and conditional expressions. The contract pins which behavior each combination produces, and every runtime must agree.
+In Go transaction puts, explicitly non-nil empty collections inside nested structs are preserved unless those fields
+use `omitempty`.
 
 The dedicated [omit-empty scenario](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/02-omitempty.yml) exercises every type variant in the matrix.
 

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -13,6 +13,7 @@ This page documents TableTheory's public write-transaction surfaces, which use t
 - **Condition evaluation** is server-side: each write item carries its own conditional expression, and a single failed condition aborts the whole transaction.
 - **Optimistic-lock composition**: a versioned item in the group asserts its expected version; a version mismatch aborts the transaction atomically.
 - **Encryption composition**: encrypted fields are encrypted before the transaction is submitted; a KMS failure aborts before any write hits DynamoDB.
+- **Marshaling parity**: transaction puts preserve non-nil empty lists and maps, including inside nested Go structs, unless the field explicitly uses `omitempty`.
 - **Cross-runtime parity**: a write transaction submitted from Python sees the same atomicity guarantees as one submitted from Go.
 
 ## Write transaction limits to know

--- a/internal/expr/anonymous_embed_encoding.go
+++ b/internal/expr/anonymous_embed_encoding.go
@@ -17,8 +17,8 @@ type ConvertOptions struct {
 	LegacyStructFieldNames bool
 
 	// OmitZeroFieldsByDefault preserves pkg/types.Converter's historical
-	// struct encoding behavior where zero-valued exported fields are omitted even
-	// without omitempty.
+	// reflect.Value.IsZero struct encoding behavior. In particular, non-nil empty
+	// collections are preserved unless omitempty is explicit.
 	OmitZeroFieldsByDefault bool
 
 	// FixedFloatFormat preserves pkg/types.Converter's historical decimal-string

--- a/internal/expr/converter.go
+++ b/internal/expr/converter.go
@@ -181,7 +181,8 @@ func convertStructToAttributeValueWithConvention(v reflect.Value, inheritedConve
 		}
 
 		fieldValue := v.FieldByIndex(fieldPlan.IndexPath)
-		if shouldOmitEmptyField(fieldValue, theorydbTag, jsonTag) || (opts.OmitZeroFieldsByDefault && isZeroValue(fieldValue)) {
+		if shouldOmitEmptyField(fieldValue, theorydbTag, jsonTag) ||
+			(opts.OmitZeroFieldsByDefault && fieldValue.IsZero()) {
 			continue
 		}
 

--- a/pkg/transaction/nested_empty_collections_test.go
+++ b/pkg/transaction/nested_empty_collections_test.go
@@ -1,0 +1,65 @@
+package transaction
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/v2/pkg/model"
+	pkgTypes "github.com/theory-cloud/tabletheory/v2/pkg/types"
+)
+
+type nestedCollectionPayload struct {
+	EmptyMap    map[string]string `theorydb:"attr:emptyMap" json:"emptyMap"`
+	OmittedMap  map[string]string `theorydb:"attr:omittedMap,omitempty" json:"omittedMap,omitempty"`
+	EmptyList   []string          `theorydb:"attr:emptyList" json:"emptyList"`
+	OmittedList []string          `theorydb:"attr:omittedList,omitempty" json:"omittedList,omitempty"`
+}
+
+type nestedCollectionRecord struct {
+	PK      string                  `theorydb:"pk,attr:PK" json:"PK"`
+	SK      string                  `theorydb:"sk,attr:SK" json:"SK"`
+	Payload nestedCollectionPayload `theorydb:"attr:payload" json:"payload"`
+}
+
+func TestTransactionCreatePreservesNestedEmptyCollectionsWithoutOmitEmpty(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&nestedCollectionRecord{}))
+
+	builder := NewBuilder(nil, registry, pkgTypes.NewConverter())
+	mockClient := newMockTransactClient(t, nil)
+	builder.client = mockClient
+
+	record := &nestedCollectionRecord{
+		PK: "RECORD#empty-collections",
+		SK: "PAYLOAD",
+		Payload: nestedCollectionPayload{
+			EmptyList:   []string{},
+			EmptyMap:    map[string]string{},
+			OmittedList: []string{},
+			OmittedMap:  map[string]string{},
+		},
+	}
+
+	require.NoError(t, builder.Create(record).Execute())
+	require.Len(t, mockClient.inputs, 1)
+	require.Len(t, mockClient.inputs[0].TransactItems, 1)
+
+	put := mockClient.inputs[0].TransactItems[0].Put
+	require.NotNil(t, put)
+
+	payload, ok := put.Item["payload"].(*types.AttributeValueMemberM)
+	require.True(t, ok, "payload should be a DynamoDB map")
+
+	emptyList, ok := payload.Value["emptyList"].(*types.AttributeValueMemberL)
+	require.True(t, ok, "non-omitempty empty list should be present")
+	require.Empty(t, emptyList.Value)
+
+	emptyMap, ok := payload.Value["emptyMap"].(*types.AttributeValueMemberM)
+	require.True(t, ok, "non-omitempty empty map should be present")
+	require.Empty(t, emptyMap.Value)
+
+	require.NotContains(t, payload.Value, "omittedList")
+	require.NotContains(t, payload.Value, "omittedMap")
+}


### PR DESCRIPTION
## Summary

- restore the Go converter's historical `reflect.Value.IsZero()` behavior for implicit nested-struct omission
- preserve explicitly non-nil empty nested slices and maps as DynamoDB `L` / `M` values while leaving explicit `omitempty` behavior unchanged
- add a public Go transaction-builder regression test and a shared P2 transaction fixture for Go, TypeScript, and Python
- document the repaired behavior and record it in the unreleased changelog

## Root cause

The converter-stack consolidation changed the `OmitZeroFieldsByDefault` compatibility path from `reflect.Value.IsZero()` to length-based empty detection. As a result, Go transaction puts dropped non-nil empty collections inside typed nested structs even when those fields did not declare `omitempty`. This diverged from ordinary Go marshaling and the TypeScript/Python transaction runtimes.

Reported downstream as `equaltoai/lesser-host#982`.

## Impact

Go `TransactWrite -> Create` / `Put` now preserves contract-required empty nested collections. Fields that explicitly declare `theorydb` or JSON `omitempty` remain omitted, so the fix is narrowly backward-compatible and requires no DMS change.

## Validation

- `go test -count=1 ./internal/expr ./pkg/types ./pkg/marshal ./pkg/transaction`
- Go P2 contract runner
- TypeScript P2 contract runner
- Python P2 contract runner
- `NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS=true make rubric` — PASS, 36/36