### PR TITLE
fix(deps): bump aws-cdk-lib to 2.263.0 and retire bundled exception

### DIFF
--- a/examples/cdk-multilang/package-lock.json
+++ b/examples/cdk-multilang/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-dynamodb": "3.1098.0",
         "@aws-sdk/client-kms": "3.1098.0",
         "@aws-sdk/client-s3": "3.1098.0",
-        "aws-cdk-lib": "2.262.2",
+        "aws-cdk-lib": "2.263.0",
         "constructs": "10.8.0"
       },
       "devDependencies": {
@@ -1328,9 +1328,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.262.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.2.tgz",
-      "integrity": "sha512-lWQRW/AHxB4gMgkRmfYQIKWqiJLD4whkl7sQF3c26eK1DVt1Jw9rNBSFvVQ+DZddxxnifNGan/i97YgsNpgOeQ==",
+      "version": "2.263.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
+      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -1351,7 +1351,7 @@
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.5.1-beta",
+        "@aws/cloudformation-validate": "1.6.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -1386,7 +1386,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.5.1-beta",
+      "version": "1.6.0-beta",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1407,14 +1407,14 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.7",
+      "version": "5.0.8",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {

--- a/examples/cdk-multilang/package.json
+++ b/examples/cdk-multilang/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-dynamodb": "3.1098.0",
     "@aws-sdk/client-kms": "3.1098.0",
     "@aws-sdk/client-s3": "3.1098.0",
-    "aws-cdk-lib": "2.262.2",
+    "aws-cdk-lib": "2.263.0",
     "constructs": "10.8.0"
   },
   "devDependencies": {

--- a/gov-infra/planning/theorydb-visible-npm-audit-findings.json
+++ b/gov-infra/planning/theorydb-visible-npm-audit-findings.json
@@ -1,18 +1,5 @@
 {
   "$schema": "https://theory.cloud/tabletheory/schemas/visible-npm-audit-findings.schema.json",
   "purpose": "Findings listed here are intentionally visible in SEC-2 evidence and are not supply-chain allowlist suppressions.",
-  "findings": [
-    {
-      "project": "examples/cdk-multilang",
-      "package": "brace-expansion",
-      "advisory": "GHSA-mh99-v99m-4gvg",
-      "node": "node_modules/aws-cdk-lib/node_modules/brace-expansion",
-      "visibility": "visible",
-      "status": "upstream-bundled-pending-fix",
-      "reviewed_on": "2026-07-30",
-      "expires_on": "2026-08-13",
-      "remove_when": "Remove this entry as soon as aws-cdk-lib bundles brace-expansion 5.0.8 or newer; the npm-audit policy test intentionally fails if the lockfile is fixed while this entry remains.",
-      "justification": "aws-cdk-lib 2.262.2 is the latest AWS CDK release and bundles brace-expansion 5.0.7, which remains affected by GHSA-mh99-v99m-4gvg. npm cannot replace this bundled dependency. The affected minimatch path is used only while synthesizing this fixed-input infrastructure example and is not shipped in its Lambda assets. Keep the advisory visible in SEC-2 evidence and re-review or remove this exception by the expiry date."
-    }
-  ]
+  "findings": []
 }

--- a/scripts/test-npm-audit-policy.sh
+++ b/scripts/test-npm-audit-policy.sh
@@ -169,14 +169,17 @@ const visibleBracePolicy = policy.findings?.find(
     finding.advisory === 'GHSA-mh99-v99m-4gvg' &&
     finding.node === 'node_modules/aws-cdk-lib/node_modules/brace-expansion'
 );
-if (!versionAtLeast(bundledBrace?.version, '5.0.7')) {
-  throw new Error(`expected aws-cdk-lib to bundle brace-expansion 5.0.7 or newer, got ${bundledBrace?.version ?? 'missing'}`);
-}
-if (!visibleBracePolicy) {
-  throw new Error('expected the current aws-cdk-lib bundled brace-expansion advisory to remain visibly documented');
-}
 if (versionAtLeast(bundledBrace?.version, '5.0.8')) {
-  throw new Error('aws-cdk-lib now bundles fixed brace-expansion; remove the visible exception before merging');
+  if (visibleBracePolicy) {
+    throw new Error('aws-cdk-lib now bundles fixed brace-expansion; remove the visible exception before merging');
+  }
+} else {
+  if (!versionAtLeast(bundledBrace?.version, '5.0.7')) {
+    throw new Error(`expected aws-cdk-lib to bundle brace-expansion 5.0.7 or newer, got ${bundledBrace?.version ?? 'missing'}`);
+  }
+  if (!visibleBracePolicy) {
+    throw new Error('expected the current aws-cdk-lib bundled brace-expansion advisory to remain visibly documented');
+  }
 }
 NODE
 


### PR DESCRIPTION
## Summary
- bump the CDK multilang example from `aws-cdk-lib` 2.262.2 to 2.263.0
- regenerate only the affected lock entries, including bundled `brace-expansion` 5.0.8
- remove the now-obsolete visible GHSA-mh99-v99m-4gvg finding
- correct the policy test's fixed-version branch so 5.0.8+ requires the exception to be absent

The policy-test correction is necessary because staging's unconditional missing-policy assertion still required the visible finding after the bundled dependency became fixed; the requested bump plus exception removal otherwise failed `scripts/test-npm-audit-policy.sh`.

Refs THE-2778

## Validation
- `bash scripts/test-npm-audit-policy.sh`
  - `npm-audit-policy-test: PASS`
- `bash scripts/sec-npm-audit.sh`
  - `npm-audit: PASS (ts)`
  - `npm-audit: PASS (contract-tests/runners/ts)`
  - `npm-audit: PASS (examples/cdk-multilang)`
  - `npm-audit: PASS`
- `npm_config_allow_remote=all npm run synth` in `examples/cdk-multilang`
  - exit 0; synthesized `TheorydbMultilangDemoStack`
- `./scripts/verify-rubric.sh`
  - `Status: PASS (pass=36 fail=0 blocked=0)`
  - `verify-theorycloud-tabletheory-subtree: PASS`
  - `rubric: PASS`
- installed artifact proof
  - `aws-cdk-lib=2.263.0`
  - `bundled brace-expansion=5.0.8`

The OSV/npm advisory response did not flip during validation; the audit gate passed on its first run.
