### PR TITLE
fix(transaction): align explicit update parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@
 
 ### Bug Fixes
 
+* **transaction:** refresh library-owned `updated_at` values on Go and TypeScript model-shaped transactional updates,
+  matching Python and each runtime's non-transactional update behavior
+* **ts:** reject `createdAt` and version fields from model-shaped transactional update selections, and validate
+  `updateFn` keys before invoking caller callbacks
+* **go:** normalize `theorydb:"json"` values identically in query and explicit transaction updates
+* **ci:** mechanically classify every Go `IsEmpty` / `IsSparseUpdateEmpty` call site so predicate drift fails the rubric
 * **transaction:** preserve non-nil empty collections in nested Go structs unless `omitempty` is explicit
 * **ci:** select direct-PR verifier scripts while a promotion base still contains the retired queue-era policy
 * **ci:** retire merge queues and restore direct protected-PR merges with strict live-ref provenance

--- a/contract-tests/scenarios/p1/61-transact-write-updated-at.yml
+++ b/contract-tests/scenarios/p1/61-transact-write-updated-at.yml
@@ -1,0 +1,51 @@
+name: "p1.transact_write_updated_at"
+dms_version: "0.2"
+requires_capabilities: ["transact.write"]
+model: "User"
+table:
+  name: "users_contract"
+steps:
+  - op: create
+    item:
+      PK: "USER#TX-UPDATED-AT"
+      SK: "PROFILE"
+      nickname: "before"
+    expect:
+      ok: true
+
+  - op: get
+    key:
+      PK: "USER#TX-UPDATED-AT"
+      SK: "PROFILE"
+    save:
+      createdAt0: "createdAt"
+      updatedAt0: "updatedAt"
+    expect:
+      item_has_fields: ["createdAt", "updatedAt"]
+
+  - op: sleep
+    ms: 25
+
+  - op: transact_write
+    transact_write:
+      actions:
+        - kind: "update"
+          key:
+            PK: "USER#TX-UPDATED-AT"
+            SK: "PROFILE"
+          set:
+            nickname: "after"
+    expect:
+      ok: true
+
+  - op: get
+    key:
+      PK: "USER#TX-UPDATED-AT"
+      SK: "PROFILE"
+    expect:
+      item_contains:
+        nickname: "after"
+      item_field_equals_var:
+        createdAt: "createdAt0"
+      item_field_not_equals_var:
+        updatedAt: "updatedAt0"

--- a/contract-tests/scenarios/p1/62-transact-write-rejects-lifecycle-fields.yml
+++ b/contract-tests/scenarios/p1/62-transact-write-rejects-lifecycle-fields.yml
@@ -1,0 +1,102 @@
+name: "p1.transact_write_rejects_lifecycle_fields"
+dms_version: "0.2"
+requires_capabilities: ["transact.write"]
+model: "User"
+table:
+  name: "users_contract"
+steps:
+  - op: create
+    item:
+      PK: "USER#TX-LIFECYCLE-REJECT"
+      SK: "PROFILE"
+      nickname: "before"
+    expect:
+      ok: true
+
+  - op: get
+    key:
+      PK: "USER#TX-LIFECYCLE-REJECT"
+      SK: "PROFILE"
+    save:
+      createdAt0: "createdAt"
+      updatedAt0: "updatedAt"
+      version0: "version"
+    expect:
+      item_contains:
+        nickname: "before"
+      item_has_fields: ["createdAt", "updatedAt", "version"]
+
+  - op: transact_write
+    transact_write:
+      actions:
+        - kind: "update"
+          key:
+            PK: "USER#TX-LIFECYCLE-REJECT"
+            SK: "PROFILE"
+          set:
+            createdAt: "2026-07-31T00:00:00Z"
+            nickname: "created-at-should-not-write"
+    expect:
+      error: "ErrInvalidModel"
+
+  - op: get
+    key:
+      PK: "USER#TX-LIFECYCLE-REJECT"
+      SK: "PROFILE"
+    expect:
+      item_contains:
+        nickname: "before"
+      item_field_equals_var:
+        createdAt: "createdAt0"
+        updatedAt: "updatedAt0"
+        version: "version0"
+
+  - op: transact_write
+    transact_write:
+      actions:
+        - kind: "update"
+          key:
+            PK: "USER#TX-LIFECYCLE-REJECT"
+            SK: "PROFILE"
+          set:
+            updatedAt: "2026-07-31T00:00:00Z"
+            nickname: "updated-at-should-not-write"
+    expect:
+      error: "ErrInvalidModel"
+
+  - op: get
+    key:
+      PK: "USER#TX-LIFECYCLE-REJECT"
+      SK: "PROFILE"
+    expect:
+      item_contains:
+        nickname: "before"
+      item_field_equals_var:
+        createdAt: "createdAt0"
+        updatedAt: "updatedAt0"
+        version: "version0"
+
+  - op: transact_write
+    transact_write:
+      actions:
+        - kind: "update"
+          key:
+            PK: "USER#TX-LIFECYCLE-REJECT"
+            SK: "PROFILE"
+          set:
+            version: 99
+            nickname: "version-should-not-write"
+    expect:
+      error: "ErrInvalidModel"
+
+  - op: get
+    key:
+      PK: "USER#TX-LIFECYCLE-REJECT"
+      SK: "PROFILE"
+    expect:
+      item_contains:
+        nickname: "before"
+      item_field_equals_var:
+        createdAt: "createdAt0"
+        updatedAt: "updatedAt0"
+        version: "version0"

--- a/docs/features/lifecycle-timestamps.md
+++ b/docs/features/lifecycle-timestamps.md
@@ -14,6 +14,11 @@ TypeScript, and Python populate these fields in their shared P0 write paths:
 - update writes preserve `created_at` and advance `updated_at`;
 - a failed conditional update does not advance `updated_at`.
 
+The update rule includes model-shaped explicit-field transaction updates: Go
+`TransactionBuilder.Update`, TypeScript `item` + `fields` transaction actions,
+and Python `TransactUpdate`. Raw expressions and update-builder callbacks are
+low-level escape hatches and mutate lifecycle fields only when the caller asks.
+
 The [lifecycle P0 fixture](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p0/03-lifecycle-created-updated.yml)
 tracks the shared contract shape and expected timestamp ordering across all
 three runtimes.

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -70,8 +70,9 @@ err := db.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
 Update actions provide either `item` plus an explicit `fields` selection, or
 `key` plus a raw `updateExpression` or an `updateFn` that uses the
 `UpdateBuilder` DSL. The model-based `item` + `fields` action removes a selected
-empty `omit_empty` attribute and sets every other selected attribute. The
-builder and raw expression variants remain caller-controlled.
+empty `omit_empty` attribute, sets every other selected attribute, and advances
+the model's library-owned `updatedAt` role. It rejects `createdAt` and version
+in `fields`. The builder and raw expression variants remain caller-controlled.
 
 ```typescript
 await db.transactWrite([

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -63,6 +63,13 @@ err := db.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
 > `db.TransactionFunc(...)` compatibility helpers no longer exist; migrate to
 > the atomic `Transact()` surface.
 
+Go model-based `Update(model, fields)` transactions reject explicit selection
+of the library-owned `created_at`, `updated_at`, and version fields with
+`ErrInvalidModel`. The transaction runtime remains the single writer of
+`updated_at`, so the generated expression cannot contain overlapping lifecycle
+document paths. `UpdateWithBuilder` remains a caller-controlled low-level
+surface.
+
 ## TypeScript
 
 `TheorydbClient.transactWrite(actions: TransactAction[])` accepts a list of
@@ -72,7 +79,9 @@ Update actions provide either `item` plus an explicit `fields` selection, or
 `UpdateBuilder` DSL. The model-based `item` + `fields` action removes a selected
 empty `omit_empty` attribute, sets every other selected attribute, and advances
 the model's library-owned `updatedAt` role. It rejects `createdAt` and version
-in `fields`. The builder and raw expression variants remain caller-controlled.
+in `fields`. It also rejects caller-selected `updatedAt`, leaving the injected
+lifecycle refresh as the single writer. The builder and raw expression variants
+remain caller-controlled.
 
 ```typescript
 await db.transactWrite([

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -119,8 +119,10 @@ See [`ts/src/transaction.ts`](https://github.com/theory-cloud/tabletheory/blob/m
 `TransactPut`, `TransactUpdate`, `TransactDelete`, `TransactConditionCheck` — all importable from `tabletheory_py`.
 Model-shaped `TransactUpdate.updates` rejects the Python fields carrying
 `created_at`, `updated_at`, and version roles with `ValidationError`. It does not
-increment version or add a version condition; use a deliberate raw transaction
-surface when transactional optimistic locking is required.
+increment version or add a version condition. Python has no partial-update
+version path on the transactional surface; transactional optimistic locking
+requires a `TransactPut` of the item with an explicitly incremented version plus
+a `condition_expression` on the current version.
 
 ```python
 from tabletheory_py import TransactPut, TransactUpdate

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -68,7 +68,8 @@ of the library-owned `created_at`, `updated_at`, and version fields with
 `ErrInvalidModel`. The transaction runtime remains the single writer of
 `updated_at`, so the generated expression cannot contain overlapping lifecycle
 document paths. `UpdateWithBuilder` remains a caller-controlled low-level
-surface.
+surface. The model-based path does not increment version or add a version
+condition; use `UpdateWithBuilder` for optimistic locking in a transaction.
 
 ## TypeScript
 
@@ -116,6 +117,10 @@ See [`ts/src/transaction.ts`](https://github.com/theory-cloud/tabletheory/blob/m
 
 `Table.transact_write(actions)` accepts a list of dataclass actions —
 `TransactPut`, `TransactUpdate`, `TransactDelete`, `TransactConditionCheck` — all importable from `tabletheory_py`.
+Model-shaped `TransactUpdate.updates` rejects the Python fields carrying
+`created_at`, `updated_at`, and version roles with `ValidationError`. It does not
+increment version or add a version condition; use a deliberate raw transaction
+surface when transactional optimistic locking is required.
 
 ```python
 from tabletheory_py import TransactPut, TransactUpdate

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -44,12 +44,19 @@ are zero.
 Model-shaped transactional updates now follow the same lifecycle contract as
 non-transactional updates in all three runtimes: a successful explicit-field
 transaction update advances the library-owned `updated_at` attribute and
-preserves `created_at`. TypeScript's `item` + `fields` transaction action now
-rejects `createdAt` and the version attribute with `ErrInvalidModel`, matching
-the high-level update surface; `updateFn` and raw `updateExpression` remain
-deliberate low-level escape hatches. TypeScript also marshals an `updateFn`
-action's key before invoking the callback, so a malformed key cannot run caller
-side effects before the key error is returned.
+preserves `created_at`. Go and TypeScript model-shaped transaction updates now
+reject explicit selection of `created_at`, `updated_at`, or the version
+attribute with `ErrInvalidModel`, matching Python's lifecycle-owned field
+behavior. TypeScript's `updateFn` and raw `updateExpression`, and Go's
+`UpdateWithBuilder`, remain deliberate low-level escape hatches. TypeScript also
+marshals an `updateFn` action's key before invoking the callback, so a malformed
+key cannot run caller side effects before the key error is returned.
+
+The F6 JSON normalization parity fix changes the transactional wire encoding
+for Go fields tagged with both `json` and `encrypted`: the value is normalized
+to a JSON string before encryption instead of encrypting raw marshaled bytes.
+Reads through `UnmarshalJSONFieldValue` tolerate both encodings, so existing
+items remain readable. This is an intentional convergence with the query path.
 
 ## Consumer migration
 
@@ -93,8 +100,9 @@ side effects before the key error is returned.
     marshaler now omits those fields instead of persisting their zero values.
     Add explicit matching `theorydb` and `json` tags without `omitempty` when a
     nested zero value must remain present on the DynamoDB wire.
-11. Audit TypeScript model-shaped transaction field lists for `createdAt` or
-    the version attribute and remove them; the runtime owns those values.
+11. Audit Go and TypeScript model-shaped transaction field lists for
+    `created_at`, `updated_at`, or the version attribute and remove them; the
+    runtime owns those values.
 12. If a TypeScript `updateFn` callback intentionally relied on running before
     malformed-key validation, move that work outside the callback and validate
     the key first.

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -41,6 +41,16 @@ the DMS carrier-size/length rules then apply. For record-shaped `M` values,
 tagged child fields without `omitempty` remain present even when their values
 are zero.
 
+Model-shaped transactional updates now follow the same lifecycle contract as
+non-transactional updates in all three runtimes: a successful explicit-field
+transaction update advances the library-owned `updated_at` attribute and
+preserves `created_at`. TypeScript's `item` + `fields` transaction action now
+rejects `createdAt` and the version attribute with `ErrInvalidModel`, matching
+the high-level update surface; `updateFn` and raw `updateExpression` remain
+deliberate low-level escape hatches. TypeScript also marshals an `updateFn`
+action's key before invoking the callback, so a malformed key cannot run caller
+side effects before the key error is returned.
+
 ## Consumer migration
 
 1. For Go consumers, update `go.mod` and every TableTheory import:
@@ -83,6 +93,11 @@ are zero.
     marshaler now omits those fields instead of persisting their zero values.
     Add explicit matching `theorydb` and `json` tags without `omitempty` when a
     nested zero value must remain present on the DynamoDB wire.
+11. Audit TypeScript model-shaped transaction field lists for `createdAt` or
+    the version attribute and remove them; the runtime owns those values.
+12. If a TypeScript `updateFn` callback intentionally relied on running before
+    malformed-key validation, move that work outside the callback and validate
+    the key first.
 
 Legacy Go index-role tags such as `theorydb:"gsi:Name:pk"` and
 `theorydb:"gsi:Name:sk"` remain protected from update assignment. Exact token

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -44,19 +44,22 @@ are zero.
 Model-shaped transactional updates now follow the same lifecycle contract as
 non-transactional updates in all three runtimes: a successful explicit-field
 transaction update advances the library-owned `updated_at` attribute and
-preserves `created_at`. Go and TypeScript model-shaped transaction updates now
-reject explicit selection of `created_at`, `updated_at`, or the version
-attribute with `ErrInvalidModel`, matching Python's lifecycle-owned field
-behavior. TypeScript's `updateFn` and raw `updateExpression`, and Go's
-`UpdateWithBuilder`, remain deliberate low-level escape hatches. TypeScript also
+preserves `created_at`. Go, TypeScript, and Python model-shaped transaction
+updates now reject explicit selection of `created_at`, `updated_at`, or the
+version attribute with their invalid-model validation errors. These
+model-shaped paths neither increment version nor add a version condition;
+versioned transactional writes must use Go's `UpdateWithBuilder`, TypeScript's
+`updateFn` or raw `updateExpression`, or a deliberate raw transaction surface.
+TypeScript also
 marshals an `updateFn` action's key before invoking the callback, so a malformed
 key cannot run caller side effects before the key error is returned.
 
 The F6 JSON normalization parity fix changes the transactional wire encoding
-for Go fields tagged with both `json` and `encrypted`: the value is normalized
-to a JSON string before encryption instead of encrypting raw marshaled bytes.
-Reads through `UnmarshalJSONFieldValue` tolerate both encodings, so existing
-items remain readable. This is an intentional convergence with the query path.
+for Go `json`-tagged `[]byte` and `json.RawMessage` fields, whether encrypted or
+not: their DynamoDB attribute type changes from `B` to normalized JSON `S`.
+Reads through `setJSONStringCarrierValue` / `attributeValueToJSONBytes` tolerate
+both encodings, so existing items remain readable. Other `json`-tagged carrier
+types are unaffected. This is an intentional convergence with the query path.
 
 ## Consumer migration
 
@@ -100,12 +103,16 @@ items remain readable. This is an intentional convergence with the query path.
     marshaler now omits those fields instead of persisting their zero values.
     Add explicit matching `theorydb` and `json` tags without `omitempty` when a
     nested zero value must remain present on the DynamoDB wire.
-11. Audit Go and TypeScript model-shaped transaction field lists for
+11. Audit Go, TypeScript, and Python model-shaped transaction field lists for
     `created_at`, `updated_at`, or the version attribute and remove them; the
-    runtime owns those values.
+    runtime owns those values. Move version increments and conditions to the
+    appropriate low-level transaction surface.
 12. If a TypeScript `updateFn` callback intentionally relied on running before
     malformed-key validation, move that work outside the callback and validate
     the key first.
+13. Audit Go model-shaped transaction updates for `json`-tagged `[]byte` and
+    `json.RawMessage` fields, encrypted or not. Their wire type changes from `B`
+    to normalized JSON `S`; existing reads remain tolerant of both encodings.
 
 Legacy Go index-role tags such as `theorydb:"gsi:Name:pk"` and
 `theorydb:"gsi:Name:sk"` remain protected from update assignment. Exact token

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -49,7 +49,9 @@ updates now reject explicit selection of `created_at`, `updated_at`, or the
 version attribute with their invalid-model validation errors. These
 model-shaped paths neither increment version nor add a version condition;
 versioned transactional writes must use Go's `UpdateWithBuilder`, TypeScript's
-`updateFn` or raw `updateExpression`, or a deliberate raw transaction surface.
+`updateFn` or raw `updateExpression`, or Python's `TransactPut` of the item with
+an explicitly incremented version plus a `condition_expression` on the current
+version. Python has no partial-update version path on the transactional surface.
 TypeScript also
 marshals an `updateFn` action's key before invoking the callback, so a malformed
 key cannot run caller side effects before the key error is returned.
@@ -105,8 +107,11 @@ types are unaffected. This is an intentional convergence with the query path.
     nested zero value must remain present on the DynamoDB wire.
 11. Audit Go, TypeScript, and Python model-shaped transaction field lists for
     `created_at`, `updated_at`, or the version attribute and remove them; the
-    runtime owns those values. Move version increments and conditions to the
-    appropriate low-level transaction surface.
+    runtime owns those values. Move version increments and conditions to Go's
+    `UpdateWithBuilder`, TypeScript's `updateFn` or raw `updateExpression`, or
+    Python's `TransactPut` of the item with an explicitly incremented version
+    plus a `condition_expression` on the current version. Python has no
+    partial-update version path on the transactional surface.
 12. If a TypeScript `updateFn` callback intentionally relied on running before
     malformed-key validation, move that work outside the callback and validate
     the key first.

--- a/docs/reference/contract-scenarios.md
+++ b/docs/reference/contract-scenarios.md
@@ -81,6 +81,10 @@ The P1
 [`61-transact-write-updated-at.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p1/61-transact-write-updated-at.yml)
 scenario asserts that an explicit-field transactional update advances
 `updatedAt` while preserving `createdAt` in Go, TypeScript, and Python.
+The P1
+[`62-transact-write-rejects-lifecycle-fields.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p1/62-transact-write-rejects-lifecycle-fields.yml)
+scenario asserts that all three runtimes reject caller-selected `createdAt`,
+`updatedAt`, and version fields before a model-shaped transaction can write.
 
 ## How a scenario is run
 

--- a/docs/reference/contract-scenarios.md
+++ b/docs/reference/contract-scenarios.md
@@ -77,6 +77,11 @@ runs the supported runtimes against the new scenario *before* adding it to the P
 set. New shapes incubate in P1/P2 status — important but not yet frozen — until
 they pass cross-runtime in three consecutive releases.
 
+The P1
+[`61-transact-write-updated-at.yml`](https://github.com/theory-cloud/tabletheory/blob/main/contract-tests/scenarios/p1/61-transact-write-updated-at.yml)
+scenario asserts that an explicit-field transactional update advances
+`updatedAt` while preserving `createdAt` in Go, TypeScript, and Python.
+
 ## How a scenario is run
 
 ```bash

--- a/docs/runtimes/typescript/api-reference.md
+++ b/docs/runtimes/typescript/api-reference.md
@@ -492,7 +492,9 @@ type TransactUpdateWithBuilder = {
  *
  * Selected empty `omit_empty` attributes are removed according to DMS v0.2;
  * every other selected attribute is set from `item`. Fields not listed in
- * `fields` are not mutated.
+ * `fields` are not mutated, except that the runtime advances `updatedAt` when
+ * the model declares that lifecycle role. `createdAt` and version cannot be
+ * selected because those attributes are library-owned.
  */
 export type TransactModelUpdate = {
     kind: 'update';

--- a/gov-infra/planning/theorydb-10of10-rubric.md
+++ b/gov-infra/planning/theorydb-10of10-rubric.md
@@ -44,7 +44,7 @@ Enforcement rule (anti-drift):
 | --- | ---: | --- | --- |
 | CON-1 | 3 | gofmt/formatter clean (no diffs) | `bash scripts/verify-formatting.sh` |
 | CON-2 | 5 | Lint/static analysis green (pinned version) | `bash scripts/verify-lint.sh` |
-| CON-3 | 2 | Public boundary contract parity + DMS-first workflow + generated-model drift gate | `bash scripts/verify-public-api-contracts.sh`, `bash scripts/verify-dms-first-workflow.sh`, `bash scripts/verify-generated-models.sh --check` |
+| CON-3 | 2 | Public boundary contract parity + DMS-first workflow + generated-model and empty-predicate drift gates | `bash scripts/verify-public-api-contracts.sh`, `bash scripts/verify-dms-first-workflow.sh`, `bash scripts/verify-generated-models.sh --check`, `bash scripts/verify-empty-predicate-call-sites.sh` |
 
 **10/10 definition:** CON-1 through CON-3 pass.
 
@@ -126,6 +126,7 @@ bash scripts/verify-coverage.sh
 bash scripts/verify-formatting.sh
 bash scripts/verify-lint.sh
 bash scripts/verify-public-api-contracts.sh
+bash scripts/verify-empty-predicate-call-sites.sh
 
 bash scripts/verify-ci-toolchain.sh
 bash scripts/verify-builds.sh

--- a/gov-infra/planning/theorydb-evidence-plan.md
+++ b/gov-infra/planning/theorydb-evidence-plan.md
@@ -34,7 +34,7 @@ Every rubric ID maps to exactly one verifier and one primary evidence location.
 | QUA-5 | Fuzz smoke output | `gov-infra/evidence/QUA-5-output.log` | `bash scripts/fuzz-smoke.sh` |
 | CON-1 | Formatter diff list | `gov-infra/evidence/CON-1-output.log` | `bash scripts/verify-formatting.sh` |
 | CON-2 | Lint output | `gov-infra/evidence/CON-2-output.log` | `bash scripts/verify-lint.sh` |
-| CON-3 | Contract verification output | `gov-infra/evidence/CON-3-output.log` | `bash scripts/verify-public-api-contracts.sh`, `bash scripts/verify-dms-first-workflow.sh`, `bash scripts/verify-generated-models.sh --check` |
+| CON-3 | Contract verification output | `gov-infra/evidence/CON-3-output.log` | `bash scripts/verify-public-api-contracts.sh`, `bash scripts/verify-dms-first-workflow.sh`, `bash scripts/verify-generated-models.sh --check`, `bash scripts/verify-empty-predicate-call-sites.sh` |
 | COM-1 | Builds + version alignment output | `gov-infra/evidence/COM-1-output.log` | `bash scripts/verify-typescript-deps.sh`, `bash scripts/verify-python-deps.sh`, `bash scripts/verify-builds.sh` |
 | COM-2 | Toolchain pin verification | `gov-infra/evidence/COM-2-output.log` | `bash scripts/verify-ci-toolchain.sh` |
 | COM-3 | Planning docs presence | `gov-infra/evidence/COM-3-output.log` | `bash scripts/verify-planning-docs.sh` |

--- a/gov-infra/planning/theorydb-threat-model.md
+++ b/gov-infra/planning/theorydb-threat-model.md
@@ -41,7 +41,7 @@ Threat IDs must be stable over time. When a new class of risk is discovered:
 | THR-4 | DoS / cost blowups via unbounded operations | Unbounded scans/queries/batches cause throttling or large spend | QUA-2, SEC-7 | `bash scripts/verify-integration-tests.sh`, `bash scripts/verify-network-hygiene.sh` (plus targeted regression tests as needed) |
 | THR-5 | Sensitive data exposure | Values that may include CHD/PII leak via logs/errors/examples; encryption tags become “paper security” | SEC-5, SEC-8, SEC-9 | `bash scripts/verify-safe-defaults.sh`, `bash scripts/verify-encrypted-tag-implemented.sh`, `bash gov-infra/verifiers/gov-verify-rubric.sh` |
 | THR-6 | Supply-chain and verifier drift | CI/tool versions drift or gates are weakened (excludes/threshold lowering) causing missed issues | COM-1..8, SEC-2, SEC-3, DOC-4, DOC-5 | `bash gov-infra/verifiers/gov-verify-rubric.sh` |
-| THR-7 | Public API contract drift | Exported helpers or generated contract-runner models diverge from canonical tag/DMS semantics; consumers make unsafe assumptions | CON-3 | `bash scripts/verify-public-api-contracts.sh`, `bash scripts/verify-dms-first-workflow.sh`, `bash scripts/verify-generated-models.sh --check` |
+| THR-7 | Public API contract drift | Exported helpers, generated contract-runner models, or empty-predicate call sites diverge from canonical tag/DMS semantics; consumers make unsafe assumptions | CON-3 | `bash scripts/verify-public-api-contracts.sh`, `bash scripts/verify-dms-first-workflow.sh`, `bash scripts/verify-generated-models.sh --check`, `bash scripts/verify-empty-predicate-call-sites.sh` |
 
 ## Parity Rule (no “named threat without control”)
 - Every `THR-*` listed above must appear at least once in the controls matrix “Threat IDs” column.

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -657,7 +657,7 @@ CMD_FUZZ="bash scripts/fuzz-smoke.sh"
 
 CMD_FMT="bash scripts/verify-formatting.sh"
 CMD_LINT="bash scripts/verify-lint.sh"
-CMD_CONTRACT="bash scripts/verify-public-api-contracts.sh && bash scripts/verify-dms-first-workflow.sh && bash scripts/verify-generated-models.sh --check"
+CMD_CONTRACT="bash scripts/verify-public-api-contracts.sh && bash scripts/verify-dms-first-workflow.sh && bash scripts/verify-generated-models.sh --check && bash scripts/verify-empty-predicate-call-sites.sh"
 
 CMD_BUILDS="bash scripts/verify-typescript-deps.sh && bash scripts/verify-python-deps.sh && bash scripts/verify-builds.sh"
 CMD_TOOLCHAIN="bash scripts/verify-ci-toolchain.sh"

--- a/pkg/transaction/builder.go
+++ b/pkg/transaction/builder.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/theory-cloud/tabletheory/v3/internal/encryption"
 	"github.com/theory-cloud/tabletheory/v3/internal/expr"
+	"github.com/theory-cloud/tabletheory/v3/internal/fieldcodec"
 	"github.com/theory-cloud/tabletheory/v3/internal/reflectutil"
 	"github.com/theory-cloud/tabletheory/v3/pkg/core"
 	customerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
@@ -379,8 +380,22 @@ func (b *Builder) buildFieldUpdate(op transactOperation) (*types.Update, error) 
 			}
 			continue
 		}
-		if err := builder.AddUpdateSet(fieldMeta.DBName, fieldValue.Interface()); err != nil {
+		valueToSet := fieldValue.Interface()
+		if fieldcodec.HasJSONTag(fieldMeta.Tags) {
+			normalized, err := fieldcodec.NormalizeJSONReflectValue(fieldMeta.Type, fieldValue)
+			if err != nil {
+				return nil, fmt.Errorf("failed to normalize json field %s: %w", field, err)
+			}
+			valueToSet = normalized
+		}
+		if err := builder.AddUpdateSet(fieldMeta.DBName, valueToSet); err != nil {
 			return nil, fmt.Errorf("failed to build update for %s: %w", field, err)
+		}
+	}
+
+	if op.metadata.UpdatedAtField != nil {
+		if err := builder.AddUpdateSet(op.metadata.UpdatedAtField.DBName, time.Now()); err != nil {
+			return nil, fmt.Errorf("failed to build updated_at update: %w", err)
 		}
 	}
 

--- a/pkg/transaction/builder.go
+++ b/pkg/transaction/builder.go
@@ -370,6 +370,12 @@ func (b *Builder) buildFieldUpdate(op transactOperation) (*types.Update, error) 
 		if fieldMeta == nil {
 			return nil, fmt.Errorf("unknown field %s for update", field)
 		}
+		switch {
+		case fieldMeta.IsCreatedAt, fieldMeta.IsUpdatedAt:
+			return nil, fmt.Errorf("%w: cannot update lifecycle timestamp field %s", customerrors.ErrInvalidModel, field)
+		case fieldMeta.IsVersion:
+			return nil, fmt.Errorf("%w: do not include version in update fields: %s", customerrors.ErrInvalidModel, field)
+		}
 		fieldValue := value.Field(fieldMeta.Index)
 		if !fieldValue.IsValid() {
 			return nil, fmt.Errorf("field %s is invalid", field)

--- a/pkg/transaction/transaction_json_parity_test.go
+++ b/pkg/transaction/transaction_json_parity_test.go
@@ -1,0 +1,57 @@
+package transaction
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/v3/pkg/model"
+	"github.com/theory-cloud/tabletheory/v3/pkg/query"
+	"github.com/theory-cloud/tabletheory/v3/pkg/session"
+	pkgTypes "github.com/theory-cloud/tabletheory/v3/pkg/types"
+)
+
+type transactionalJSONRecord struct {
+	PK      string          `theorydb:"pk,attr:PK" json:"PK"`
+	Payload json.RawMessage `theorydb:"json,attr:payload" json:"payload"`
+	Legacy  json.RawMessage `theorydb:"attr:legacy" json:"legacy"`
+}
+
+func (transactionalJSONRecord) TableName() string {
+	return "transactional_json_records"
+}
+
+func TestBuilderUpdateMatchesQueryJSONNormalization(t *testing.T) {
+	record := &transactionalJSONRecord{
+		PK:      "RECORD#json",
+		Payload: json.RawMessage(`{"count":4}`),
+		Legacy:  json.RawMessage(`{"count":4}`),
+	}
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(record))
+	metadata, err := registry.GetMetadata(record)
+	require.NoError(t, err)
+
+	capture := &capturingUpdateExecutor{}
+	q := query.New(record, adaptMetadata(metadata), capture)
+	q.Where("PK", "=", record.PK)
+	require.NoError(t, q.Update("Payload", "Legacy"))
+	require.NotNil(t, capture.compiled)
+
+	builder := NewBuilder(&session.Session{}, registry, pkgTypes.NewConverter())
+	builder.Update(record, []string{"Payload", "Legacy"})
+	items, err := builder.materializeOperations()
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	update := items[0].Update
+	require.NotNil(t, update)
+
+	require.Equal(t, capture.compiled.ExpressionAttributeNames, update.ExpressionAttributeNames)
+	require.Equal(t, capture.compiled.ExpressionAttributeValues, update.ExpressionAttributeValues)
+	require.Contains(t, update.ExpressionAttributeValues, ":v1")
+	require.Contains(t, update.ExpressionAttributeValues, ":v2")
+	require.Equal(t, &types.AttributeValueMemberS{Value: `{"count":4}`}, update.ExpressionAttributeValues[":v1"])
+	require.Equal(t, &types.AttributeValueMemberB{Value: []byte(`{"count":4}`)}, update.ExpressionAttributeValues[":v2"])
+}

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -1,0 +1,48 @@
+package transaction
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/v3/pkg/model"
+	"github.com/theory-cloud/tabletheory/v3/pkg/session"
+	pkgTypes "github.com/theory-cloud/tabletheory/v3/pkg/types"
+)
+
+type transactionalLifecycleRecord struct {
+	CreatedAt time.Time `theorydb:"created_at,attr:createdAt" json:"createdAt"`
+	UpdatedAt time.Time `theorydb:"updated_at,attr:updatedAt" json:"updatedAt"`
+	PK        string    `theorydb:"pk,attr:PK" json:"PK"`
+	SK        string    `theorydb:"sk,attr:SK" json:"SK"`
+	Value     string    `theorydb:"attr:value" json:"value"`
+}
+
+func (transactionalLifecycleRecord) TableName() string {
+	return "transactional_lifecycle_records"
+}
+
+func TestBuilderUpdateRefreshesUpdatedAt(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&transactionalLifecycleRecord{}))
+
+	builder := NewBuilder(&session.Session{}, registry, pkgTypes.NewConverter())
+	builder.Update(&transactionalLifecycleRecord{
+		PK:    "USER#lifecycle",
+		SK:    "PROFILE",
+		Value: "changed",
+	}, []string{"Value"})
+
+	items, err := builder.materializeOperations()
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	update := items[0].Update
+	require.NotNil(t, update)
+	require.Contains(t, aws.ToString(update.UpdateExpression), "SET")
+	require.Contains(t, attributeNames(update.ExpressionAttributeNames), "value")
+	require.Contains(t, attributeNames(update.ExpressionAttributeNames), "updatedAt")
+	require.NotContains(t, attributeNames(update.ExpressionAttributeNames), "createdAt")
+	require.Len(t, update.ExpressionAttributeValues, 2)
+}

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/require"
 
+	customerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"github.com/theory-cloud/tabletheory/v3/pkg/model"
 	"github.com/theory-cloud/tabletheory/v3/pkg/session"
 	pkgTypes "github.com/theory-cloud/tabletheory/v3/pkg/types"
@@ -18,6 +19,39 @@ type transactionalLifecycleRecord struct {
 	PK        string    `theorydb:"pk,attr:PK" json:"PK"`
 	SK        string    `theorydb:"sk,attr:SK" json:"SK"`
 	Value     string    `theorydb:"attr:value" json:"value"`
+	Version   int       `theorydb:"version,attr:version" json:"version"`
+}
+
+func TestBuilderUpdateRejectsLifecycleOwnedFields(t *testing.T) {
+	tests := []struct {
+		field       string
+		messagePart string
+	}{
+		{field: "CreatedAt", messagePart: "cannot update lifecycle timestamp field CreatedAt"},
+		{field: "UpdatedAt", messagePart: "cannot update lifecycle timestamp field UpdatedAt"},
+		{field: "Version", messagePart: "do not include version in update fields: Version"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.field, func(t *testing.T) {
+			registry := model.NewRegistry()
+			require.NoError(t, registry.Register(&transactionalLifecycleRecord{}))
+
+			builder := NewBuilder(&session.Session{}, registry, pkgTypes.NewConverter())
+			builder.Update(&transactionalLifecycleRecord{
+				PK:        "USER#lifecycle",
+				SK:        "PROFILE",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+				Version:   7,
+			}, []string{test.field})
+
+			items, err := builder.materializeOperations()
+			require.ErrorIs(t, err, customerrors.ErrInvalidModel)
+			require.ErrorContains(t, err, test.messagePart)
+			require.Nil(t, items, "invalid lifecycle selection must not produce a DynamoDB write")
+		})
+	}
 }
 
 func (transactionalLifecycleRecord) TableName() string {

--- a/py/src/tabletheory_py/table.py
+++ b/py/src/tabletheory_py/table.py
@@ -869,6 +869,7 @@ class Table[T]:
                             expression_attribute_names=action.expression_attribute_names,
                             expression_attribute_values=action.expression_attribute_values,
                             protected_attributes=action.protected_attributes,
+                            reject_version_field=True,
                         )
                     }
                 )
@@ -1033,6 +1034,7 @@ class Table[T]:
         expression_attribute_values: Mapping[str, Any] | None = None,
         protected_attributes: Sequence[str] = (),
         expected_version: int | None = None,
+        reject_version_field: bool = False,
         return_values: str | None = None,
     ) -> dict[str, Any]:
         key = self._to_key(pk, sk)
@@ -1070,9 +1072,9 @@ class Table[T]:
             ):
                 raise ValidationError(f"cannot update key field: {field_name}")
             if (
-                expected_version is not None
-                and version_attr is not None
+                version_attr is not None
                 and field_name == version_attr.python_name
+                and (expected_version is not None or reject_version_field)
             ):
                 raise ValidationError(f"do not include version in update fields: {field_name}")
 

--- a/py/tests/unit/test_table_additional_coverage.py
+++ b/py/tests/unit/test_table_additional_coverage.py
@@ -45,6 +45,7 @@ class LifecycleItem:
     value: int = theorydb_field(name="value")
     created_at: str = theorydb_field(name="createdAt", roles=["created_at"], default="")
     updated_at: str = theorydb_field(name="updatedAt", roles=["updated_at"], default="")
+    version: int = theorydb_field(name="version", roles=["version"], default=0)
 
 
 class _StubClient:
@@ -380,6 +381,38 @@ def test_transact_update_refreshes_updated_at_without_accepting_lifecycle_input(
     assert update["UpdateExpression"] == ("SET #d_updated_at = :d_updated_at, #d_value = :d_value")
     assert update["ExpressionAttributeNames"]["#d_updated_at"] == "updatedAt"
     assert update["ExpressionAttributeValues"][":d_updated_at"] == {"S": now}
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "message"),
+    [
+        ("created_at", "caller-created", "cannot update lifecycle timestamp field: created_at"),
+        ("updated_at", "caller-updated", "cannot update lifecycle timestamp field: updated_at"),
+        ("version", 99, "do not include version in update fields: version"),
+    ],
+)
+def test_transact_update_rejects_lifecycle_owned_fields_without_send(
+    field_name: str,
+    value: Any,
+    message: str,
+) -> None:
+    model = ModelDefinition.from_dataclass(LifecycleItem, table_name="tbl")
+    stub = _StubClient()
+    table: Table[LifecycleItem] = Table(model, client=stub)
+
+    with pytest.raises(ValidationError) as exc_info:
+        table.transact_write(
+            [
+                TransactUpdate(
+                    pk="A",
+                    sk="1",
+                    updates={field_name: value},
+                )
+            ]
+        )
+
+    assert str(exc_info.value) == message
+    assert stub.transact_write_reqs == []
 
 
 def test_put_delete_update_expression_attribute_maps_and_build_request_merges() -> None:

--- a/py/tests/unit/test_table_additional_coverage.py
+++ b/py/tests/unit/test_table_additional_coverage.py
@@ -38,6 +38,15 @@ class Item:
     note: str = theorydb_field(name="note", default="")
 
 
+@dataclass(frozen=True)
+class LifecycleItem:
+    pk: str = theorydb_field(name="PK", roles=["pk"])
+    sk: str = theorydb_field(name="SK", roles=["sk"])
+    value: int = theorydb_field(name="value")
+    created_at: str = theorydb_field(name="createdAt", roles=["created_at"], default="")
+    updated_at: str = theorydb_field(name="updatedAt", roles=["updated_at"], default="")
+
+
 class _StubClient:
     def __init__(self) -> None:
         self.query_reqs: list[dict[str, Any]] = []
@@ -349,6 +358,28 @@ def test_transact_update_supports_add_and_if_not_exists() -> None:
     assert "ADD" in update["UpdateExpression"]
     assert "if_not_exists" in update["UpdateExpression"]
     assert update["ExpressionAttributeValues"][":d_value"]["N"] == "1"
+
+
+def test_transact_update_refreshes_updated_at_without_accepting_lifecycle_input() -> None:
+    model = ModelDefinition.from_dataclass(LifecycleItem, table_name="tbl")
+    stub = _StubClient()
+    now = "2026-07-31T12:34:56.123456789Z"
+    table: Table[LifecycleItem] = Table(model, client=stub, now=lambda: now)
+
+    table.transact_write(
+        [
+            TransactUpdate(
+                pk="A",
+                sk="1",
+                updates={"value": 2},
+            )
+        ]
+    )
+
+    update = stub.transact_write_reqs[0]["TransactItems"][0]["Update"]
+    assert update["UpdateExpression"] == ("SET #d_updated_at = :d_updated_at, #d_value = :d_value")
+    assert update["ExpressionAttributeNames"]["#d_updated_at"] == "updatedAt"
+    assert update["ExpressionAttributeValues"][":d_updated_at"] == {"S": now}
 
 
 def test_put_delete_update_expression_attribute_maps_and_build_request_merges() -> None:

--- a/scripts/verify-empty-predicate-call-sites.sh
+++ b/scripts/verify-empty-predicate-call-sites.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+tmp="$(mktemp -d)"
+cleanup() { rm -rf "${tmp}"; }
+trap cleanup EXIT
+
+# Explicit selection and marshaling use DMS IsEmpty. Duplicate entries are
+# distinct known call sites with identical source text.
+cat >"${tmp}/expected" <<'EOF'
+internal/expr/converter.go|IsEmpty|return reflectutil.IsEmpty(v)
+pkg/marshal/marshaler.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty(v) {
+pkg/marshal/marshaler.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty(v) {
+pkg/marshal/marshaler.go|IsEmpty|if hasOmitEmpty && reflectutil.IsEmpty(fieldValue) {
+pkg/marshal/safe_marshaler.go|IsEmpty|if fieldMeta != nil && fieldMeta.omitEmpty && reflectutil.IsEmpty(v) {
+pkg/marshal/safe_marshaler.go|IsEmpty|if hasOmitEmpty && reflectutil.IsEmpty(fieldValue) {
+pkg/query/query_execution.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty(fieldValue) {
+pkg/query/query_execution.go|IsEmpty|if fieldcodec.HasModifier(tag, "omitempty") && reflectutil.IsEmpty(fieldValue) {
+pkg/query/query_marshal.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty(fieldValue) {
+pkg/query/query_marshal.go|IsEmpty|if fieldcodec.HasModifier(tag, "omitempty") && reflectutil.IsEmpty(fieldValue) {
+pkg/query/tagged_encode_helpers.go|IsEmpty|if fieldcodec.HasModifier(tag, "omitempty") && reflectutil.IsEmpty(fieldValue) {
+pkg/transaction/builder.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty(fieldValue) {
+pkg/transaction/transaction.go|IsEmpty|if fieldValue.IsValid() && !reflectutil.IsEmpty(fieldValue) {
+pkg/transaction/transaction.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty(fieldValue) {
+EOF
+
+# Only implicit whole-model sparse selection uses the compatibility predicate.
+cat >>"${tmp}/expected" <<'EOF'
+pkg/query/query_execution.go|IsSparseUpdateEmpty|if fieldMeta.OmitEmpty && reflectutil.IsSparseUpdateEmpty(fieldValue) {
+pkg/query/query_execution.go|IsSparseUpdateEmpty|if fieldcodec.HasModifier(tag, "omitempty") && reflectutil.IsSparseUpdateEmpty(fieldValue) {
+pkg/query/tagged_encode_helpers.go|IsSparseUpdateEmpty|if fieldcodec.HasModifier(tag, "omitempty") && reflectutil.IsSparseUpdateEmpty(fieldValue) {
+pkg/transaction/transaction.go|IsSparseUpdateEmpty|if !fieldValue.IsValid() || (fieldMeta.OmitEmpty && reflectutil.IsSparseUpdateEmpty(fieldValue)) {
+pkg/transaction/write_policy.go|IsSparseUpdateEmpty|if !fieldValue.IsValid() || (fieldMeta.OmitEmpty && reflectutil.IsSparseUpdateEmpty(fieldValue)) {
+EOF
+
+rg --no-heading --line-number \
+  --glob '*.go' \
+  --glob '!*_test.go' \
+  --glob '!internal/reflectutil/empty.go' \
+  'reflectutil\.Is(SparseUpdate)?Empty\(' internal pkg |
+  while IFS=: read -r file _ source; do
+    predicate="$(grep -oE 'Is(SparseUpdate)?Empty' <<<"${source}" | head -n 1)"
+    normalized="$(sed -E 's/^[[:space:]]+//; s/[[:space:]]+/ /g; s/[[:space:]]+$//' <<<"${source}")"
+    printf '%s|%s|%s\n' "${file}" "${predicate}" "${normalized}"
+  done >"${tmp}/actual"
+
+sort "${tmp}/expected" -o "${tmp}/expected"
+sort "${tmp}/actual" -o "${tmp}/actual"
+
+if ! diff -u "${tmp}/expected" "${tmp}/actual"; then
+  echo "empty-predicate-call-sites: FAIL update the classified allowlist only after reviewing the call-site semantics" >&2
+  exit 1
+fi
+
+echo "empty-predicate-call-sites: PASS"

--- a/scripts/verify-empty-predicate-call-sites.sh
+++ b/scripts/verify-empty-predicate-call-sites.sh
@@ -8,8 +8,14 @@ tmp="$(mktemp -d)"
 cleanup() { rm -rf "${tmp}"; }
 trap cleanup EXIT
 
-# Explicit selection and marshaling use DMS IsEmpty. Duplicate entries are
-# distinct known call sites with identical source text.
+# Explicit selection, marshaling, and the legacy updated_at caller-value guard
+# use DMS IsEmpty. Duplicate entries are distinct known call sites with
+# identical source text.
+#
+# Coverage is Go-only and limited to internal/ and pkg/; TypeScript's
+# isEmptyAttribute and Python's _is_empty have no equivalent gate yet. The
+# allowlist is a per-file multiset: it verifies which source lines exist, not
+# which function contains each line.
 cat >"${tmp}/expected" <<'EOF'
 internal/expr/converter.go|IsEmpty|return reflectutil.IsEmpty(v)
 pkg/marshal/marshaler.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty(v) {

--- a/ts/docs/api-reference.md
+++ b/ts/docs/api-reference.md
@@ -479,7 +479,9 @@ type TransactUpdateWithBuilder = {
  *
  * Selected empty `omit_empty` attributes are removed according to DMS v0.2;
  * every other selected attribute is set from `item`. Fields not listed in
- * `fields` are not mutated.
+ * `fields` are not mutated, except that the runtime advances `updatedAt` when
+ * the model declares that lifecycle role. `createdAt` and version cannot be
+ * selected because those attributes are library-owned.
  */
 export type TransactModelUpdate = {
     kind: 'update';

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -733,8 +733,10 @@ export class TheorydbClient {
               a,
               provider,
               this.sendOptions,
+              this.now(),
             );
           } else if (typeof a.updateFn === 'function') {
+            const key = marshalKey(model, a.key);
             const builder = new UpdateBuilder(
               this.ddb,
               model,
@@ -746,7 +748,7 @@ export class TheorydbClient {
             const built = await builder.build();
             update = {
               TableName: model.tableName,
-              Key: marshalKey(model, a.key),
+              Key: key,
               UpdateExpression: built.updateExpression,
               ConditionExpression: built.conditionExpression,
               ExpressionAttributeNames: built.expressionAttributeNames,
@@ -768,7 +770,7 @@ export class TheorydbClient {
             if (provider) {
               throw new TheorydbError(
                 'ErrInvalidModel',
-                `Encrypted transaction updates for model ${model.name} must use updateFn`,
+                `Encrypted transaction updates for model ${model.name} must use updateFn or the model-based item + fields action`,
               );
             }
             update = {
@@ -869,6 +871,7 @@ async function buildTransactModelUpdate(
   action: TransactModelUpdate,
   provider: EncryptionProvider | undefined,
   sendOptions: SendOptions | undefined,
+  now: string,
 ): Promise<Update> {
   const builder = new UpdateBuilder(
     ddb,
@@ -878,7 +881,23 @@ async function buildTransactModelUpdate(
     sendOptions,
   );
 
+  if (model.roles.updatedAt) {
+    builder.set(model.roles.updatedAt, now);
+  }
+
   for (const field of action.fields) {
+    if (field === model.roles.createdAt) {
+      throw new TheorydbError(
+        'ErrInvalidModel',
+        `Cannot update createdAt field: ${field}`,
+      );
+    }
+    if (field === model.roles.version) {
+      throw new TheorydbError(
+        'ErrInvalidModel',
+        `Do not include version in update fields: ${field}`,
+      );
+    }
     const schema = model.attributes.get(field);
     if (!schema) {
       throw new TheorydbError(

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -886,10 +886,10 @@ async function buildTransactModelUpdate(
   }
 
   for (const field of action.fields) {
-    if (field === model.roles.createdAt) {
+    if (field === model.roles.createdAt || field === model.roles.updatedAt) {
       throw new TheorydbError(
         'ErrInvalidModel',
-        `Cannot update createdAt field: ${field}`,
+        `Cannot update lifecycle timestamp field: ${field}`,
       );
     }
     if (field === model.roles.version) {

--- a/ts/src/transaction.ts
+++ b/ts/src/transaction.ts
@@ -38,7 +38,9 @@ type TransactUpdateWithBuilder = {
  *
  * Selected empty `omit_empty` attributes are removed according to DMS v0.2;
  * every other selected attribute is set from `item`. Fields not listed in
- * `fields` are not mutated.
+ * `fields` are not mutated, except that the runtime advances `updatedAt` when
+ * the model declares that lifecycle role. `createdAt` and version cannot be
+ * selected because those attributes are library-owned.
  */
 export type TransactModelUpdate = {
   kind: 'update';

--- a/ts/test/unit/client.test.ts
+++ b/ts/test/unit/client.test.ts
@@ -704,7 +704,12 @@ void test('TransactModelUpdate rejects lifecycle-owned fields', async (t) => {
     {
       field: 'createdAt',
       value: 'caller-value',
-      message: 'Cannot update createdAt field: createdAt',
+      message: 'Cannot update lifecycle timestamp field: createdAt',
+    },
+    {
+      field: 'updatedAt',
+      value: 'caller-value',
+      message: 'Cannot update lifecycle timestamp field: updatedAt',
     },
     {
       field: 'version',

--- a/ts/test/unit/client.test.ts
+++ b/ts/test/unit/client.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import test from 'node:test';
 
 import {
   BatchGetItemCommand,
@@ -610,31 +611,40 @@ class StubDdb {
   assert.ok(update?.ConditionExpression?.includes('<'));
 }
 
-{
+void test('TransactModelUpdate selects only explicit fields', async (t) => {
+  const now = '2026-07-31T12:34:56.123456789Z';
   const cases = [
     {
       name: 'selected empty omit_empty field is removed',
       item: { PK: 'A', SK: '1', nickname: '' },
       fields: ['nickname'],
-      expectedExpression: 'REMOVE #u1',
-      expectedNames: { '#u1': 'nickname' },
-      expectedValues: undefined,
+      expectedExpression: 'SET #u1 = :u1 REMOVE #u2',
+      expectedNames: { '#u1': 'updatedAt', '#u2': 'nickname' },
+      expectedValues: { ':u1': { S: now } },
     },
     {
       name: 'selected non-empty field is set',
       item: { PK: 'A', SK: '1', nickname: 'present', alias: '' },
       fields: ['nickname', 'alias'],
-      expectedExpression: 'SET #u1 = :u1 REMOVE #u2',
-      expectedNames: { '#u1': 'nickname', '#u2': 'alias' },
-      expectedValues: { ':u1': { S: 'present' } },
+      expectedExpression: 'SET #u1 = :u1, #u2 = :u2 REMOVE #u3',
+      expectedNames: {
+        '#u1': 'updatedAt',
+        '#u2': 'nickname',
+        '#u3': 'alias',
+      },
+      expectedValues: { ':u1': { S: now }, ':u2': { S: 'present' } },
     },
     {
       name: 'selected empty non-omit_empty field is set',
       item: { PK: 'A', SK: '1', nickname: '', displayName: '' },
       fields: ['nickname', 'displayName'],
-      expectedExpression: 'SET #u2 = :u1 REMOVE #u1',
-      expectedNames: { '#u1': 'nickname', '#u2': 'displayName' },
-      expectedValues: { ':u1': { S: '' } },
+      expectedExpression: 'SET #u1 = :u1, #u3 = :u2 REMOVE #u2',
+      expectedNames: {
+        '#u1': 'updatedAt',
+        '#u2': 'nickname',
+        '#u3': 'displayName',
+      },
+      expectedValues: { ':u1': { S: now }, ':u2': { S: '' } },
     },
     {
       name: 'unselected fields are untouched',
@@ -646,22 +656,21 @@ class StubDdb {
         displayName: 'not-selected',
       },
       fields: ['nickname'],
-      expectedExpression: 'REMOVE #u1',
-      expectedNames: { '#u1': 'nickname' },
-      expectedValues: undefined,
+      expectedExpression: 'SET #u1 = :u1 REMOVE #u2',
+      expectedNames: { '#u1': 'updatedAt', '#u2': 'nickname' },
+      expectedValues: { ':u1': { S: now } },
     },
   ] as const;
 
-  const failures: string[] = [];
   for (const tc of cases) {
-    try {
+    await t.test(tc.name, async () => {
       const ddb = new StubDdb((cmd) => {
         if (cmd instanceof TransactWriteItemsCommand) return {};
         throw new Error('unexpected');
       });
-      const client = new TheorydbClient(
-        ddb as unknown as DynamoDBClient,
-      ).register(User);
+      const client = new TheorydbClient(ddb as unknown as DynamoDBClient, {
+        now: () => now,
+      }).register(User);
 
       await client.transactWrite([
         {
@@ -686,12 +695,112 @@ class StubDdb {
         tc.expectedValues,
         tc.name,
       );
-    } catch (error) {
-      failures.push(`${tc.name}: ${String(error)}`);
-    }
+    });
   }
-  assert.deepEqual(failures, []);
-}
+});
+
+void test('TransactModelUpdate rejects lifecycle-owned fields', async (t) => {
+  const cases = [
+    {
+      field: 'createdAt',
+      value: 'caller-value',
+      message: 'Cannot update createdAt field: createdAt',
+    },
+    {
+      field: 'version',
+      value: 7,
+      message: 'Do not include version in update fields: version',
+    },
+  ] as const;
+
+  for (const tc of cases) {
+    await t.test(tc.field, async () => {
+      const ddb = new StubDdb(() => {
+        throw new Error('lifecycle field update should not send');
+      });
+      const client = new TheorydbClient(
+        ddb as unknown as DynamoDBClient,
+      ).register(User);
+
+      await assert.rejects(
+        () =>
+          client.transactWrite([
+            {
+              kind: 'update',
+              model: 'User',
+              item: { PK: 'A', SK: '1', [tc.field]: tc.value },
+              fields: [tc.field],
+            },
+          ]),
+        (error) =>
+          error instanceof TheorydbError &&
+          error.code === 'ErrInvalidModel' &&
+          error.message === tc.message,
+      );
+      assert.equal(ddb.sent.length, 0);
+    });
+  }
+});
+
+void test('transaction updateFn marshals the key before callback', async () => {
+  const ddb = new StubDdb(() => {
+    throw new Error('malformed-key transaction should not send');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient).register(
+    User,
+  );
+  let callbackRan = false;
+
+  await assert.rejects(
+    () =>
+      client.transactWrite([
+        {
+          kind: 'update',
+          model: 'User',
+          key: { PK: 'A' },
+          updateFn: (builder) => {
+            callbackRan = true;
+            builder.set('nickname', 'should-not-run');
+          },
+        },
+      ]),
+    (error) =>
+      error instanceof TheorydbError &&
+      error.code === 'ErrMissingPrimaryKey' &&
+      error.message === 'Missing sort key: SK',
+  );
+  assert.equal(callbackRan, false);
+  assert.equal(ddb.sent.length, 0);
+});
+
+void test('encrypted raw transaction error names both safe alternatives', async () => {
+  const ddb = new StubDdb(() => {
+    throw new Error('encrypted raw transaction should not send');
+  });
+  const client = new TheorydbClient(ddb as unknown as DynamoDBClient, {
+    encryption: createDeterministicEncryptionProvider('seed'),
+  }).register(EncryptedUser);
+
+  await assert.rejects(
+    () =>
+      client.transactWrite([
+        {
+          kind: 'update',
+          model: 'EncryptedUser',
+          key: { PK: 'A', SK: '1' },
+          updateExpression: 'SET #s = :s',
+          expressionAttributeNames: { '#s': 'secret' },
+          expressionAttributeValues: { ':s': { S: 'plaintext' } },
+        },
+      ]),
+    (error) =>
+      error instanceof TheorydbError &&
+      error.code === 'ErrInvalidModel' &&
+      error.message ===
+        'Encrypted transaction updates for model EncryptedUser must use updateFn or the model-based item + fields action',
+  );
+  assert.equal(ddb.sent.length, 0);
+});
 
 {
   const ddb = new StubDdb((cmd) => {


### PR DESCRIPTION
## Summary

- align model-shaped transactional updates across Go, TypeScript, and Python so successful explicit-field updates preserve 'createdAt' and refresh library-owned 'updatedAt'
- add P1 scenario 61 plus per-runtime unit coverage for transactional lifecycle behavior
- harden TypeScript model updates, callback ordering, encrypted-update guidance, and node:test accounting
- normalize Go transactional 'theorydb:"json"' fields like query updates
- add a rubric-wired allowlist verifier for 'IsEmpty' versus 'IsSparseUpdateEmpty' call sites

## Normative lifecycle decision

DMS v0.2 says 'updated_at' is set on update and lifecycle fields are library-owned. The lifecycle guide and all three non-transactional update paths agree. Python's behavior was originally added while executing the shared lifecycle contract. Therefore model-shaped transactional explicit-field updates refresh 'updatedAt'; low-level raw/update-builder escape hatches remain caller-controlled.

## Findings addressed

- **F1:** Go and TypeScript transactional model updates now refresh 'updatedAt'; Python is pinned; P1 scenario 61 asserts changed 'updatedAt' and unchanged 'createdAt'.
- **F2:** TypeScript rejects 'createdAt' and version in 'TransactModelUpdate.fields' with existing 'ErrInvalidModel' messages.
- **F3:** TypeScript marshals an 'updateFn' key before invoking the callback.
- **F4:** encrypted raw transaction errors name 'updateFn' and the model-based 'item' + 'fields' action.
- **F5:** the PR #452 test block now runs assertions inside 'node:test' subtests; the REMOVE mutant reports real failure counts.
- **F6:** Go explicit transaction updates apply the query path's JSON-tag normalization guard.
- **F7:** a small classified call-site verifier fails on new or swapped empty predicates and runs under CON-3.

## Validation

- 'make fmt'
- 'go test ./...'
- 'npm --prefix ts run check'
- 'npm --prefix ts test'
- 'bash scripts/verify-contract-tests.sh'
- 'python3 scripts/sync-runtime-docs-site.py --check'
- 'NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS=true bash gov-infra/verifiers/gov-verify-rubric.sh' — 'Status: PASS (pass=36 fail=0 blocked=0)'
- targeted pre-fix mutants for F1-F7 all exited 1; fixed tests and verifier pass
