### PR TITLE
docs(transaction): document legacy implicit update semantics

### DIFF
--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -63,6 +63,33 @@ err := db.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
 > `db.TransactionFunc(...)` compatibility helpers no longer exist; migrate to
 > the atomic `Transact()` surface.
 
+### Legacy one-argument `Transaction.Update(model)`
+
+The legacy `(*transaction.Transaction).Update(model)` path is a whole-model,
+implicit-selection surface. As of v3.0.1, its implicit candidate list excludes
+the five library-managed fields: `PK`, `SK`, `created_at`, `updated_at`, and
+`version`. It silently ignores caller-set lifecycle values: `created_at` is not
+assigned, and `updated_at` is assigned only by the library.
+
+Managed assignments are appended after implicit selection. An `updated_at`
+field always receives the library timestamp, and a non-zero `version` adds both
+an expected-version condition and the managed increment. A zero version adds
+neither. This differs from v3.0.0 and every v2.x release, where a non-empty
+caller-set `updated_at` was preserved instead of refreshed.
+
+When no caller field is selected and no managed assignment qualifies,
+`Update(model)` returns `no non-key fields to update` and does not queue a
+write. Earlier releases could commit an all-managed-field model by silently
+writing its caller-set `created_at`, which could clobber the stored creation
+timestamp. Account for both changes in deterministic-timestamp tests and
+backfills.
+
+The legacy implicit path does not reject caller-populated lifecycle fields;
+it ignores them. Rejection of `created_at`, `updated_at`, and version is limited
+to the explicit named-field transaction surfaces in Go, TypeScript, and Python.
+Use a deliberate caller-controlled low-level surface rather than the legacy
+whole-model path when a backfill must set a historical lifecycle value.
+
 Go model-based `Update(model, fields)` transactions reject explicit selection
 of the library-owned `created_at`, `updated_at`, and version fields with
 `ErrInvalidModel`. The transaction runtime remains the single writer of

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -56,6 +56,35 @@ TypeScript also
 marshals an `updateFn` action's key before invoking the callback, so a malformed
 key cannot run caller side effects before the key error is returned.
 
+### Go legacy implicit transaction updates in v3.0.1
+
+TableTheory v3.0.1 changes the legacy Go one-argument
+`(*transaction.Transaction).Update(model)` whole-model surface. This path
+selects fields implicitly; it is distinct from the explicit
+`TransactionBuilder.Update(model, fields)` surface described above.
+
+The implicit field selection excludes all five library-managed fields: `PK`,
+`SK`, `created_at`, `updated_at`, and `version`. Caller-set lifecycle values do
+not produce a validation error on this legacy surface; they are silently
+ignored. A caller-set `created_at` is excluded so the stored value is preserved,
+while a caller-set `updated_at` is overridden by the library timestamp.
+Lifecycle-field rejection remains limited to explicit named-field transaction
+updates in Go, TypeScript, and Python.
+
+This is a behavior change from v3.0.0 and every v2.x release, where a non-empty
+caller-set `updated_at` on the legacy one-argument path was preserved instead
+of refreshed. In v3.0.1 the library always writes its timestamp when the model
+declares an `updated_at` field. A non-zero `version` still adds the expected
+version condition and a managed increment; a zero version adds neither.
+
+If implicit selection and the qualifying managed assignments produce no
+assignment, `Update(model)` returns `no non-key fields to update` and queues no
+write. In earlier releases, an all-managed-field shape could instead commit by
+silently writing the caller's `created_at`, clobbering the stored creation
+timestamp. This change affects deterministic-timestamp tests and backfills:
+neither should depend on a caller-populated lifecycle value winning on the
+legacy whole-model path.
+
 The F6 JSON normalization parity fix changes the transactional wire encoding
 for Go `json`-tagged `[]byte` and `json.RawMessage` fields, whether encrypted or
 not: their DynamoDB attribute type changes from `B` to normalized JSON `S`.
@@ -118,6 +147,10 @@ types are unaffected. This is an intentional convergence with the query path.
 13. Audit Go model-shaped transaction updates for `json`-tagged `[]byte` and
     `json.RawMessage` fields, encrypted or not. Their wire type changes from `B`
     to normalized JSON `S`; existing reads remain tolerant of both encodings.
+14. Audit legacy Go one-argument `Transaction.Update(model)` callers,
+    especially deterministic-timestamp tests and backfills. Remove expectations
+    that caller-set `updated_at` is preserved, and handle
+    `no non-key fields to update` before committing the transaction.
 
 Legacy Go index-role tags such as `theorydb:"gsi:Name:pk"` and
 `theorydb:"gsi:Name:sk"` remain protected from update assignment. Exact token


### PR DESCRIPTION
## Summary

- document the v3.0.1 contract for legacy Go one-argument `Transaction.Update(model)`
- distinguish implicit lifecycle-field exclusion from explicit named-field rejection across runtimes
- call out managed assignment rules, the empty-update error, and deterministic-test/backfill impact

## Validation

- `bash scripts/verify-doc-integrity.sh` — PASS (`doc-integrity`, API reference, runtime docs site, and generative artifacts)
- `make rubric` — `Status: PASS (pass=36 fail=0 blocked=0)`

## Scope

Documentation only. No code, tests, version metadata, or release configuration changed.

Refs THE-2786
