### PR TITLE
fix(ci): detect pending major transition verifier support

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -179,6 +179,8 @@ jobs:
               "py/src/tabletheory_py/version.json" "canonical Python version marker" "${reasons_name}"
             add_v2_marker_reason "${root}" "scripts/verify-release-cycle-state.sh" \
               "scripts/verify-go-semantic-import-version.sh" "Go semantic import verifier marker" "${reasons_name}"
+            add_v2_marker_reason "${root}" "scripts/verify-go-semantic-import-version.sh" \
+              "pending-major-transition" "pending-major-transition support marker" "${reasons_name}"
             add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \
               "scripts/prepare-release-package-versions.py" "package-version stamping marker" "${reasons_name}"
             add_v2_marker_reason "${root}" "scripts/verify-branch-release-supply-chain.sh" \

--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -328,6 +328,20 @@ SH
 #!/usr/bin/env bash
 echo "manifest-derived stable Release-As"
 SH
+  cat >"${root}/scripts/verify-go-semantic-import-version.sh" <<'SH'
+#!/usr/bin/env bash
+echo "go-semantic-import: PASS (pending-major-transition=2->3)"
+SH
+}
+
+write_v2_pre_pending_major_transition_verifier_fixture() {
+  local root="$1"
+
+  write_v2_verifier_fixture "${root}"
+  cat >"${root}/scripts/verify-go-semantic-import-version.sh" <<'SH'
+#!/usr/bin/env bash
+echo "go-semantic-import: PASS"
+SH
 }
 
 write_v2_merge_queue_verifier_fixture() {
@@ -434,6 +448,7 @@ run_verifier_source_selector_fixture() {
     v2-numbered-rc) write_v2_numbered_rc_verifier_fixture "${fixture}/trusted-release" ;;
     v2-legacy-promotion-source) write_v2_legacy_promotion_source_verifier_fixture "${fixture}/trusted-release" ;;
     v2-merge-queue) write_v2_merge_queue_verifier_fixture "${fixture}/trusted-release" ;;
+    v2-pre-pending-major-transition) write_v2_pre_pending_major_transition_verifier_fixture "${fixture}/trusted-release" ;;
     v2) write_v2_verifier_fixture "${fixture}/trusted-release" ;;
     *) echo "release-hygiene-policy-test: unknown trusted fixture ${trusted_shape}" >&2; exit 1 ;;
   esac
@@ -443,6 +458,7 @@ run_verifier_source_selector_fixture() {
     v2-numbered-rc) write_v2_numbered_rc_verifier_fixture "${fixture}/pr" ;;
     v2-legacy-promotion-source) write_v2_legacy_promotion_source_verifier_fixture "${fixture}/pr" ;;
     v2-merge-queue) write_v2_merge_queue_verifier_fixture "${fixture}/pr" ;;
+    v2-pre-pending-major-transition) write_v2_pre_pending_major_transition_verifier_fixture "${fixture}/pr" ;;
     v2) write_v2_verifier_fixture "${fixture}/pr" ;;
     *) echo "release-hygiene-policy-test: unknown head fixture ${head_shape}" >&2; exit 1 ;;
   esac
@@ -1338,6 +1354,11 @@ grep -Fq "direct protected-PR verifier marker" "${repo_root}/.github/workflows/r
   exit 1
 }
 
+grep -Fq "pending-major-transition" "${repo_root}/.github/workflows/release-hygiene.yml" || {
+  echo "release-hygiene-policy-test: verifier selector must feature-detect pending major transition support"
+  exit 1
+}
+
 selector_result="$(
   run_verifier_source_selector_fixture \
     v1 v2 \
@@ -1361,6 +1382,18 @@ assert_selector_result \
   "." \
   "protected-pr-head-v2" \
   "scripts/verify-branch-release-supply-chain.sh lacks direct protected-PR verifier marker"
+
+selector_result="$(
+  run_verifier_source_selector_fixture \
+    v2-pre-pending-major-transition v2 \
+    premain staging \
+    "${repo}" "${repo}"
+)"
+assert_selector_result \
+  "${selector_result}" \
+  "." \
+  "protected-pr-head-v2" \
+  "scripts/verify-go-semantic-import-version.sh lacks pending-major-transition support marker"
 
 selector_result="$(
   run_verifier_source_selector_fixture \

--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -236,6 +236,8 @@ if [[ -f ".github/workflows/release-hygiene.yml" ]]; then
     "release-hygiene verifier selector must detect Go semantic import verifier support"
   require_fixed "Go semantic import supply-chain marker" "${h}" \
     "release-hygiene verifier selector must detect Go semantic import supply-chain support"
+  require_fixed "pending-major-transition support marker" "${h}" \
+    "release-hygiene verifier selector must detect pending major transition support"
   require_fixed "github.base_ref == 'premain' && github.head_ref == 'staging'" "${h}" \
     "release-hygiene must run the release driver guard on staging -> premain PRs"
   require_fixed "github.base_ref == 'main' && github.head_ref == 'premain'" "${h}" \


### PR DESCRIPTION
## Summary

- feature-detect `pending-major-transition` support in the release-hygiene verifier selector
- model premain's current verifier generation and prove the protected `premain:staging` fallback selects `protected-pr-head-v2`
- pin the marker in release-hygiene and release supply-chain policy checks

## Release-lane safety

The trusted base remains the default verifier source. PR-head fallback remains restricted to same-repository protected promotions after provenance. This changes no workflow permissions, secrets, publishing behavior, versions, manifests, or release artifacts.

## Validation

- `bash scripts/test-release-hygiene-policy.sh`
- `bash scripts/verify-branch-release-supply-chain.sh`
- `GITHUB_BASE_REF=premain RELEASE_CYCLE_ALLOW_PENDING_STABLE_PROMOTION=false bash scripts/verify-release-cycle-state.sh`
- `go test ./...`
- `NPM_AUDIT_ACCEPT_VISIBLE_FINDINGS=true bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS, 36/36; Go 90.2%, TypeScript 90.74%, Python 90.62%

Refs THE-2771
