### PR TITLE
fix(ci): honor prerelease promotion release driver

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -52,6 +52,16 @@ jobs:
           cat "${repair_log}"
           exit 1
 
+      - name: Resolve prerelease promotion release driver
+        id: driver
+        if: steps.cycle.outputs.pending_stable_repair != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          release_as="$(bash scripts/resolve-prerelease-release-as.sh --repo "${GITHUB_REPOSITORY}" --sha "${GITHUB_SHA}" --base premain)"
+          echo "release_as=${release_as}" >> "${GITHUB_OUTPUT}"
+
       - name: Release Please (PR only)
         id: release
         if: steps.cycle.outputs.pending_stable_repair != 'true'
@@ -62,11 +72,13 @@ jobs:
           config-file: release-please-config.premain.json
           manifest-file: .release-please-manifest.json
           skip-github-release: true
+          release-as: ${{ steps.driver.outputs.release_as }}
 
       - name: Verify prerelease Release PR postcondition
         if: steps.cycle.outputs.pending_stable_repair != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          PRERELEASE_PR_EXPECTED_VERSION: ${{ steps.driver.outputs.release_as }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   rubric:
@@ -26,6 +27,34 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+
+      - name: Verify staged PR is release-eligible
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${HEAD_REF}" == "main" ]]; then
+            echo "staging-release-driver: PASS (post-release main back-merge)"
+            exit 0
+          fi
+          gh pr view "${PR_NUMBER}" --json title,body,commits > pr.json
+          python3 - pr.json <<'PY2'
+          import json, re, sys
+          pr = json.load(open(sys.argv[1], encoding="utf-8"))
+          text = "\n".join([pr.get("title", ""), pr.get("body", "")] + [
+              "\n".join((commit.get("messageHeadline", ""), commit.get("messageBody", "")))
+              for commit in pr.get("commits", [])
+          ])
+          if re.search(r"(?m)^(?:feat|fix|perf)(?:\([^)]+\))?!?: ", text):
+              print("staging-release-driver: PASS (release-eligible conventional commit)")
+              raise SystemExit(0)
+          if re.search(r"(?im)^Release-As:[ \t]*v?\d+\.\d+\.\d+-rc(?:\.\d+)?[ \t]*$", text):
+              print("staging-release-driver: PASS (explicit RC Release-As driver)")
+              raise SystemExit(0)
+          raise SystemExit("staging-release-driver: FAIL (staging PR must contain feat:, fix:, or perf:, or an RC-shaped Release-As footer; chore-only work cannot enter the release lane)")
+          PY2
 
       - name: Fetch release-lane refs
         run: |

--- a/scripts/resolve-prerelease-release-as.sh
+++ b/scripts/resolve-prerelease-release-as.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:-theory-cloud/TableTheory}"
+sha="${GITHUB_SHA:-}"
+base="premain"
+json=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo="$2"; shift 2 ;;
+    --sha) sha="$2"; shift 2 ;;
+    --base) base="$2"; shift 2 ;;
+    --prs-json) json="$2"; shift 2 ;;
+    *) echo "resolve-prerelease-release-as: unknown argument $1" >&2; exit 2 ;;
+  esac
+done
+[[ -n "${sha}" ]] || { echo "resolve-prerelease-release-as: --sha is required" >&2; exit 2; }
+[[ -n "${json}" ]] || json="$(gh api "repos/${repo}/commits/${sha}/pulls")"
+printf '%s' "${json}" | python3 -c '
+import json, re, sys
+base = sys.argv[1]
+rc = re.compile(r"(?im)^[ \t]*Release-As:[ \t]*v?([0-9]+\.[0-9]+\.[0-9]+-rc(?:\.[0-9]+)?)[ \t]*$")
+versions = set()
+for pr in json.load(sys.stdin):
+    if pr.get("base", {}).get("ref") == base and pr.get("merged_at"):
+        versions.update(rc.findall("\n".join((pr.get("title") or "", pr.get("body") or ""))))
+if len(versions) > 1:
+    raise SystemExit("resolve-prerelease-release-as: multiple RC Release-As footers found")
+print(next(iter(versions), ""))
+' "${base}"


### PR DESCRIPTION
Fixes the prerelease release lane so an RC-shaped `Release-As` footer on a merged `staging` → `premain` promotion is passed to release-please and verified as the expected RC PR.\n\nValidation: fixture resolution of `Release-As: 2.0.6-rc.1` and `git diff --check`.