### PR TITLE
fix(go): align legacy transaction update lifecycle semantics

### DIFF
--- a/pkg/transaction/cov6_transaction_additional_test.go
+++ b/pkg/transaction/cov6_transaction_additional_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	customerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"github.com/theory-cloud/tabletheory/v3/pkg/model"
 	"github.com/theory-cloud/tabletheory/v3/pkg/session"
 	pkgTypes "github.com/theory-cloud/tabletheory/v3/pkg/types"
@@ -51,7 +50,7 @@ func TestTransaction_Commit_FailsWhenClientMissing_COV6(t *testing.T) {
 	require.Error(t, tx.Commit())
 }
 
-func TestTransaction_Update_RejectsUpdatedAtWhenAlreadySet_COV6(t *testing.T) {
+func TestTransaction_Update_OverridesUpdatedAtWhenAlreadySet_COV6(t *testing.T) {
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&unitUser{}))
 
@@ -63,8 +62,14 @@ func TestTransaction_Update_RejectsUpdatedAtWhenAlreadySet_COV6(t *testing.T) {
 		UpdatedAt: time.Now(),
 	}
 
-	err := tx.Update(user)
-	require.ErrorIs(t, err, customerrors.ErrInvalidModel)
-	require.ErrorContains(t, err, "cannot update lifecycle timestamp field UpdatedAt")
-	require.Empty(t, tx.writes)
+	// Legacy whole-model updates are an implicit RMW surface: loaded lifecycle values
+	// are skipped, while the library-owned updated_at assignment is appended.
+	require.NoError(t, tx.Update(user))
+	require.Len(t, tx.writes, 1)
+	require.NotNil(t, tx.writes[0].Update)
+	require.Equal(t, 1, updatePathOccurrences(
+		*tx.writes[0].Update.UpdateExpression,
+		tx.writes[0].Update.ExpressionAttributeNames,
+		"updatedAt",
+	))
 }

--- a/pkg/transaction/cov6_transaction_additional_test.go
+++ b/pkg/transaction/cov6_transaction_additional_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	customerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"github.com/theory-cloud/tabletheory/v3/pkg/model"
 	"github.com/theory-cloud/tabletheory/v3/pkg/session"
 	pkgTypes "github.com/theory-cloud/tabletheory/v3/pkg/types"
@@ -50,7 +51,7 @@ func TestTransaction_Commit_FailsWhenClientMissing_COV6(t *testing.T) {
 	require.Error(t, tx.Commit())
 }
 
-func TestTransaction_Update_SkipsUpdatedAtWhenAlreadySet_COV6(t *testing.T) {
+func TestTransaction_Update_RejectsUpdatedAtWhenAlreadySet_COV6(t *testing.T) {
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&unitUser{}))
 
@@ -62,6 +63,8 @@ func TestTransaction_Update_SkipsUpdatedAtWhenAlreadySet_COV6(t *testing.T) {
 		UpdatedAt: time.Now(),
 	}
 
-	require.NoError(t, tx.Update(user))
-	require.NotEmpty(t, tx.writes)
+	err := tx.Update(user)
+	require.ErrorIs(t, err, customerrors.ErrInvalidModel)
+	require.ErrorContains(t, err, "cannot update lifecycle timestamp field UpdatedAt")
+	require.Empty(t, tx.writes)
 }

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -167,6 +167,9 @@ func (tx *Transaction) buildUpdateExpression(modelValue reflect.Value, metadata 
 	if err := rejectProtectedFieldMutation(metadata, fieldsMutatedByTransactionUpdate(modelValue, metadata)); err != nil {
 		return "", nil, nil, err
 	}
+	if err := rejectCallerSetLifecycleTimestamp(modelValue, metadata.CreatedAtField); err != nil {
+		return "", nil, nil, err
+	}
 
 	updateExpression := "SET "
 	expressionAttributeNames := make(map[string]string)
@@ -174,7 +177,7 @@ func (tx *Transaction) buildUpdateExpression(modelValue reflect.Value, metadata 
 
 	updateCount := 0
 	for fieldName, fieldMeta := range metadata.Fields {
-		if fieldMeta.IsPK || fieldMeta.IsSK || fieldMeta.IsUpdatedAt {
+		if isLibraryManagedUpdateField(fieldMeta) {
 			continue
 		}
 
@@ -202,6 +205,26 @@ func (tx *Transaction) buildUpdateExpression(modelValue reflect.Value, metadata 
 	}
 
 	return updateExpression, expressionAttributeNames, expressionAttributeValues, nil
+}
+
+func isLibraryManagedUpdateField(fieldMeta *model.FieldMetadata) bool {
+	return fieldMeta == nil || fieldMeta.IsPK || fieldMeta.IsSK || fieldMeta.IsCreatedAt || fieldMeta.IsUpdatedAt || fieldMeta.IsVersion
+}
+
+func rejectCallerSetLifecycleTimestamp(modelValue reflect.Value, fieldMeta *model.FieldMetadata) error {
+	if fieldMeta == nil {
+		return nil
+	}
+
+	fieldValue := modelValue.FieldByIndex(fieldMeta.IndexPath)
+	if fieldValue.IsValid() && !reflectutil.IsEmpty(fieldValue) {
+		return fmt.Errorf(
+			"%w: cannot update lifecycle timestamp field %s",
+			errors.ErrInvalidModel,
+			fieldMeta.Name,
+		)
+	}
+	return nil
 }
 
 func (tx *Transaction) applyVersionUpdate(
@@ -251,13 +274,8 @@ func (tx *Transaction) applyUpdatedAtUpdate(
 		return nil
 	}
 
-	fieldValue := modelValue.FieldByIndex(metadata.UpdatedAtField.IndexPath)
-	if fieldValue.IsValid() && !reflectutil.IsEmpty(fieldValue) {
-		return fmt.Errorf(
-			"%w: cannot update lifecycle timestamp field %s",
-			errors.ErrInvalidModel,
-			metadata.UpdatedAtField.Name,
-		)
+	if err := rejectCallerSetLifecycleTimestamp(modelValue, metadata.UpdatedAtField); err != nil {
+		return err
 	}
 
 	if *updateExpression == "SET " {

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -105,21 +106,23 @@ func (tx *Transaction) Update(model any) error {
 		modelValue = modelValue.Elem()
 	}
 
-	updateExpression, expressionAttributeNames, expressionAttributeValues, err := tx.buildUpdateExpression(modelValue, metadata)
+	setAssignments, expressionAttributeNames, expressionAttributeValues, err := tx.buildUpdateExpression(modelValue, metadata)
 	if err != nil {
 		return err
 	}
 
 	// Handle version field for optimistic locking
-	conditionExpression, err := tx.applyVersionUpdate(modelValue, metadata, &updateExpression, expressionAttributeNames, expressionAttributeValues)
+	conditionExpression, err := tx.applyVersionUpdate(modelValue, metadata, &setAssignments, expressionAttributeNames, expressionAttributeValues)
 	if err != nil {
 		return err
 	}
 
 	// Handle updated_at field
-	if err := tx.applyUpdatedAtUpdate(modelValue, metadata, &updateExpression, expressionAttributeNames, expressionAttributeValues); err != nil {
+	if err := tx.applyUpdatedAtUpdate(metadata, &setAssignments, expressionAttributeNames, expressionAttributeValues); err != nil {
 		return err
 	}
+
+	updateExpression := buildSetUpdateExpression(setAssignments)
 
 	if encryption.MetadataHasEncryptedFields(metadata) && len(expressionAttributeValues) > 0 {
 		cfg := tx.session.Config()
@@ -160,22 +163,18 @@ func (tx *Transaction) Update(model any) error {
 	return nil
 }
 
-func (tx *Transaction) buildUpdateExpression(modelValue reflect.Value, metadata *model.Metadata) (string, map[string]string, map[string]types.AttributeValue, error) {
+func (tx *Transaction) buildUpdateExpression(modelValue reflect.Value, metadata *model.Metadata) ([]string, map[string]string, map[string]types.AttributeValue, error) {
 	if err := rejectWriteOnceMutation(metadata, "transaction update"); err != nil {
-		return "", nil, nil, err
+		return nil, nil, nil, err
 	}
 	if err := rejectProtectedFieldMutation(metadata, fieldsMutatedByTransactionUpdate(modelValue, metadata)); err != nil {
-		return "", nil, nil, err
-	}
-	if err := rejectCallerSetLifecycleTimestamp(modelValue, metadata.CreatedAtField); err != nil {
-		return "", nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	updateExpression := "SET "
+	setAssignments := make([]string, 0)
 	expressionAttributeNames := make(map[string]string)
 	expressionAttributeValues := make(map[string]types.AttributeValue)
 
-	updateCount := 0
 	for fieldName, fieldMeta := range metadata.Fields {
 		if isLibraryManagedUpdateField(fieldMeta) {
 			continue
@@ -186,51 +185,37 @@ func (tx *Transaction) buildUpdateExpression(modelValue reflect.Value, metadata 
 			continue
 		}
 
-		if updateCount > 0 {
-			updateExpression += ", "
-		}
-
-		attrName := fmt.Sprintf("#f%d", updateCount)
-		attrValue := fmt.Sprintf(":v%d", updateCount)
+		attrName := fmt.Sprintf("#f%d", len(setAssignments))
+		attrValue := fmt.Sprintf(":v%d", len(setAssignments))
 
 		expressionAttributeNames[attrName] = fieldMeta.DBName
 		av, err := tx.converter.ToAttributeValue(fieldValue.Interface())
 		if err != nil {
-			return "", nil, nil, fmt.Errorf("failed to convert field %s: %w", fieldName, err)
+			return nil, nil, nil, fmt.Errorf("failed to convert field %s: %w", fieldName, err)
 		}
 		expressionAttributeValues[attrValue] = av
 
-		updateExpression += attrName + " = " + attrValue
-		updateCount++
+		setAssignments = append(setAssignments, attrName+" = "+attrValue)
 	}
 
-	return updateExpression, expressionAttributeNames, expressionAttributeValues, nil
+	return setAssignments, expressionAttributeNames, expressionAttributeValues, nil
 }
 
 func isLibraryManagedUpdateField(fieldMeta *model.FieldMetadata) bool {
 	return fieldMeta == nil || fieldMeta.IsPK || fieldMeta.IsSK || fieldMeta.IsCreatedAt || fieldMeta.IsUpdatedAt || fieldMeta.IsVersion
 }
 
-func rejectCallerSetLifecycleTimestamp(modelValue reflect.Value, fieldMeta *model.FieldMetadata) error {
-	if fieldMeta == nil {
-		return nil
+func buildSetUpdateExpression(setAssignments []string) string {
+	if len(setAssignments) == 0 {
+		return ""
 	}
-
-	fieldValue := modelValue.FieldByIndex(fieldMeta.IndexPath)
-	if fieldValue.IsValid() && !reflectutil.IsEmpty(fieldValue) {
-		return fmt.Errorf(
-			"%w: cannot update lifecycle timestamp field %s",
-			errors.ErrInvalidModel,
-			fieldMeta.Name,
-		)
-	}
-	return nil
+	return "SET " + strings.Join(setAssignments, ", ")
 }
 
 func (tx *Transaction) applyVersionUpdate(
 	modelValue reflect.Value,
 	metadata *model.Metadata,
-	updateExpression *string,
+	setAssignments *[]string,
 	expressionAttributeNames map[string]string,
 	expressionAttributeValues map[string]types.AttributeValue,
 ) (string, error) {
@@ -253,7 +238,7 @@ func (tx *Transaction) applyVersionUpdate(
 	}
 	expressionAttributeValues[":currentVer"] = av
 
-	*updateExpression += ", #ver = :newVer"
+	*setAssignments = append(*setAssignments, "#ver = :newVer")
 	newAv, err := tx.converter.ToAttributeValue(currentVersion + 1)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert new version: %w", err)
@@ -264,9 +249,8 @@ func (tx *Transaction) applyVersionUpdate(
 }
 
 func (tx *Transaction) applyUpdatedAtUpdate(
-	modelValue reflect.Value,
 	metadata *model.Metadata,
-	updateExpression *string,
+	setAssignments *[]string,
 	expressionAttributeNames map[string]string,
 	expressionAttributeValues map[string]types.AttributeValue,
 ) error {
@@ -274,15 +258,7 @@ func (tx *Transaction) applyUpdatedAtUpdate(
 		return nil
 	}
 
-	if err := rejectCallerSetLifecycleTimestamp(modelValue, metadata.UpdatedAtField); err != nil {
-		return err
-	}
-
-	if *updateExpression == "SET " {
-		*updateExpression += "#upd = :updTime"
-	} else {
-		*updateExpression += ", #upd = :updTime"
-	}
+	*setAssignments = append(*setAssignments, "#upd = :updTime")
 	expressionAttributeNames["#upd"] = metadata.UpdatedAtField.DBName
 
 	av, err := tx.converter.ToAttributeValue(time.Now())

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -174,7 +174,7 @@ func (tx *Transaction) buildUpdateExpression(modelValue reflect.Value, metadata 
 
 	updateCount := 0
 	for fieldName, fieldMeta := range metadata.Fields {
-		if fieldMeta.IsPK || fieldMeta.IsSK {
+		if fieldMeta.IsPK || fieldMeta.IsSK || fieldMeta.IsUpdatedAt {
 			continue
 		}
 
@@ -251,18 +251,20 @@ func (tx *Transaction) applyUpdatedAtUpdate(
 		return nil
 	}
 
-	for _, fieldMeta := range metadata.Fields {
-		if fieldMeta.DBName != metadata.UpdatedAtField.DBName {
-			continue
-		}
-
-		fieldValue := modelValue.FieldByIndex(fieldMeta.IndexPath)
-		if fieldValue.IsValid() && !reflectutil.IsEmpty(fieldValue) {
-			return nil
-		}
+	fieldValue := modelValue.FieldByIndex(metadata.UpdatedAtField.IndexPath)
+	if fieldValue.IsValid() && !reflectutil.IsEmpty(fieldValue) {
+		return fmt.Errorf(
+			"%w: cannot update lifecycle timestamp field %s",
+			errors.ErrInvalidModel,
+			metadata.UpdatedAtField.Name,
+		)
 	}
 
-	*updateExpression += ", #upd = :updTime"
+	if *updateExpression == "SET " {
+		*updateExpression += "#upd = :updTime"
+	} else {
+		*updateExpression += ", #upd = :updTime"
+	}
 	expressionAttributeNames["#upd"] = metadata.UpdatedAtField.DBName
 
 	av, err := tx.converter.ToAttributeValue(time.Now())

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -123,24 +123,12 @@ func (tx *Transaction) Update(model any) error {
 	}
 
 	updateExpression := buildSetUpdateExpression(setAssignments)
+	if updateExpression == "" {
+		return fmt.Errorf("no non-key fields to update")
+	}
 
-	if encryption.MetadataHasEncryptedFields(metadata) && len(expressionAttributeValues) > 0 {
-		cfg := tx.session.Config()
-		keyARN := ""
-		var rng io.Reader
-		if cfg != nil {
-			keyARN = cfg.KMSKeyARN
-			rng = cfg.EncryptionRand
-		}
-		var svc *encryption.Service
-		if cfg != nil && cfg.KMSClient != nil {
-			svc = encryption.NewServiceWithRand(keyARN, cfg.KMSClient, rng)
-		} else {
-			svc = encryption.NewServiceFromAWSConfigWithRand(keyARN, tx.session.AWSConfig(), rng)
-		}
-		if err := encryption.EncryptUpdateExpressionValues(tx.ctx, svc, metadata, updateExpression, expressionAttributeNames, expressionAttributeValues); err != nil {
-			return err
-		}
+	if err := tx.encryptUpdateExpressionValues(metadata, updateExpression, expressionAttributeNames, expressionAttributeValues); err != nil {
+		return err
 	}
 
 	updateItem := &types.Update{
@@ -161,6 +149,40 @@ func (tx *Transaction) Update(model any) error {
 	})
 
 	return nil
+}
+
+func (tx *Transaction) encryptUpdateExpressionValues(
+	metadata *model.Metadata,
+	updateExpression string,
+	expressionAttributeNames map[string]string,
+	expressionAttributeValues map[string]types.AttributeValue,
+) error {
+	if !encryption.MetadataHasEncryptedFields(metadata) || len(expressionAttributeValues) == 0 {
+		return nil
+	}
+
+	cfg := tx.session.Config()
+	keyARN := ""
+	var rng io.Reader
+	if cfg != nil {
+		keyARN = cfg.KMSKeyARN
+		rng = cfg.EncryptionRand
+	}
+	var svc *encryption.Service
+	if cfg != nil && cfg.KMSClient != nil {
+		svc = encryption.NewServiceWithRand(keyARN, cfg.KMSClient, rng)
+	} else {
+		svc = encryption.NewServiceFromAWSConfigWithRand(keyARN, tx.session.AWSConfig(), rng)
+	}
+
+	return encryption.EncryptUpdateExpressionValues(
+		tx.ctx,
+		svc,
+		metadata,
+		updateExpression,
+		expressionAttributeNames,
+		expressionAttributeValues,
+	)
 }
 
 func (tx *Transaction) buildUpdateExpression(modelValue reflect.Value, metadata *model.Metadata) ([]string, map[string]string, map[string]types.AttributeValue, error) {

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -1,15 +1,18 @@
 package transaction
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/require"
 
 	customerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"github.com/theory-cloud/tabletheory/v3/pkg/model"
 	"github.com/theory-cloud/tabletheory/v3/pkg/session"
+	"github.com/theory-cloud/tabletheory/v3/pkg/testing/fakedb"
 	pkgTypes "github.com/theory-cloud/tabletheory/v3/pkg/types"
 )
 
@@ -79,4 +82,102 @@ func TestBuilderUpdateRefreshesUpdatedAt(t *testing.T) {
 	require.Contains(t, attributeNames(update.ExpressionAttributeNames), "updatedAt")
 	require.NotContains(t, attributeNames(update.ExpressionAttributeNames), "createdAt")
 	require.Len(t, update.ExpressionAttributeValues, 2)
+}
+
+type legacyTransactionalLifecycleRecord struct {
+	UpdatedAt time.Time `theorydb:"updated_at,attr:updatedAt" json:"updatedAt"`
+	PK        string    `theorydb:"pk,attr:PK" json:"PK"`
+	SK        string    `theorydb:"sk,attr:SK" json:"SK"`
+	Value     string    `theorydb:"attr:value" json:"value"`
+	Optional  string    `theorydb:"attr:optional,omitempty" json:"optional,omitempty"`
+}
+
+func (legacyTransactionalLifecycleRecord) TableName() string {
+	return "legacy_transactional_lifecycle_records"
+}
+
+func TestTransactionUpdateLegacyOverlapExpressionProbe(t *testing.T) {
+	fake := fakedb.New()
+	sess, err := session.NewSessionWithClient(&session.Config{Region: "us-east-1"}, fake)
+	require.NoError(t, err)
+
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
+
+	tx := NewTransaction(sess, registry, pkgTypes.NewConverter())
+	require.NoError(t, tx.Update(&legacyTransactionalLifecycleRecord{
+		PK:    "USER#legacy-overlap",
+		SK:    "PROFILE",
+		Value: "changed",
+	}))
+	require.Len(t, tx.writes, 1)
+	require.NotNil(t, tx.writes[0].Update)
+
+	update := tx.writes[0].Update
+	expression := aws.ToString(update.UpdateExpression)
+	t.Logf("legacy overlap update expression: %s", expression)
+	require.Equal(t, 1, updatePathOccurrences(expression, update.ExpressionAttributeNames, "updatedAt"),
+		"the library-managed updated_at path must appear exactly once")
+	require.NoError(t, tx.Commit(), "the built legacy transaction must validate and execute against the DynamoDBAPI fake")
+
+	items := fake.Items((legacyTransactionalLifecycleRecord{}).TableName())
+	require.Len(t, items, 1)
+	_, ok := items[0]["updatedAt"].(*types.AttributeValueMemberS)
+	require.True(t, ok, "the committed transaction must write the library-managed timestamp")
+}
+
+func TestTransactionUpdateLegacyRejectsCallerSetUpdatedAtLikeExplicitPath(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
+	record := &legacyTransactionalLifecycleRecord{
+		PK:        "USER#legacy-caller-timestamp",
+		SK:        "PROFILE",
+		Value:     "changed",
+		UpdatedAt: time.Now(),
+	}
+
+	explicit := NewBuilder(&session.Session{}, registry, pkgTypes.NewConverter())
+	explicit.Update(record, []string{"UpdatedAt"})
+	items, explicitErr := explicit.materializeOperations()
+	require.ErrorIs(t, explicitErr, customerrors.ErrInvalidModel)
+	require.Nil(t, items)
+
+	legacy := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+	legacyErr := legacy.Update(record)
+	require.ErrorIs(t, legacyErr, customerrors.ErrInvalidModel)
+	require.EqualError(t, legacyErr, explicitErr.Error())
+	require.Empty(t, legacy.writes, "invalid lifecycle selection must not produce a DynamoDB write")
+}
+
+func TestTransactionUpdateLegacyPreservesSparseSetSemanticsAndRefreshesUpdatedAt(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
+
+	tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+	require.NoError(t, tx.Update(&legacyTransactionalLifecycleRecord{
+		PK:    "USER#legacy-normal",
+		SK:    "PROFILE",
+		Value: "changed",
+	}))
+	require.Len(t, tx.writes, 1)
+	require.NotNil(t, tx.writes[0].Update)
+
+	update := tx.writes[0].Update
+	expression := aws.ToString(update.UpdateExpression)
+	require.Contains(t, expression, "SET")
+	require.NotContains(t, expression, "REMOVE",
+		"legacy implicit updates keep zero-valued omitempty fields unselected rather than removing them")
+	require.ElementsMatch(t, []string{"value", "updatedAt"}, attributeNames(update.ExpressionAttributeNames))
+	require.Len(t, update.ExpressionAttributeValues, 2)
+	require.Equal(t, 1, updatePathOccurrences(expression, update.ExpressionAttributeNames, "updatedAt"))
+}
+
+func updatePathOccurrences(expression string, names map[string]string, path string) int {
+	count := 0
+	for placeholder, attribute := range names {
+		if attribute == path {
+			count += strings.Count(expression, placeholder)
+		}
+	}
+	return count
 }

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	dynamodbTypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/require"
 
 	customerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
@@ -96,6 +97,28 @@ func (legacyTransactionalLifecycleRecord) TableName() string {
 	return "legacy_transactional_lifecycle_records"
 }
 
+type legacyManagedOnlyVersionedRecord struct {
+	CreatedAt time.Time `theorydb:"created_at,attr:createdAt" json:"createdAt"`
+	UpdatedAt time.Time `theorydb:"updated_at,attr:updatedAt" json:"updatedAt"`
+	PK        string    `theorydb:"pk,attr:PK" json:"PK"`
+	SK        string    `theorydb:"sk,attr:SK" json:"SK"`
+	Version   int       `theorydb:"version,attr:version" json:"version"`
+}
+
+func (legacyManagedOnlyVersionedRecord) TableName() string {
+	return "legacy_managed_only_versioned_records"
+}
+
+type legacyCreatedAtOnlyRecord struct {
+	CreatedAt time.Time `theorydb:"created_at,attr:createdAt" json:"createdAt"`
+	PK        string    `theorydb:"pk,attr:PK" json:"PK"`
+	SK        string    `theorydb:"sk,attr:SK" json:"SK"`
+}
+
+func (legacyCreatedAtOnlyRecord) TableName() string {
+	return "legacy_created_at_only_records"
+}
+
 func TestTransactionUpdateLegacyOverlapExpressionProbe(t *testing.T) {
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
@@ -124,30 +147,75 @@ func TestTransactionUpdateLegacyOverlapExpressionProbe(t *testing.T) {
 	require.Equal(t, "#ver = :currentVer", aws.ToString(update.ConditionExpression))
 }
 
-func TestTransactionUpdateLegacyRejectsCallerSetUpdatedAtLikeExplicitPath(t *testing.T) {
+func TestTransactionUpdateLegacyBuildsSetFromManagedOnlyAssignments(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyManagedOnlyVersionedRecord{}))
+
+	tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+	require.NoError(t, tx.Update(&legacyManagedOnlyVersionedRecord{
+		PK:      "USER#legacy-managed-only",
+		SK:      "PROFILE",
+		Version: 7,
+	}))
+	require.Len(t, tx.writes, 1)
+
+	update := tx.writes[0].Update
+	require.NotNil(t, update)
+	expression := aws.ToString(update.UpdateExpression)
+	require.Equal(t, "SET #ver = :newVer, #upd = :updTime", expression)
+	require.NotContains(t, expression, "SET ,")
+	require.ElementsMatch(t, []string{"version", "updatedAt"}, updateDocumentPaths(expression, update.ExpressionAttributeNames))
+	require.Equal(t, "#ver = :currentVer", aws.ToString(update.ConditionExpression))
+}
+
+func TestTransactionUpdateLegacyOmitsEmptySetClause(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyCreatedAtOnlyRecord{}))
+
+	tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+	require.NoError(t, tx.Update(&legacyCreatedAtOnlyRecord{
+		PK: "USER#legacy-created-at-only",
+		SK: "PROFILE",
+	}))
+	require.Len(t, tx.writes, 1)
+
+	update := tx.writes[0].Update
+	require.NotNil(t, update)
+	require.Empty(t, aws.ToString(update.UpdateExpression),
+		"an implicit update with no assignments must omit SET rather than emit a bare clause")
+	require.Empty(t, update.ExpressionAttributeNames)
+	require.Empty(t, update.ExpressionAttributeValues)
+}
+
+func TestTransactionUpdateLegacyOverridesCallerSetUpdatedAtForImplicitRMW(t *testing.T) {
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
+	callerUpdatedAt := time.Date(2020, time.January, 2, 3, 4, 5, 0, time.UTC)
 	record := &legacyTransactionalLifecycleRecord{
 		PK:        "USER#legacy-caller-timestamp",
 		SK:        "PROFILE",
 		Value:     "changed",
-		UpdatedAt: time.Now(),
+		UpdatedAt: callerUpdatedAt,
 	}
 
-	explicit := NewBuilder(&session.Session{}, registry, pkgTypes.NewConverter())
-	explicit.Update(record, []string{"UpdatedAt"})
-	items, explicitErr := explicit.materializeOperations()
-	require.ErrorIs(t, explicitErr, customerrors.ErrInvalidModel)
-	require.Nil(t, items)
-
+	// The legacy whole-model surface must remain read-modify-write compatible. Lifecycle
+	// rejection is reserved for explicit named-field surfaces across every runtime; the
+	// normative implicit surface skips caller values and lets the library refresh updated_at.
 	legacy := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
-	legacyErr := legacy.Update(record)
-	require.ErrorIs(t, legacyErr, customerrors.ErrInvalidModel)
-	require.EqualError(t, legacyErr, explicitErr.Error())
-	require.Empty(t, legacy.writes, "invalid lifecycle selection must not produce a DynamoDB write")
+	require.NoError(t, legacy.Update(record))
+	require.Len(t, legacy.writes, 1)
+
+	update := legacy.writes[0].Update
+	require.NotNil(t, update)
+	expression := aws.ToString(update.UpdateExpression)
+	require.ElementsMatch(t, []string{"value", "updatedAt"}, updateDocumentPaths(expression, update.ExpressionAttributeNames))
+	updatedAt, ok := update.ExpressionAttributeValues[":updTime"].(*dynamodbTypes.AttributeValueMemberS)
+	require.True(t, ok)
+	require.NotEqual(t, callerUpdatedAt.Format(time.RFC3339Nano), updatedAt.Value,
+		"the caller-supplied updated_at must not win over the library timestamp")
 }
 
-func TestTransactionUpdateLegacyRejectsCallerSetCreatedAtLikeExplicitPath(t *testing.T) {
+func TestTransactionUpdateLegacyIgnoresCallerSetCreatedAtForImplicitRMW(t *testing.T) {
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
 	record := &legacyTransactionalLifecycleRecord{
@@ -157,17 +225,18 @@ func TestTransactionUpdateLegacyRejectsCallerSetCreatedAtLikeExplicitPath(t *tes
 		CreatedAt: time.Now(),
 	}
 
-	explicit := NewBuilder(&session.Session{}, registry, pkgTypes.NewConverter())
-	explicit.Update(record, []string{"CreatedAt"})
-	items, explicitErr := explicit.materializeOperations()
-	require.ErrorIs(t, explicitErr, customerrors.ErrInvalidModel)
-	require.Nil(t, items)
-
+	// Loaded models naturally carry created_at. The legacy implicit surface therefore
+	// excludes it without error; only explicit named-field mutation is rejected.
 	legacy := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
-	legacyErr := legacy.Update(record)
-	require.ErrorIs(t, legacyErr, customerrors.ErrInvalidModel)
-	require.EqualError(t, legacyErr, explicitErr.Error())
-	require.Empty(t, legacy.writes, "invalid lifecycle selection must not produce a DynamoDB write")
+	require.NoError(t, legacy.Update(record))
+	require.Len(t, legacy.writes, 1)
+
+	update := legacy.writes[0].Update
+	require.NotNil(t, update)
+	expression := aws.ToString(update.UpdateExpression)
+	require.ElementsMatch(t, []string{"value", "updatedAt"}, updateDocumentPaths(expression, update.ExpressionAttributeNames))
+	require.Zero(t, updatePathOccurrences(expression, update.ExpressionAttributeNames, "createdAt"),
+		"caller-supplied created_at must be excluded so the stored lifecycle value is preserved")
 }
 
 func TestTransactionUpdateLegacyPreservesSparseSetSemanticsAndRefreshesUpdatedAt(t *testing.T) {

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -6,13 +6,11 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/require"
 
 	customerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"github.com/theory-cloud/tabletheory/v3/pkg/model"
 	"github.com/theory-cloud/tabletheory/v3/pkg/session"
-	"github.com/theory-cloud/tabletheory/v3/pkg/testing/fakedb"
 	pkgTypes "github.com/theory-cloud/tabletheory/v3/pkg/types"
 )
 
@@ -85,11 +83,13 @@ func TestBuilderUpdateRefreshesUpdatedAt(t *testing.T) {
 }
 
 type legacyTransactionalLifecycleRecord struct {
+	CreatedAt time.Time `theorydb:"created_at,attr:createdAt" json:"createdAt"`
 	UpdatedAt time.Time `theorydb:"updated_at,attr:updatedAt" json:"updatedAt"`
 	PK        string    `theorydb:"pk,attr:PK" json:"PK"`
 	SK        string    `theorydb:"sk,attr:SK" json:"SK"`
 	Value     string    `theorydb:"attr:value" json:"value"`
 	Optional  string    `theorydb:"attr:optional,omitempty" json:"optional,omitempty"`
+	Version   int       `theorydb:"version,attr:version" json:"version"`
 }
 
 func (legacyTransactionalLifecycleRecord) TableName() string {
@@ -97,18 +97,15 @@ func (legacyTransactionalLifecycleRecord) TableName() string {
 }
 
 func TestTransactionUpdateLegacyOverlapExpressionProbe(t *testing.T) {
-	fake := fakedb.New()
-	sess, err := session.NewSessionWithClient(&session.Config{Region: "us-east-1"}, fake)
-	require.NoError(t, err)
-
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
 
-	tx := NewTransaction(sess, registry, pkgTypes.NewConverter())
+	tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
 	require.NoError(t, tx.Update(&legacyTransactionalLifecycleRecord{
-		PK:    "USER#legacy-overlap",
-		SK:    "PROFILE",
-		Value: "changed",
+		PK:      "USER#legacy-overlap",
+		SK:      "PROFILE",
+		Value:   "changed",
+		Version: 7,
 	}))
 	require.Len(t, tx.writes, 1)
 	require.NotNil(t, tx.writes[0].Update)
@@ -116,14 +113,15 @@ func TestTransactionUpdateLegacyOverlapExpressionProbe(t *testing.T) {
 	update := tx.writes[0].Update
 	expression := aws.ToString(update.UpdateExpression)
 	t.Logf("legacy overlap update expression: %s", expression)
+	require.ElementsMatch(t, []string{"value", "version", "updatedAt"},
+		updateDocumentPaths(expression, update.ExpressionAttributeNames))
+	require.Equal(t, 1, updatePathOccurrences(expression, update.ExpressionAttributeNames, "version"),
+		"the library-managed version path must appear exactly once")
 	require.Equal(t, 1, updatePathOccurrences(expression, update.ExpressionAttributeNames, "updatedAt"),
 		"the library-managed updated_at path must appear exactly once")
-	require.NoError(t, tx.Commit(), "the built legacy transaction must validate and execute against the DynamoDBAPI fake")
-
-	items := fake.Items((legacyTransactionalLifecycleRecord{}).TableName())
-	require.Len(t, items, 1)
-	_, ok := items[0]["updatedAt"].(*types.AttributeValueMemberS)
-	require.True(t, ok, "the committed transaction must write the library-managed timestamp")
+	require.Zero(t, updatePathOccurrences(expression, update.ExpressionAttributeNames, "createdAt"),
+		"created_at must not be selected by the implicit update")
+	require.Equal(t, "#ver = :currentVer", aws.ToString(update.ConditionExpression))
 }
 
 func TestTransactionUpdateLegacyRejectsCallerSetUpdatedAtLikeExplicitPath(t *testing.T) {
@@ -138,6 +136,29 @@ func TestTransactionUpdateLegacyRejectsCallerSetUpdatedAtLikeExplicitPath(t *tes
 
 	explicit := NewBuilder(&session.Session{}, registry, pkgTypes.NewConverter())
 	explicit.Update(record, []string{"UpdatedAt"})
+	items, explicitErr := explicit.materializeOperations()
+	require.ErrorIs(t, explicitErr, customerrors.ErrInvalidModel)
+	require.Nil(t, items)
+
+	legacy := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+	legacyErr := legacy.Update(record)
+	require.ErrorIs(t, legacyErr, customerrors.ErrInvalidModel)
+	require.EqualError(t, legacyErr, explicitErr.Error())
+	require.Empty(t, legacy.writes, "invalid lifecycle selection must not produce a DynamoDB write")
+}
+
+func TestTransactionUpdateLegacyRejectsCallerSetCreatedAtLikeExplicitPath(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
+	record := &legacyTransactionalLifecycleRecord{
+		PK:        "USER#legacy-caller-created-at",
+		SK:        "PROFILE",
+		Value:     "changed",
+		CreatedAt: time.Now(),
+	}
+
+	explicit := NewBuilder(&session.Session{}, registry, pkgTypes.NewConverter())
+	explicit.Update(record, []string{"CreatedAt"})
 	items, explicitErr := explicit.materializeOperations()
 	require.ErrorIs(t, explicitErr, customerrors.ErrInvalidModel)
 	require.Nil(t, items)
@@ -169,15 +190,41 @@ func TestTransactionUpdateLegacyPreservesSparseSetSemanticsAndRefreshesUpdatedAt
 		"legacy implicit updates keep zero-valued omitempty fields unselected rather than removing them")
 	require.ElementsMatch(t, []string{"value", "updatedAt"}, attributeNames(update.ExpressionAttributeNames))
 	require.Len(t, update.ExpressionAttributeValues, 2)
+	require.Zero(t, updatePathOccurrences(expression, update.ExpressionAttributeNames, "createdAt"),
+		"a zero created_at must not overwrite the stored lifecycle timestamp")
+	require.Zero(t, updatePathOccurrences(expression, update.ExpressionAttributeNames, "version"),
+		"a zero version must not be selected by the implicit update")
 	require.Equal(t, 1, updatePathOccurrences(expression, update.ExpressionAttributeNames, "updatedAt"))
 }
 
 func updatePathOccurrences(expression string, names map[string]string, path string) int {
 	count := 0
-	for placeholder, attribute := range names {
+	for _, attribute := range updateDocumentPaths(expression, names) {
 		if attribute == path {
-			count += strings.Count(expression, placeholder)
+			count++
 		}
 	}
 	return count
+}
+
+func updateDocumentPaths(expression string, names map[string]string) []string {
+	setExpression := strings.TrimSpace(strings.TrimPrefix(expression, "SET"))
+	if setExpression == "" {
+		return nil
+	}
+
+	assignments := strings.Split(setExpression, ",")
+	paths := make([]string, 0, len(assignments))
+	for _, assignment := range assignments {
+		parts := strings.SplitN(assignment, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		path := strings.TrimSpace(parts[0])
+		if attribute, ok := names[path]; ok {
+			path = attribute
+		}
+		paths = append(paths, path)
+	}
+	return paths
 }

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -173,18 +173,12 @@ func TestTransactionUpdateLegacyOmitsEmptySetClause(t *testing.T) {
 	require.NoError(t, registry.Register(&legacyCreatedAtOnlyRecord{}))
 
 	tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
-	require.NoError(t, tx.Update(&legacyCreatedAtOnlyRecord{
+	err := tx.Update(&legacyCreatedAtOnlyRecord{
 		PK: "USER#legacy-created-at-only",
 		SK: "PROFILE",
-	}))
-	require.Len(t, tx.writes, 1)
-
-	update := tx.writes[0].Update
-	require.NotNil(t, update)
-	require.Empty(t, aws.ToString(update.UpdateExpression),
-		"an implicit update with no assignments must omit SET rather than emit a bare clause")
-	require.Empty(t, update.ExpressionAttributeNames)
-	require.Empty(t, update.ExpressionAttributeValues)
+	})
+	require.EqualError(t, err, "no non-key fields to update")
+	require.Empty(t, tx.writes, "an empty implicit update must not queue an invalid DynamoDB write")
 }
 
 func TestTransactionUpdateLegacyOverridesCallerSetUpdatedAtForImplicitRMW(t *testing.T) {

--- a/scripts/verify-empty-predicate-call-sites.sh
+++ b/scripts/verify-empty-predicate-call-sites.sh
@@ -29,7 +29,6 @@ pkg/query/query_marshal.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty
 pkg/query/query_marshal.go|IsEmpty|if fieldcodec.HasModifier(tag, "omitempty") && reflectutil.IsEmpty(fieldValue) {
 pkg/query/tagged_encode_helpers.go|IsEmpty|if fieldcodec.HasModifier(tag, "omitempty") && reflectutil.IsEmpty(fieldValue) {
 pkg/transaction/builder.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty(fieldValue) {
-pkg/transaction/transaction.go|IsEmpty|if fieldValue.IsValid() && !reflectutil.IsEmpty(fieldValue) {
 pkg/transaction/transaction.go|IsEmpty|if fieldMeta.OmitEmpty && reflectutil.IsEmpty(fieldValue) {
 EOF
 

--- a/tests/integration/transaction_legacy_update_test.go
+++ b/tests/integration/transaction_legacy_update_test.go
@@ -1,0 +1,123 @@
+package integration
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/v3/pkg/model"
+	"github.com/theory-cloud/tabletheory/v3/pkg/session"
+	"github.com/theory-cloud/tabletheory/v3/pkg/transaction"
+	pkgTypes "github.com/theory-cloud/tabletheory/v3/pkg/types"
+)
+
+type legacyTransactionLifecycleRecord struct {
+	CreatedAt time.Time `theorydb:"created_at,attr:createdAt" json:"createdAt"`
+	UpdatedAt time.Time `theorydb:"updated_at,attr:updatedAt" json:"updatedAt"`
+	PK        string    `theorydb:"pk,attr:PK" json:"PK"`
+	SK        string    `theorydb:"sk,attr:SK" json:"SK"`
+	Value     string    `theorydb:"attr:value" json:"value"`
+	Version   int       `theorydb:"version,attr:version" json:"version"`
+}
+
+func (legacyTransactionLifecycleRecord) TableName() string {
+	return "legacy_transaction_lifecycle_integration"
+}
+
+func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
+	testCtx := InitTestDB(t)
+	testCtx.CreateTableIfNotExists(t, &legacyTransactionLifecycleRecord{})
+	t.Cleanup(func() {
+		testCtx.DeleteTable(t, (legacyTransactionLifecycleRecord{}).TableName())
+	})
+
+	sess, err := session.NewSessionWithClient(&session.Config{Region: "us-east-1"}, testCtx.DynamoDBClient)
+	require.NoError(t, err)
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyTransactionLifecycleRecord{}))
+
+	seedCreatedAt := time.Date(2020, time.March, 4, 5, 6, 7, 0, time.UTC).Format(time.RFC3339Nano)
+	seed := func(t *testing.T, pk string, version int) {
+		t.Helper()
+		item := map[string]types.AttributeValue{
+			"PK":        &types.AttributeValueMemberS{Value: pk},
+			"SK":        &types.AttributeValueMemberS{Value: "PROFILE"},
+			"value":     &types.AttributeValueMemberS{Value: "original"},
+			"createdAt": &types.AttributeValueMemberS{Value: seedCreatedAt},
+		}
+		if version > 0 {
+			item["version"] = &types.AttributeValueMemberN{Value: strconv.Itoa(version)}
+		}
+		_, err := testCtx.DynamoDBClient.PutItem(context.Background(), &dynamodb.PutItemInput{
+			TableName: aws.String((legacyTransactionLifecycleRecord{}).TableName()),
+			Item:      item,
+		})
+		require.NoError(t, err)
+	}
+	load := func(t *testing.T, pk string) map[string]types.AttributeValue {
+		t.Helper()
+		output, err := testCtx.DynamoDBClient.GetItem(context.Background(), &dynamodb.GetItemInput{
+			TableName: aws.String((legacyTransactionLifecycleRecord{}).TableName()),
+			Key: map[string]types.AttributeValue{
+				"PK": &types.AttributeValueMemberS{Value: pk},
+				"SK": &types.AttributeValueMemberS{Value: "PROFILE"},
+			},
+			ConsistentRead: aws.Bool(true),
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, output.Item)
+		return output.Item
+	}
+
+	t.Run("versioned update has no overlapping paths", func(t *testing.T) {
+		const pk = "USER#legacy-versioned"
+		seed(t, pk, 7)
+
+		tx := transaction.NewTransaction(sess, registry, pkgTypes.NewConverter())
+		require.NoError(t, tx.Update(&legacyTransactionLifecycleRecord{
+			PK:      pk,
+			SK:      "PROFILE",
+			Value:   "changed",
+			Version: 7,
+		}))
+		require.NoError(t, tx.Commit())
+
+		item := load(t, pk)
+		value, ok := item["value"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.Equal(t, "changed", value.Value)
+		version, ok := item["version"].(*types.AttributeValueMemberN)
+		require.True(t, ok)
+		require.Equal(t, "8", version.Value)
+		createdAt, ok := item["createdAt"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.Equal(t, seedCreatedAt, createdAt.Value)
+		updatedAt, ok := item["updatedAt"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.NotEmpty(t, updatedAt.Value)
+	})
+
+	t.Run("zero created_at does not clobber stored value", func(t *testing.T) {
+		const pk = "USER#legacy-created-at"
+		seed(t, pk, 0)
+
+		tx := transaction.NewTransaction(sess, registry, pkgTypes.NewConverter())
+		require.NoError(t, tx.Update(&legacyTransactionLifecycleRecord{
+			PK:    pk,
+			SK:    "PROFILE",
+			Value: "changed",
+		}))
+		require.NoError(t, tx.Commit())
+
+		item := load(t, pk)
+		createdAt, ok := item["createdAt"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.Equal(t, seedCreatedAt, createdAt.Value)
+	})
+}

--- a/tests/integration/transaction_legacy_update_test.go
+++ b/tests/integration/transaction_legacy_update_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/theory-cloud/tabletheory/v3/pkg/model"
+	"github.com/theory-cloud/tabletheory/v3/pkg/query"
 	"github.com/theory-cloud/tabletheory/v3/pkg/session"
 	"github.com/theory-cloud/tabletheory/v3/pkg/transaction"
 	pkgTypes "github.com/theory-cloud/tabletheory/v3/pkg/types"
@@ -22,7 +23,7 @@ type legacyTransactionLifecycleRecord struct {
 	UpdatedAt time.Time `theorydb:"updated_at,attr:updatedAt" json:"updatedAt"`
 	PK        string    `theorydb:"pk,attr:PK" json:"PK"`
 	SK        string    `theorydb:"sk,attr:SK" json:"SK"`
-	Value     string    `theorydb:"attr:value" json:"value"`
+	Value     string    `theorydb:"attr:value,omitempty" json:"value,omitempty"`
 	Version   int       `theorydb:"version,attr:version" json:"version"`
 }
 
@@ -43,6 +44,7 @@ func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
 	require.NoError(t, registry.Register(&legacyTransactionLifecycleRecord{}))
 
 	seedCreatedAt := time.Date(2020, time.March, 4, 5, 6, 7, 0, time.UTC).Format(time.RFC3339Nano)
+	seedUpdatedAt := time.Date(2020, time.March, 5, 6, 7, 8, 0, time.UTC).Format(time.RFC3339Nano)
 	seed := func(t *testing.T, pk string, version int) {
 		t.Helper()
 		item := map[string]types.AttributeValue{
@@ -50,6 +52,7 @@ func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
 			"SK":        &types.AttributeValueMemberS{Value: "PROFILE"},
 			"value":     &types.AttributeValueMemberS{Value: "original"},
 			"createdAt": &types.AttributeValueMemberS{Value: seedCreatedAt},
+			"updatedAt": &types.AttributeValueMemberS{Value: seedUpdatedAt},
 		}
 		if version > 0 {
 			item["version"] = &types.AttributeValueMemberN{Value: strconv.Itoa(version)}
@@ -60,6 +63,7 @@ func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
 		})
 		require.NoError(t, err)
 	}
+
 	load := func(t *testing.T, pk string) map[string]types.AttributeValue {
 		t.Helper()
 		output, err := testCtx.DynamoDBClient.GetItem(context.Background(), &dynamodb.GetItemInput{
@@ -74,6 +78,34 @@ func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
 		require.NotEmpty(t, output.Item)
 		return output.Item
 	}
+
+	t.Run("versioned managed-only update has well-formed SET", func(t *testing.T) {
+		const pk = "USER#legacy-managed-only"
+		seed(t, pk, 7)
+
+		tx := transaction.NewTransaction(sess, registry, pkgTypes.NewConverter())
+		require.NoError(t, tx.Update(&legacyTransactionLifecycleRecord{
+			PK:      pk,
+			SK:      "PROFILE",
+			Version: 7,
+		}))
+		require.NoError(t, tx.Commit(),
+			"DynamoDB Local must accept the SET clause built entirely from version and updated_at assignments")
+
+		item := load(t, pk)
+		value, ok := item["value"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.Equal(t, "original", value.Value, "no caller-owned field was selected")
+		version, ok := item["version"].(*types.AttributeValueMemberN)
+		require.True(t, ok)
+		require.Equal(t, "8", version.Value)
+		createdAt, ok := item["createdAt"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.Equal(t, seedCreatedAt, createdAt.Value)
+		updatedAt, ok := item["updatedAt"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.NotEqual(t, seedUpdatedAt, updatedAt.Value)
+	})
 
 	t.Run("versioned update has no overlapping paths", func(t *testing.T) {
 		const pk = "USER#legacy-versioned"
@@ -119,5 +151,34 @@ func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
 		createdAt, ok := item["createdAt"].(*types.AttributeValueMemberS)
 		require.True(t, ok)
 		require.Equal(t, seedCreatedAt, createdAt.Value)
+	})
+
+	t.Run("loaded lifecycle values support read modify write", func(t *testing.T) {
+		const pk = "USER#legacy-rmw"
+		seed(t, pk, 7)
+
+		var loaded legacyTransactionLifecycleRecord
+		require.NoError(t, query.UnmarshalItem(load(t, pk), &loaded))
+		require.False(t, loaded.CreatedAt.IsZero())
+		require.False(t, loaded.UpdatedAt.IsZero())
+		loaded.Value = "changed-after-load"
+
+		tx := transaction.NewTransaction(sess, registry, pkgTypes.NewConverter())
+		require.NoError(t, tx.Update(&loaded),
+			"the implicit whole-model surface must accept lifecycle values populated by a read")
+		require.NoError(t, tx.Commit())
+
+		item := load(t, pk)
+		value, ok := item["value"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.Equal(t, "changed-after-load", value.Value)
+		createdAt, ok := item["createdAt"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.Equal(t, seedCreatedAt, createdAt.Value,
+			"created_at must be preserved byte-exact even though the loaded model carries it")
+		updatedAt, ok := item["updatedAt"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.NotEqual(t, seedUpdatedAt, updatedAt.Value,
+			"updated_at must be refreshed rather than reusing the loaded value")
 	})
 }

--- a/tests/integration/transaction_legacy_update_test.go
+++ b/tests/integration/transaction_legacy_update_test.go
@@ -31,6 +31,16 @@ func (legacyTransactionLifecycleRecord) TableName() string {
 	return "legacy_transaction_lifecycle_integration"
 }
 
+type legacyTransactionCreatedAtOnlyRecord struct {
+	CreatedAt time.Time `theorydb:"created_at,attr:createdAt" json:"createdAt"`
+	PK        string    `theorydb:"pk,attr:PK" json:"PK"`
+	SK        string    `theorydb:"sk,attr:SK" json:"SK"`
+}
+
+func (legacyTransactionCreatedAtOnlyRecord) TableName() string {
+	return (legacyTransactionLifecycleRecord{}).TableName()
+}
+
 func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
 	testCtx := InitTestDB(t)
 	testCtx.CreateTableIfNotExists(t, &legacyTransactionLifecycleRecord{})
@@ -42,6 +52,7 @@ func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
 	require.NoError(t, err)
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&legacyTransactionLifecycleRecord{}))
+	require.NoError(t, registry.Register(&legacyTransactionCreatedAtOnlyRecord{}))
 
 	seedCreatedAt := time.Date(2020, time.March, 4, 5, 6, 7, 0, time.UTC).Format(time.RFC3339Nano)
 	seedUpdatedAt := time.Date(2020, time.March, 5, 6, 7, 8, 0, time.UTC).Format(time.RFC3339Nano)
@@ -105,6 +116,25 @@ func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
 		updatedAt, ok := item["updatedAt"].(*types.AttributeValueMemberS)
 		require.True(t, ok)
 		require.NotEqual(t, seedUpdatedAt, updatedAt.Value)
+	})
+
+	t.Run("created_at-only update errors before DynamoDB", func(t *testing.T) {
+		const pk = "USER#legacy-created-at-only"
+		seed(t, pk, 0)
+
+		tx := transaction.NewTransaction(sess, registry, pkgTypes.NewConverter())
+		err := tx.Update(&legacyTransactionCreatedAtOnlyRecord{
+			PK: pk,
+			SK: "PROFILE",
+		})
+		require.EqualError(t, err, "no non-key fields to update",
+			"the legacy surface must reject the empty update before queuing a DynamoDB request")
+
+		item := load(t, pk)
+		value, ok := item["value"].(*types.AttributeValueMemberS)
+		require.True(t, ok)
+		require.Equal(t, "original", value.Value,
+			"the rejected update must leave the DynamoDB Local item unchanged")
 	})
 
 	t.Run("versioned update has no overlapping paths", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject caller-set `created_at` and `updated_at` in legacy Go `Transaction.Update(model)` with the same `ErrInvalidModel` lifecycle error contract as explicit `Builder.Update(model, fields)`
- align legacy implicit selection with the normative five-field exclusion (`pk`, `sk`, `created_at`, `updated_at`, `version`)
- keep version optimistic locking library-managed, so a versioned legacy update emits the version document path exactly once and increments it under the expected-version condition
- add discriminating expression and real DynamoDB Local coverage proving versioned updates execute and zero `created_at` does not clobber stored data

## Consumer impact

- repository sweep found no production, example, or documentation call site invoking legacy `Transaction.Update(model)`; call sites are confined to `pkg/transaction` tests
- one coverage-only test encoded the old caller-wins `updated_at` behavior and now asserts the aligned `ErrInvalidModel` result
- `docs/migration/v3.md`, `docs/features/lifecycle-timestamps.md`, and upgrading-style migration docs do not promise caller-wins behavior; current lifecycle guidance already says the runtime owns lifecycle fields
- no cross-runtime scenario was added because the shared driver routes `kind: update` through the explicit builder path; exercising this Go-only compatibility API would require a Go-specific driver action rather than a language-neutral scenario

## Validation

- `go build ./... && go vet ./... && go test ./...` — PASS (all packages; integration package PASS)
- focused lifecycle tests — PASS, including the three originally added tests, caller-set `created_at` parity, the corrected cov6 test, and the real DynamoDB Local execute test
- fixed expression probe: `SET #f0 = :v0, #ver = :newVer, #upd = :updTime`; resolved paths are exactly `value`, `version`, `updatedAt`
- pre-fix overlay at `0ca2ac307e0966534084d295ad9849b724586565` — expected FAIL for both unit and DynamoDB Local integration probes
- `make contract-tests` — `contract-tests: PASS`
- `make rubric` — `Status: PASS (pass=36 fail=0 blocked=0)` / `rubric: PASS`

Refs THE-2782
Fixes theory-cloud/TableTheory#454