### PR TITLE
fix(model): reject duplicate database attribute mappings

### DIFF
--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -63,6 +63,19 @@ Reads through `setJSONStringCarrierValue` / `attributeValueToJSONBytes` tolerate
 both encodings, so existing items remain readable. Other `json`-tagged carrier
 types are unaffected. This is an intentional convergence with the query path.
 
+### Duplicate database attribute mappings in v3.0.2
+
+As of v3.0.2, TableTheory rejects duplicate database attribute mappings when a
+model is parsed or registered. This includes Go struct embedding promotion
+shadowing where an outer tagged field and a promoted embedded tagged field map
+the same Go field name to the same DynamoDB attribute. Declaration order could
+otherwise make the persisted value and the field resolved for reads or updates
+diverge.
+
+If registration reports this error, give one field a distinct DynamoDB
+attribute tag (`theorydb:"attr:<name>"` in Go, or the runtime's database-name
+setting) or exclude one field with `theorydb:"-"` (or the runtime equivalent).
+
 ## Consumer migration
 
 1. For Go consumers, update `go.mod` and every TableTheory import:
@@ -118,6 +131,9 @@ types are unaffected. This is an intentional convergence with the query path.
 13. Audit Go model-shaped transaction updates for `json`-tagged `[]byte` and
     `json.RawMessage` fields, encrypted or not. Their wire type changes from `B`
     to normalized JSON `S`; existing reads remain tolerant of both encodings.
+14. Audit models for fields that map to the same DynamoDB attribute, including
+    tagged fields shadowed through Go struct embedding. Rename or exclude one
+    mapping before upgrading to v3.0.2.
 
 Legacy Go index-role tags such as `theorydb:"gsi:Name:pk"` and
 `theorydb:"gsi:Name:sk"` remain protected from update assignment. Exact token

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -68,13 +68,21 @@ types are unaffected. This is an intentional convergence with the query path.
 As of v3.0.2, TableTheory rejects duplicate database attribute mappings when a
 model is parsed or registered. This includes Go struct embedding promotion
 shadowing where an outer tagged field and a promoted embedded tagged field map
-the same Go field name to the same DynamoDB attribute. Declaration order could
-otherwise make the persisted value and the field resolved for reads or updates
-diverge.
+the same Go field name to the same DynamoDB attribute. Models accepted by
+v3.0.1 can therefore fail registration after upgrading. In the Go embedding
+shape, TableTheory may otherwise persist and read a different field than the
+one the consumer's Go code addresses.
 
-If registration reports this error, give one field a distinct DynamoDB
-attribute tag (`theorydb:"attr:<name>"` in Go, or the runtime's database-name
-setting) or exclude one field with `theorydb:"-"` (or the runtime equivalent).
+For duplicate DynamoDB attribute mappings on fields with different Go field
+names, give one field a distinct attribute tag (`theorydb:"attr:<name>"` in Go,
+or the runtime's database-name setting) or exclude one mapping.
+
+For same-name fields involving Go embedding, rename the **Go field name** on
+one declaration so both fields remain independently addressable and mapped.
+Alternatively, exclude the embedded field with `theorydb:"-"`; this requires
+editing the shared mixin or embedded struct, which may not be yours to edit.
+Renaming only the `dynamo` or `theorydb` attribute tag does **not** resolve this
+shadowing shape because TableTheory metadata is also keyed by Go field name.
 
 ## Consumer migration
 
@@ -132,8 +140,11 @@ setting) or exclude one field with `theorydb:"-"` (or the runtime equivalent).
     `json.RawMessage` fields, encrypted or not. Their wire type changes from `B`
     to normalized JSON `S`; existing reads remain tolerant of both encodings.
 14. Audit models for fields that map to the same DynamoDB attribute, including
-    tagged fields shadowed through Go struct embedding. Rename or exclude one
-    mapping before upgrading to v3.0.2.
+    same-name tagged fields involving Go struct embedding; previously accepted
+    models may now fail registration. For different Go field names, rename or
+    exclude one attribute mapping. For the Go embedding shape, rename one Go
+    field or exclude the embedded field; changing only its attribute tag does
+    not resolve the collision.
 
 Legacy Go index-role tags such as `theorydb:"gsi:Name:pk"` and
 `theorydb:"gsi:Name:sk"` remain protected from update assignment. Exact token

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -66,21 +66,25 @@ types are unaffected. This is an intentional convergence with the query path.
 ### Duplicate database attribute mappings in v3.0.2
 
 As of v3.0.2, TableTheory rejects duplicate database attribute mappings when a
-model is parsed or registered. This includes Go struct embedding promotion
-shadowing where an outer tagged field and a promoted embedded tagged field map
-the same Go field name to the same DynamoDB attribute. Models accepted by
-v3.0.1 can therefore fail registration after upgrading. In the Go embedding
-shape, TableTheory may otherwise persist and read a different field than the
-one the consumer's Go code addresses.
+model is parsed or registered. This includes Go struct embedding shapes where
+an outer tagged field shadows a promoted embedded tagged field, or two sibling
+mixins promote the same tagged Go field name at equal depth, with mappings to
+the same DynamoDB attribute. Models accepted by v3.0.1 can therefore fail
+registration after upgrading. In these Go embedding shapes, TableTheory may
+otherwise persist and read a different field than the one the consumer's Go
+code addresses.
 
 For duplicate DynamoDB attribute mappings on fields with different Go field
 names, give one field a distinct attribute tag (`theorydb:"attr:<name>"` in Go,
 or the runtime's database-name setting) or exclude one mapping.
 
 For same-name fields involving Go embedding, rename the **Go field name** on
-one declaration so both fields remain independently addressable and mapped.
-Alternatively, exclude the embedded field with `theorydb:"-"`; this requires
-editing the shared mixin or embedded struct, which may not be yours to edit.
+one declaration so both fields remain independently addressable. When the
+database attribute is derived from the Go field name, this also makes the
+attribute mappings distinct. When both declarations explicitly pin the same
+attribute, also give one field a distinct attribute tag or exclude one mapping.
+An embedded field can be excluded with `theorydb:"-"`; this requires editing
+the shared mixin or embedded struct, which may not be yours to edit.
 Renaming only the `dynamo` or `theorydb` attribute tag does **not** resolve this
 shadowing shape because TableTheory metadata is also keyed by Go field name.
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -54,7 +54,8 @@ var (
 
 	// ErrDuplicatePrimaryKey is returned when multiple primary keys are defined.
 	// It matches ErrInvalidModel via errors.Is because duplicate keys are invalid model shapes.
-	ErrDuplicatePrimaryKey = invalidModelSubtypeError("duplicate primary key definition")
+	// Its declared error type is part of the published API contract.
+	ErrDuplicatePrimaryKey error = invalidModelSubtypeError("duplicate primary key definition")
 
 	// ErrEmptyValue is returned when a required value is empty
 	ErrEmptyValue = errors.New("empty value")

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -52,8 +52,9 @@ var (
 	// ErrTableNotFound is returned when a table doesn't exist
 	ErrTableNotFound = errors.New("table not found")
 
-	// ErrDuplicatePrimaryKey is returned when multiple primary keys are defined
-	ErrDuplicatePrimaryKey = errors.New("duplicate primary key definition")
+	// ErrDuplicatePrimaryKey is returned when multiple primary keys are defined.
+	// It matches ErrInvalidModel via errors.Is because duplicate keys are invalid model shapes.
+	ErrDuplicatePrimaryKey = invalidModelSubtypeError("duplicate primary key definition")
 
 	// ErrEmptyValue is returned when a required value is empty
 	ErrEmptyValue = errors.New("empty value")
@@ -88,6 +89,16 @@ func (e conditionSubtypeError) Error() string {
 
 func (e conditionSubtypeError) Is(target error) bool {
 	return target == ErrConditionFailed
+}
+
+type invalidModelSubtypeError string
+
+func (e invalidModelSubtypeError) Error() string {
+	return string(e)
+}
+
+func (e invalidModelSubtypeError) Is(target error) bool {
+	return target == ErrInvalidModel
 }
 
 type transactionSubtypeError string

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -132,7 +132,10 @@ func TestErrorTaxonomySubtypeCompatibility(t *testing.T) {
 	require.ErrorIs(t, fmt.Errorf("wrapped: %w", ErrVersionConflict), ErrConditionFailed)
 	require.ErrorIs(t, ErrDuplicatePrimaryKey, ErrInvalidModel)
 	require.NotErrorIs(t, ErrInvalidModel, ErrDuplicatePrimaryKey)
-	require.ErrorIs(t, fmt.Errorf("wrapped: %w", ErrDuplicatePrimaryKey), ErrInvalidModel)
+	duplicatePrimaryKey := ErrDuplicatePrimaryKey
+	duplicatePrimaryKey = fmt.Errorf("wrapped: %w", duplicatePrimaryKey)
+	require.ErrorIs(t, duplicatePrimaryKey, ErrDuplicatePrimaryKey)
+	require.ErrorIs(t, duplicatePrimaryKey, ErrInvalidModel)
 	require.ErrorIs(t, ErrTransactionConflict, ErrTransactionFailed)
 	require.NotErrorIs(t, ErrTransactionFailed, ErrTransactionConflict)
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -130,6 +130,9 @@ func TestErrorTaxonomySubtypeCompatibility(t *testing.T) {
 	require.ErrorIs(t, ErrVersionConflict, ErrConditionFailed)
 	require.NotErrorIs(t, ErrConditionFailed, ErrVersionConflict)
 	require.ErrorIs(t, fmt.Errorf("wrapped: %w", ErrVersionConflict), ErrConditionFailed)
+	require.ErrorIs(t, ErrDuplicatePrimaryKey, ErrInvalidModel)
+	require.NotErrorIs(t, ErrInvalidModel, ErrDuplicatePrimaryKey)
+	require.ErrorIs(t, fmt.Errorf("wrapped: %w", ErrDuplicatePrimaryKey), ErrInvalidModel)
 	require.ErrorIs(t, ErrTransactionConflict, ErrTransactionFailed)
 	require.NotErrorIs(t, ErrTransactionFailed, ErrTransactionConflict)
 }

--- a/pkg/model/registry.go
+++ b/pkg/model/registry.go
@@ -439,9 +439,26 @@ func isEmbeddedStruct(field reflect.StructField) bool {
 
 func registerField(metadata *Metadata, fieldMeta *FieldMetadata) error {
 	if existing := metadata.FieldsByDBName[fieldMeta.DBName]; existing != nil {
+		cause := errors.ErrInvalidModel
+		if existing.IsPK || existing.IsSK || fieldMeta.IsPK || fieldMeta.IsSK {
+			cause = errors.ErrDuplicatePrimaryKey
+		}
+
+		// Go-only: Python dataclasses have no equivalent to embedded-field
+		// promotion, so only Go can produce this shadowing shape.
+		if existing.Name == fieldMeta.Name &&
+			(len(existing.IndexPath) > 1 || len(fieldMeta.IndexPath) > 1) {
+			return fmt.Errorf(
+				"%w: Go struct embedding promotion shadowing of tagged field %q mapped to database attribute %q is not supported; the persisted value and resolved field can diverge depending on declaration order",
+				cause,
+				fieldMeta.Name,
+				fieldMeta.DBName,
+			)
+		}
+
 		return fmt.Errorf(
 			"%w: duplicate database attribute name %q for fields %s and %s",
-			errors.ErrInvalidModel,
+			cause,
 			fieldMeta.DBName,
 			existing.Name,
 			fieldMeta.Name,

--- a/pkg/model/registry.go
+++ b/pkg/model/registry.go
@@ -409,7 +409,9 @@ func parseField(field reflect.StructField, indexPath []int, metadata *Metadata, 
 		}
 	}
 
-	registerField(metadata, fieldMeta)
+	if err := registerField(metadata, fieldMeta); err != nil {
+		return err
+	}
 
 	if err := applyKeyFields(metadata, fieldMeta); err != nil {
 		return err
@@ -435,9 +437,19 @@ func isEmbeddedStruct(field reflect.StructField) bool {
 	return field.Anonymous && field.Type.Kind() == reflect.Struct
 }
 
-func registerField(metadata *Metadata, fieldMeta *FieldMetadata) {
+func registerField(metadata *Metadata, fieldMeta *FieldMetadata) error {
+	if existing := metadata.FieldsByDBName[fieldMeta.DBName]; existing != nil {
+		return fmt.Errorf(
+			"%w: duplicate database attribute name %q for fields %s and %s",
+			errors.ErrInvalidModel,
+			fieldMeta.DBName,
+			existing.Name,
+			fieldMeta.Name,
+		)
+	}
 	metadata.Fields[fieldMeta.Name] = fieldMeta
 	metadata.FieldsByDBName[fieldMeta.DBName] = fieldMeta
+	return nil
 }
 
 func applyKeyFields(metadata *Metadata, fieldMeta *FieldMetadata) error {

--- a/pkg/model/registry.go
+++ b/pkg/model/registry.go
@@ -444,12 +444,13 @@ func registerField(metadata *Metadata, fieldMeta *FieldMetadata) error {
 			cause = errors.ErrDuplicatePrimaryKey
 		}
 
-		// Go-only: Python dataclasses have no equivalent to embedded-field
-		// promotion, so only Go can produce this shadowing shape.
+		// Go-only: Python dataclass inheritance collapses same-name fields
+		// deterministically by MRO. Go embedding leaves distinct tagged fields
+		// with the same Go name for TableTheory to resolve.
 		if existing.Name == fieldMeta.Name &&
 			(len(existing.IndexPath) > 1 || len(fieldMeta.IndexPath) > 1) {
 			return fmt.Errorf(
-				"%w: Go struct embedding promotion shadowing of tagged field %q mapped to database attribute %q is not supported; the persisted value and resolved field can diverge depending on declaration order",
+				"%w: duplicate tagged Go field name %q mapped to database attribute %q in a model with embedded structs is not supported; TableTheory may persist and read a different field than the consumer's Go code addresses",
 				cause,
 				fieldMeta.Name,
 				fieldMeta.DBName,

--- a/pkg/model/registry_test.go
+++ b/pkg/model/registry_test.go
@@ -298,12 +298,37 @@ func TestRegisterDuplicatePrimaryKey(t *testing.T) {
 		ID1 string `theorydb:"pk"`
 		ID2 string `theorydb:"pk"`
 	}
+	type DynamORMDuplicatePKModel struct {
+		_ struct{} `theorydb:"naming:dynamorm"`
 
-	registry := model.NewRegistry()
+		ID1 string `theorydb:"pk"`
+		ID2 string `theorydb:"pk"`
+	}
+	type DynamORMDuplicateSKModel struct {
+		_ struct{} `theorydb:"naming:dynamorm"`
 
-	err := registry.Register(&DuplicatePKModel{})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate primary key")
+		PK  string `theorydb:"pk"`
+		SK1 string `theorydb:"sk"`
+		SK2 string `theorydb:"sk"`
+	}
+
+	tests := []struct {
+		model any
+		name  string
+	}{
+		{name: "distinct database attributes", model: &DuplicatePKModel{}},
+		{name: "DynamORM partition key alias", model: &DynamORMDuplicatePKModel{}},
+		{name: "DynamORM sort key alias", model: &DynamORMDuplicateSKModel{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := model.NewRegistry()
+			err := registry.Register(test.model)
+			require.ErrorIs(t, err, theorydbErrors.ErrDuplicatePrimaryKey)
+			require.NotErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+		})
+	}
 }
 
 func TestRegisterRejectsDuplicateDBNameMappings(t *testing.T) {
@@ -334,11 +359,35 @@ func TestRegisterRejectsDuplicateDBNameMappings(t *testing.T) {
 			registry := model.NewRegistry()
 			err := registry.Register(test.model)
 			require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+			require.NotErrorIs(t, err, theorydbErrors.ErrDuplicatePrimaryKey)
 			require.ErrorContains(t, err, `duplicate database attribute name "shared"`)
 			require.ErrorContains(t, err, "First")
 			require.ErrorContains(t, err, "Second")
 		})
 	}
+}
+
+func TestRegisterRejectsEmbeddedTaggedFieldShadowing(t *testing.T) {
+	type EmbeddedFields struct {
+		Name string `theorydb:"attr:name" json:"name"`
+	}
+	type EmbeddedShadowing struct {
+		PK   string `theorydb:"pk,attr:PK" json:"PK"`
+		Name string `theorydb:"attr:name" json:"name"`
+		EmbeddedFields
+	}
+
+	registry := model.NewRegistry()
+	err := registry.Register(&EmbeddedShadowing{})
+	require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+	require.NotErrorIs(t, err, theorydbErrors.ErrDuplicatePrimaryKey)
+	require.ErrorContains(
+		t,
+		err,
+		`Go struct embedding promotion shadowing of tagged field "Name" mapped to database attribute "name" is not supported`,
+	)
+	require.ErrorContains(t, err, "persisted value and resolved field can diverge depending on declaration order")
+	require.NotContains(t, err.Error(), "fields Name and Name")
 }
 
 func TestRegisterModelWithIndexModifiers(t *testing.T) {

--- a/pkg/model/registry_test.go
+++ b/pkg/model/registry_test.go
@@ -306,6 +306,41 @@ func TestRegisterDuplicatePrimaryKey(t *testing.T) {
 	assert.Contains(t, err.Error(), "duplicate primary key")
 }
 
+func TestRegisterRejectsDuplicateDBNameMappings(t *testing.T) {
+	type DirectCollision struct {
+		PK     string `theorydb:"pk,attr:PK" json:"PK"`
+		First  string `theorydb:"attr:shared" json:"first"`
+		Second string `theorydb:"attr:shared" json:"second"`
+	}
+	type EmbeddedFields struct {
+		First string `theorydb:"attr:shared" json:"first"`
+	}
+	type EmbeddedCollision struct {
+		EmbeddedFields
+		PK     string `theorydb:"pk,attr:PK" json:"PK"`
+		Second string `theorydb:"attr:shared" json:"second"`
+	}
+
+	tests := []struct {
+		model any
+		name  string
+	}{
+		{name: "direct fields", model: &DirectCollision{}},
+		{name: "embedded field", model: &EmbeddedCollision{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := model.NewRegistry()
+			err := registry.Register(test.model)
+			require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+			require.ErrorContains(t, err, `duplicate database attribute name "shared"`)
+			require.ErrorContains(t, err, "First")
+			require.ErrorContains(t, err, "Second")
+		})
+	}
+}
+
 func TestRegisterModelWithIndexModifiers(t *testing.T) {
 	type IndexModifierModel struct {
 		PK     string `theorydb:"pk,attr:PK"`

--- a/pkg/model/registry_test.go
+++ b/pkg/model/registry_test.go
@@ -326,7 +326,7 @@ func TestRegisterDuplicatePrimaryKey(t *testing.T) {
 			registry := model.NewRegistry()
 			err := registry.Register(test.model)
 			require.ErrorIs(t, err, theorydbErrors.ErrDuplicatePrimaryKey)
-			require.NotErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+			require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
 		})
 	}
 }
@@ -371,23 +371,41 @@ func TestRegisterRejectsEmbeddedTaggedFieldShadowing(t *testing.T) {
 	type EmbeddedFields struct {
 		Name string `theorydb:"attr:name" json:"name"`
 	}
+	type OtherEmbeddedFields struct {
+		Name string `theorydb:"attr:name" json:"name"`
+	}
 	type EmbeddedShadowing struct {
 		PK   string `theorydb:"pk,attr:PK" json:"PK"`
 		Name string `theorydb:"attr:name" json:"name"`
 		EmbeddedFields
 	}
+	type AmbiguousEmbedding struct {
+		PK string `theorydb:"pk,attr:PK" json:"PK"`
+		EmbeddedFields
+		OtherEmbeddedFields
+	}
 
-	registry := model.NewRegistry()
-	err := registry.Register(&EmbeddedShadowing{})
-	require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
-	require.NotErrorIs(t, err, theorydbErrors.ErrDuplicatePrimaryKey)
-	require.ErrorContains(
-		t,
-		err,
-		`Go struct embedding promotion shadowing of tagged field "Name" mapped to database attribute "name" is not supported`,
-	)
-	require.ErrorContains(t, err, "persisted value and resolved field can diverge depending on declaration order")
-	require.NotContains(t, err.Error(), "fields Name and Name")
+	for _, test := range []struct {
+		name  string
+		model any
+	}{
+		{name: "outer field shadows embedded field", model: &EmbeddedShadowing{}},
+		{name: "two embedded fields are ambiguous", model: &AmbiguousEmbedding{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			registry := model.NewRegistry()
+			err := registry.Register(test.model)
+			require.ErrorIs(t, err, theorydbErrors.ErrInvalidModel)
+			require.NotErrorIs(t, err, theorydbErrors.ErrDuplicatePrimaryKey)
+			require.ErrorContains(
+				t,
+				err,
+				`duplicate tagged Go field name "Name" mapped to database attribute "name" in a model with embedded structs is not supported`,
+			)
+			require.ErrorContains(t, err, "TableTheory may persist and read a different field than the consumer's Go code addresses")
+			require.NotContains(t, err.Error(), "fields Name and Name")
+		})
+	}
 }
 
 func TestRegisterModelWithIndexModifiers(t *testing.T) {

--- a/pkg/model/registry_test.go
+++ b/pkg/model/registry_test.go
@@ -372,7 +372,7 @@ func TestRegisterRejectsEmbeddedTaggedFieldShadowing(t *testing.T) {
 		Name string `theorydb:"attr:name" json:"name"`
 	}
 	type OtherEmbeddedFields struct {
-		Name string `theorydb:"attr:name" json:"name"`
+		Name string `theorydb:"attr:name" json:"other_name"`
 	}
 	type EmbeddedShadowing struct {
 		PK   string `theorydb:"pk,attr:PK" json:"PK"`
@@ -386,8 +386,8 @@ func TestRegisterRejectsEmbeddedTaggedFieldShadowing(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name  string
 		model any
+		name  string
 	}{
 		{name: "outer field shadows embedded field", model: &EmbeddedShadowing{}},
 		{name: "two embedded fields are ambiguous", model: &AmbiguousEmbedding{}},

--- a/py/src/tabletheory_py/model.py
+++ b/py/src/tabletheory_py/model.py
@@ -256,6 +256,7 @@ class ModelDefinition[T]:
             annotations = cast(dict[str, Any], getattr(model_type, "__annotations__", {}))
 
         attributes: dict[str, AttributeDefinition] = {}
+        attribute_names: dict[str, str] = {}
         pk_fields: list[str] = []
         sk_fields: list[str] = []
 
@@ -281,6 +282,12 @@ class ModelDefinition[T]:
 
             converter = cast(AttributeConverter | None, opts.get("converter"))
             attribute_name = cast(str, opts.get("name", dc_field.name))
+            if previous_field := attribute_names.get(attribute_name):
+                raise ModelDefinitionError(
+                    f"duplicate database attribute name {attribute_name!r} "
+                    f"for fields {previous_field} and {dc_field.name}"
+                )
+            attribute_names[attribute_name] = dc_field.name
             set_flag = bool(opts.get("set", False))
             json_flag = bool(opts.get("json", False))
             binary_flag = bool(opts.get("binary", False))

--- a/py/src/tabletheory_py/model.py
+++ b/py/src/tabletheory_py/model.py
@@ -283,6 +283,8 @@ class ModelDefinition[T]:
             converter = cast(AttributeConverter | None, opts.get("converter"))
             attribute_name = cast(str, opts.get("name", dc_field.name))
             if previous_field := attribute_names.get(attribute_name):
+                # Python has no distinct duplicate-primary-key exception sentinel;
+                # all model-shape failures use ModelDefinitionError.
                 raise ModelDefinitionError(
                     f"duplicate database attribute name {attribute_name!r} "
                     f"for fields {previous_field} and {dc_field.name}"

--- a/py/tests/unit/test_model_definition.py
+++ b/py/tests/unit/test_model_definition.py
@@ -86,6 +86,20 @@ def test_model_definition_rejects_multiple_pk() -> None:
         ModelDefinition.from_dataclass(Bad)
 
 
+def test_model_definition_rejects_duplicate_database_attribute_names() -> None:
+    @dataclass(frozen=True)
+    class Collision:
+        pk: str = theorydb_field(name="PK", roles=["pk"])
+        first: str = theorydb_field(name="shared", default="")
+        second: str = theorydb_field(name="shared", default="")
+
+    with pytest.raises(
+        ModelDefinitionError,
+        match="duplicate database attribute name 'shared' for fields first and second",
+    ):
+        ModelDefinition.from_dataclass(Collision)
+
+
 def test_model_definition_rejects_encrypted_key() -> None:
     @dataclass(frozen=True)
     class Bad:


### PR DESCRIPTION
## Summary

- reject direct and embedded Go fields that resolve to the same DynamoDB attribute name during registry parsing
- return a clear error wrapping `ErrInvalidModel` before metadata maps or update expressions can become ambiguous
- add the equivalent Python direct-model guard; TypeScript already rejects duplicate DMS attributes

This is split from the transaction follow-up wave because duplicate model-name validation is a distinct registry/model-definition defect class from optimistic-lock and transaction-state semantics.

## Conclusion

F-2 is reproducible on staging: `registerField` silently overwrites `FieldsByDBName`, while `Fields` retains both fields, allowing marshal/update paths to alias the same DynamoDB attribute. Direct and embedded collision probes both register successfully on staging. The fix fails registration/parse time in Go and Python; TypeScript already rejects duplicate schema attributes.

## Validation

- `go build ./... && go vet ./... && go test ./...` — exit 0
- focused Go: `TestRegisterRejectsDuplicateDBNameMappings` — PASS (direct + embedded)
- focused Python: `test_model_definition_rejects_duplicate_database_attribute_names` — PASS
- staging overlay, Go focused test — expected failure, exit 1: `Expected error with "invalid model" in chain but got nil`
- staging-source overlay, Python focused test — expected failure, exit 1: `Failed: DID NOT RAISE ModelDefinitionError`
- `bash scripts/verify-contract-tests.sh` — `contract-tests: PASS`, exit 0
- `make rubric` — `Status: PASS (pass=36 fail=0 blocked=0)`, `rubric: PASS`, exit 0

Refs THE-2784
