### PR TITLE
fix(transaction): lock zero versions and poison failed updates

### DIFF
--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -72,6 +72,42 @@ document paths. `UpdateWithBuilder` remains a caller-controlled low-level
 surface. The model-based path does not increment version or add a version
 condition; use `UpdateWithBuilder` for optimistic locking in a transaction.
 
+### Legacy one-argument `Transaction.Update(model)`
+
+The legacy `(*transaction.Transaction).Update(model)` path is a whole-model,
+implicit-selection surface. As of v3.0.1, its implicit candidate list excludes
+the five library-managed fields: `PK`, `SK`, `created_at`, `updated_at`, and
+`version`. It silently ignores caller-set lifecycle values: `created_at` is not
+assigned, and `updated_at` is assigned only by the library.
+
+Managed assignments are appended after implicit selection. An `updated_at`
+field always receives the library timestamp. This differs from v3.0.0 and every
+v2.x release, where a non-empty caller-set `updated_at` was preserved instead
+of refreshed. Separately, v3.0.1 fixed an overlapping-document-path
+`ValidationException` that broke versioned legacy `Update(model)` calls in
+v3.0.0 and v2.x.
+
+A non-zero `version` adds both an expected-version condition and the managed
+increment; the corrected legacy path also adds both when the version is zero.
+This closes a legacy-only parity defect: v3.0.1 skipped locking and incrementing
+zero while the explicit Go query path and the TypeScript and Python runtimes
+already locked zero, as documented in
+[Optimistic Locking](optimistic-locking.md#update-is-not-an-upsert). This is a
+behavior change from v3.0.1 for zero-version legacy updates.
+
+When no caller field is selected and no managed assignment qualifies,
+`Update(model)` returns `no non-key fields to update` and does not queue a
+write. Earlier releases could commit an all-managed-field model by silently
+writing its caller-set `created_at`, which could clobber the stored creation
+timestamp. Account for both changes in deterministic-timestamp tests and
+backfills.
+
+The legacy implicit path does not reject caller-populated lifecycle fields;
+it ignores them. Rejection of `created_at`, `updated_at`, and version is limited
+to the explicit named-field transaction surfaces in Go, TypeScript, and Python.
+Use a deliberate caller-controlled low-level surface rather than the legacy
+whole-model path when a backfill must set a historical lifecycle value.
+
 ## TypeScript
 
 `TheorydbClient.transactWrite(actions: TransactAction[])` accepts a list of

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -95,6 +95,11 @@ TypeScript and Python runtimes already locked zero, as documented in
 [Optimistic Locking](optimistic-locking.md#update-is-not-an-upsert). This is a
 behavior change from v3.0.1 for zero-version legacy updates.
 
+Deletes retain their established behavior: the legacy transactional
+`Transaction.Delete(model)` surface and the explicit query `Delete()` surface
+attach an optimistic-lock condition only when the model version is non-zero.
+A key-only delete of a versioned model is therefore unconditioned by design.
+
 When no caller field is selected and no managed assignment qualifies,
 `Update(model)` returns `no non-key fields to update` and does not queue a
 write. Earlier releases could commit an all-managed-field model by silently

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -13,6 +13,7 @@ This page documents TableTheory's public write-transaction surfaces, which use t
 - **Condition evaluation** is server-side: each write item carries its own conditional expression, and a single failed condition aborts the whole transaction.
 - **Optimistic-lock composition**: a versioned item in the group asserts its expected version; a version mismatch aborts the transaction atomically.
 - **Encryption composition**: encrypted fields are encrypted before the transaction is submitted; a KMS failure aborts before any write hits DynamoDB.
+- **Rejected-update atomicity**: an update-construction error prevents the service call, so already queued writes are not partially committed. The legacy Go `Transaction.Update` path stores its first error for `Commit` to return; `Rollback` clears it.
 - **Marshaling parity**: transaction puts preserve non-nil empty lists and maps, including inside nested Go structs, unless the field explicitly uses `omitempty`.
 - **Cross-runtime parity**: a write transaction submitted from Python sees the same atomicity guarantees as one submitted from Go.
 

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -13,7 +13,7 @@ This page documents TableTheory's public write-transaction surfaces, which use t
 - **Condition evaluation** is server-side: each write item carries its own conditional expression, and a single failed condition aborts the whole transaction.
 - **Optimistic-lock composition**: a versioned item in the group asserts its expected version; a version mismatch aborts the transaction atomically.
 - **Encryption composition**: encrypted fields are encrypted before the transaction is submitted; a KMS failure aborts before any write hits DynamoDB.
-- **Rejected-update atomicity**: an update-construction error prevents the service call, so already queued writes are not partially committed. The legacy Go `Transaction.Update` path stores its first error for `Commit` to return; `Rollback` clears it.
+- **Rejected-write atomicity**: a write-construction error prevents the service call, so already queued writes are not partially committed. The legacy Go `Transaction` stores the first `Create`, `Update`, or `Delete` error for `Commit` to return; `Rollback` clears it.
 - **Marshaling parity**: transaction puts preserve non-nil empty lists and maps, including inside nested Go structs, unless the field explicitly uses `omitempty`.
 - **Cross-runtime parity**: a write transaction submitted from Python sees the same atomicity guarantees as one submitted from Go.
 
@@ -88,10 +88,10 @@ of refreshed. Separately, v3.0.1 fixed an overlapping-document-path
 v3.0.0 and v2.x.
 
 A non-zero `version` adds both an expected-version condition and the managed
-increment; the corrected legacy path also adds both when the version is zero.
-This closes a legacy-only parity defect: v3.0.1 skipped locking and incrementing
-zero while the explicit Go query path and the TypeScript and Python runtimes
-already locked zero, as documented in
+increment. As of v3.0.2, the corrected legacy path also adds both when the
+version is zero. This closes a legacy-only parity defect: v3.0.1 skipped
+locking and incrementing zero while the explicit Go query path and the
+TypeScript and Python runtimes already locked zero, as documented in
 [Optimistic Locking](optimistic-locking.md#update-is-not-an-upsert). This is a
 behavior change from v3.0.1 for zero-version legacy updates.
 
@@ -105,8 +105,9 @@ backfills.
 The legacy implicit path does not reject caller-populated lifecycle fields;
 it ignores them. Rejection of `created_at`, `updated_at`, and version is limited
 to the explicit named-field transaction surfaces in Go, TypeScript, and Python.
-Use a deliberate caller-controlled low-level surface rather than the legacy
-whole-model path when a backfill must set a historical lifecycle value.
+Use the deliberate caller-controlled `UpdateWithBuilder` low-level surface
+rather than the legacy whole-model path when a backfill must set a historical
+lifecycle value.
 
 ## TypeScript
 

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -82,14 +82,22 @@ This is a behavior change from v3.0.0 and every v2.x release, where a non-empty
 caller-set `updated_at` on the legacy one-argument path was preserved instead
 of refreshed. In v3.0.1 the library always writes its timestamp when the model
 declares an `updated_at` field. A non-zero `version` still adds the expected
-version condition and a managed increment; the corrected legacy path also adds
-both when the version is zero. This closes a legacy-only parity defect: v3.0.1
-skipped locking and incrementing zero while the explicit Go query path and the
-TypeScript and Python runtimes already locked zero, as documented in
+version condition and a managed increment. As of v3.0.2, the corrected legacy
+path also adds both when the version is zero. This closes a legacy-only parity
+defect: v3.0.1 skipped locking and incrementing zero while the explicit Go
+query path and the TypeScript and Python runtimes already locked zero, as documented in
 [Optimistic Locking](../features/optimistic-locking.md#update-is-not-an-upsert).
-This is a behavior change from v3.0.1 for zero-version legacy updates.
+This changes the v3.0.1 zero-version behavior: an update against a missing or
+mismatched item no longer upserts it. Its version condition fails and aborts
+every other write in the transaction group. Call `Rollback`, then use an
+explicit create when the item is absent.
 Separately, v3.0.1 fixed an overlapping-document-path `ValidationException`
 that broke versioned legacy `Update(model)` calls in v3.0.0 and v2.x.
+
+Also as of v3.0.2, an ignored legacy `Create`, `Update`, or `Delete`
+construction error poisons the transaction. `Commit` returns the stored first
+error and submits no queued writes. Call `Rollback` before reusing that
+transaction for another operation.
 
 If implicit selection and the qualifying managed assignments produce no
 assignment, `Update(model)` returns `no non-key fields to update` and queues no
@@ -156,8 +164,13 @@ legacy whole-model path.
     to normalized JSON `S`; existing reads remain tolerant of both encodings.
 14. Audit legacy Go one-argument `Transaction.Update(model)` callers,
     especially deterministic-timestamp tests and backfills. Remove expectations
-    that caller-set `updated_at` is preserved, and handle
-    `no non-key fields to update` before committing the transaction.
+    that caller-set `updated_at` is preserved. A zero-version update no longer
+    upserts a missing or mismatched item: its failed condition aborts the whole
+    transaction group, so call `Rollback` and issue an explicit create when the
+    item is absent. Handle every `Create`, `Update`, or `Delete` construction
+    error rather than ignoring it; the first error poisons the transaction,
+    `Commit` returns it without submitting any queued write, and `Rollback` is
+    required before the transaction can be reused.
 
 Legacy Go index-role tags such as `theorydb:"gsi:Name:pk"` and
 `theorydb:"gsi:Name:sk"` remain protected from update assignment. Exact token

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -91,6 +91,10 @@ This changes the v3.0.1 zero-version behavior: an update against a missing or
 mismatched item no longer upserts it. Its version condition fails and aborts
 every other write in the transaction group. Call `Rollback`, then use an
 explicit create when the item is absent.
+Deletes retain their established behavior: the legacy transactional
+`Transaction.Delete(model)` surface and the explicit query `Delete()` surface
+attach an optimistic-lock condition only when the model version is non-zero.
+A key-only delete of a versioned model is therefore unconditioned by design.
 Separately, v3.0.1 fixed an overlapping-document-path `ValidationException`
 that broke versioned legacy `Update(model)` calls in v3.0.0 and v2.x.
 

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -63,6 +63,42 @@ Reads through `setJSONStringCarrierValue` / `attributeValueToJSONBytes` tolerate
 both encodings, so existing items remain readable. Other `json`-tagged carrier
 types are unaffected. This is an intentional convergence with the query path.
 
+### Go legacy implicit transaction updates after v3.0.0
+
+TableTheory v3.0.1 changes the legacy Go one-argument
+`(*transaction.Transaction).Update(model)` whole-model surface. This path
+selects fields implicitly; it is distinct from the explicit
+`TransactionBuilder.Update(model, fields)` surface described above.
+
+The implicit field selection excludes all five library-managed fields: `PK`,
+`SK`, `created_at`, `updated_at`, and `version`. Caller-set lifecycle values do
+not produce a validation error on this legacy surface; they are silently
+ignored. A caller-set `created_at` is excluded so the stored value is preserved,
+while a caller-set `updated_at` is overridden by the library timestamp.
+Lifecycle-field rejection remains limited to explicit named-field transaction
+updates in Go, TypeScript, and Python.
+
+This is a behavior change from v3.0.0 and every v2.x release, where a non-empty
+caller-set `updated_at` on the legacy one-argument path was preserved instead
+of refreshed. In v3.0.1 the library always writes its timestamp when the model
+declares an `updated_at` field. A non-zero `version` still adds the expected
+version condition and a managed increment; the corrected legacy path also adds
+both when the version is zero. This closes a legacy-only parity defect: v3.0.1
+skipped locking and incrementing zero while the explicit Go query path and the
+TypeScript and Python runtimes already locked zero, as documented in
+[Optimistic Locking](../features/optimistic-locking.md#update-is-not-an-upsert).
+This is a behavior change from v3.0.1 for zero-version legacy updates.
+Separately, v3.0.1 fixed an overlapping-document-path `ValidationException`
+that broke versioned legacy `Update(model)` calls in v3.0.0 and v2.x.
+
+If implicit selection and the qualifying managed assignments produce no
+assignment, `Update(model)` returns `no non-key fields to update` and queues no
+write. In earlier releases, an all-managed-field shape could instead commit by
+silently writing the caller's `created_at`, clobbering the stored creation
+timestamp. This change affects deterministic-timestamp tests and backfills:
+neither should depend on a caller-populated lifecycle value winning on the
+legacy whole-model path.
+
 ## Consumer migration
 
 1. For Go consumers, update `go.mod` and every TableTheory import:
@@ -118,6 +154,10 @@ types are unaffected. This is an intentional convergence with the query path.
 13. Audit Go model-shaped transaction updates for `json`-tagged `[]byte` and
     `json.RawMessage` fields, encrypted or not. Their wire type changes from `B`
     to normalized JSON `S`; existing reads remain tolerant of both encodings.
+14. Audit legacy Go one-argument `Transaction.Update(model)` callers,
+    especially deterministic-timestamp tests and backfills. Remove expectations
+    that caller-set `updated_at` is preserved, and handle
+    `no non-key fields to update` before committing the transaction.
 
 Legacy Go index-role tags such as `theorydb:"gsi:Name:pk"` and
 `theorydb:"gsi:Name:sk"` remain protected from update assignment. Exact token

--- a/internal/reflectutil/version.go
+++ b/internal/reflectutil/version.go
@@ -1,0 +1,24 @@
+package reflectutil
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const maxInt64AsUint64 = ^uint64(0) >> 1
+
+// VersionNumber returns a supported signed or unsigned version value as int64.
+func VersionNumber(v reflect.Value) (int64, error) {
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		u := v.Uint()
+		if u > maxInt64AsUint64 {
+			return 0, fmt.Errorf("version value overflows int64")
+		}
+		return int64(u), nil
+	default:
+		return 0, fmt.Errorf("unsupported version kind: %s", v.Kind())
+	}
+}

--- a/pkg/marshal/version.go
+++ b/pkg/marshal/version.go
@@ -1,23 +1,13 @@
 package marshal
 
 import (
-	"fmt"
 	"reflect"
+
+	"github.com/theory-cloud/tabletheory/v3/internal/reflectutil"
 )
 
 const maxInt64AsUint64 = ^uint64(0) >> 1
 
 func versionNumberFromValue(v reflect.Value) (int64, error) {
-	switch v.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int(), nil
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		u := v.Uint()
-		if u > maxInt64AsUint64 {
-			return 0, fmt.Errorf("version value overflows int64")
-		}
-		return int64(u), nil
-	default:
-		return 0, fmt.Errorf("unsupported version kind: %s", v.Kind())
-	}
+	return reflectutil.VersionNumber(v)
 }

--- a/pkg/query/query_execution.go
+++ b/pkg/query/query_execution.go
@@ -399,7 +399,10 @@ func (q *Query) appendUpdatedAtAndVersionUpdates(builder *expr.Builder, modelVal
 	}
 
 	if q.rawMetadata.VersionField != nil {
-		current := modelValue.FieldByIndex(q.rawMetadata.VersionField.IndexPath).Int()
+		current, err := reflectutil.VersionNumber(modelValue.FieldByIndex(q.rawMetadata.VersionField.IndexPath))
+		if err != nil {
+			return fmt.Errorf("failed to read current version: %w", err)
+		}
 		if err := builder.AddConditionExpression(q.rawMetadata.VersionField.DBName, "=", current); err != nil {
 			return fmt.Errorf("failed to add version condition: %w", err)
 		}
@@ -553,7 +556,11 @@ func (q *Query) Delete() error {
 		if modelValue.Kind() == reflect.Struct {
 			versionValue := modelValue.FieldByIndex(q.rawMetadata.VersionField.IndexPath)
 			if !versionValue.IsZero() {
-				if err := builder.AddConditionExpression(q.rawMetadata.VersionField.DBName, "=", versionValue.Int()); err != nil {
+				current, err := reflectutil.VersionNumber(versionValue)
+				if err != nil {
+					return fmt.Errorf("failed to read current version: %w", err)
+				}
+				if err := builder.AddConditionExpression(q.rawMetadata.VersionField.DBName, "=", current); err != nil {
 					return fmt.Errorf("failed to add version condition: %w", err)
 				}
 			}

--- a/pkg/query/version_uint_test.go
+++ b/pkg/query/version_uint_test.go
@@ -1,0 +1,93 @@
+package query
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theory-cloud/tabletheory/v3/pkg/model"
+)
+
+type uintVersionQueryRecord struct {
+	PK      string `theorydb:"pk,attr:PK" json:"PK"`
+	SK      string `theorydb:"sk,attr:SK" json:"SK"`
+	Value   string `theorydb:"attr:value" json:"value"`
+	Version uint64 `theorydb:"version,attr:version" json:"version"`
+}
+
+func (uintVersionQueryRecord) TableName() string {
+	return "uint_version_query_records"
+}
+
+func TestQueryUpdateSupportsUint64Versions(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&uintVersionQueryRecord{}))
+	metadata, err := registry.GetMetadata(&uintVersionQueryRecord{})
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name    string
+		version uint64
+	}{
+		{name: "zero", version: 0},
+		{name: "non-zero", version: 7},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			executor := &writePolicyRecordingExecutor{}
+			q := New(&uintVersionQueryRecord{
+				PK:      "USER#uint-version",
+				SK:      "PROFILE",
+				Value:   "changed",
+				Version: test.version,
+			}, writePolicyQueryMetadata{meta: metadata}, executor)
+
+			require.NoError(t, q.Update("Value"))
+			require.NotNil(t, executor.compiled)
+			require.Contains(t, executor.compiled.ConditionExpression, versionNamePlaceholder(t, executor.compiled.ExpressionAttributeNames))
+			require.Contains(t, executor.compiled.UpdateExpression, versionNamePlaceholder(t, executor.compiled.ExpressionAttributeNames))
+			require.ElementsMatch(t, []string{fmt.Sprint(test.version), "1"}, numberAttributeValues(executor.compiled.ExpressionAttributeValues))
+		})
+	}
+}
+
+func TestQueryDeleteSupportsUint64Version(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&uintVersionQueryRecord{}))
+	metadata, err := registry.GetMetadata(&uintVersionQueryRecord{})
+	require.NoError(t, err)
+
+	executor := &writePolicyRecordingExecutor{}
+	q := New(&uintVersionQueryRecord{
+		PK:      "USER#uint-version-delete",
+		SK:      "PROFILE",
+		Version: 7,
+	}, writePolicyQueryMetadata{meta: metadata}, executor)
+
+	require.NoError(t, q.Delete())
+	require.NotNil(t, executor.compiled)
+	require.Contains(t, executor.compiled.ConditionExpression, versionNamePlaceholder(t, executor.compiled.ExpressionAttributeNames))
+	require.Equal(t, []string{"7"}, numberAttributeValues(executor.compiled.ExpressionAttributeValues))
+}
+
+func versionNamePlaceholder(t *testing.T, names map[string]string) string {
+	t.Helper()
+	for placeholder, name := range names {
+		if name == "version" {
+			return placeholder
+		}
+	}
+	require.FailNow(t, "version expression attribute name was not compiled")
+	return ""
+}
+
+func numberAttributeValues(values map[string]types.AttributeValue) []string {
+	numbers := make([]string, 0, len(values))
+	for _, value := range values {
+		if number, ok := value.(*types.AttributeValueMemberN); ok {
+			numbers = append(numbers, number.Value)
+		}
+	}
+	return numbers
+}

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -352,13 +352,18 @@ func (tx *Transaction) Delete(model any) (err error) {
 		}
 		versionValue := modelValue.Field(metadata.VersionField.Index)
 
-		if versionValue.IsValid() {
+		if versionValue.IsValid() && !versionValue.IsZero() {
+			currentVersion, err := reflectutil.VersionNumber(versionValue)
+			if err != nil {
+				return fmt.Errorf("failed to read current version: %w", err)
+			}
+
 			deleteItem.ConditionExpression = aws.String("#ver = :ver")
 			deleteItem.ExpressionAttributeNames = map[string]string{
 				"#ver": metadata.VersionField.DBName,
 			}
 
-			av, err := tx.converter.ToAttributeValue(versionValue.Interface())
+			av, err := tx.converter.ToAttributeValue(currentVersion)
 			if err != nil {
 				return fmt.Errorf("failed to convert version for delete condition: %w", err)
 			}

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -29,6 +29,7 @@ type Transaction struct {
 	session   *session.Session
 	registry  *model.Registry
 	converter *pkgTypes.Converter
+	err       error
 	results   map[string]map[string]types.AttributeValue
 	writes    []types.TransactWriteItem
 	reads     []types.TransactGetItem
@@ -86,7 +87,16 @@ func (tx *Transaction) Create(model any) error {
 }
 
 // Update adds an update operation to the transaction
-func (tx *Transaction) Update(model any) error {
+func (tx *Transaction) Update(model any) (err error) {
+	if tx.err != nil {
+		return tx.err
+	}
+	defer func() {
+		if err != nil && tx.err == nil {
+			tx.err = err
+		}
+	}()
+
 	metadata, err := tx.registry.GetMetadata(model)
 	if err != nil {
 		return fmt.Errorf("failed to get model metadata: %w", err)
@@ -246,7 +256,7 @@ func (tx *Transaction) applyVersionUpdate(
 	}
 
 	versionValue := modelValue.FieldByIndex(metadata.VersionField.IndexPath)
-	if !versionValue.IsValid() || versionValue.IsZero() {
+	if !versionValue.IsValid() {
 		return "", nil
 	}
 
@@ -377,6 +387,10 @@ func (tx *Transaction) Get(model any, dest any) error {
 
 // Commit executes the transaction
 func (tx *Transaction) Commit() error {
+	if tx.err != nil {
+		return tx.err
+	}
+
 	// Execute writes if any
 	if len(tx.writes) > 0 {
 		input := &dynamodb.TransactWriteItemsInput{
@@ -430,6 +444,7 @@ func (tx *Transaction) Rollback() error {
 	tx.writes = nil
 	tx.reads = nil
 	tx.results = nil
+	tx.err = nil
 	return nil
 }
 

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -55,7 +55,16 @@ func (tx *Transaction) WithContext(ctx context.Context) *Transaction {
 }
 
 // Create adds a create operation to the transaction
-func (tx *Transaction) Create(model any) error {
+func (tx *Transaction) Create(model any) (err error) {
+	if tx.err != nil {
+		return tx.err
+	}
+	defer func() {
+		if err != nil && tx.err == nil {
+			tx.err = err
+		}
+	}()
+
 	metadata, err := tx.registry.GetMetadata(model)
 	if err != nil {
 		return fmt.Errorf("failed to get model metadata: %w", err)
@@ -260,7 +269,10 @@ func (tx *Transaction) applyVersionUpdate(
 		return "", nil
 	}
 
-	currentVersion := versionValue.Int()
+	currentVersion, err := reflectutil.VersionNumber(versionValue)
+	if err != nil {
+		return "", fmt.Errorf("failed to read current version: %w", err)
+	}
 	conditionExpression := "#ver = :currentVer"
 	expressionAttributeNames["#ver"] = metadata.VersionField.DBName
 
@@ -302,7 +314,16 @@ func (tx *Transaction) applyUpdatedAtUpdate(
 }
 
 // Delete adds a delete operation to the transaction
-func (tx *Transaction) Delete(model any) error {
+func (tx *Transaction) Delete(model any) (err error) {
+	if tx.err != nil {
+		return tx.err
+	}
+	defer func() {
+		if err != nil && tx.err == nil {
+			tx.err = err
+		}
+	}()
+
 	metadata, err := tx.registry.GetMetadata(model)
 	if err != nil {
 		return fmt.Errorf("failed to get model metadata: %w", err)
@@ -331,7 +352,7 @@ func (tx *Transaction) Delete(model any) error {
 		}
 		versionValue := modelValue.Field(metadata.VersionField.Index)
 
-		if versionValue.IsValid() && !versionValue.IsZero() {
+		if versionValue.IsValid() {
 			deleteItem.ConditionExpression = aws.String("#ver = :ver")
 			deleteItem.ExpressionAttributeNames = map[string]string{
 				"#ver": metadata.VersionField.DBName,
@@ -443,7 +464,7 @@ func (tx *Transaction) Rollback() error {
 	// Clear any pending operations
 	tx.writes = nil
 	tx.reads = nil
-	tx.results = nil
+	tx.results = make(map[string]map[string]types.AttributeValue)
 	tx.err = nil
 	return nil
 }

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -186,8 +186,8 @@ func TestTransactionUpdateLegacySupportsUint64Versions(t *testing.T) {
 
 	for _, test := range []struct {
 		name       string
-		version    uint64
 		newVersion string
+		version    uint64
 	}{
 		{name: "zero", version: 0, newVersion: "1"},
 		{name: "non-zero", version: 7, newVersion: "8"},

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -147,6 +147,34 @@ func TestTransactionUpdateLegacyOverlapExpressionProbe(t *testing.T) {
 	require.Equal(t, "#ver = :currentVer", aws.ToString(update.ConditionExpression))
 }
 
+func TestTransactionUpdateLegacyLocksZeroVersion(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
+
+	tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+	require.NoError(t, tx.Update(&legacyTransactionalLifecycleRecord{
+		PK:      "USER#legacy-version-zero",
+		SK:      "PROFILE",
+		Value:   "changed",
+		Version: 0,
+	}))
+	require.Len(t, tx.writes, 1)
+
+	update := tx.writes[0].Update
+	require.NotNil(t, update)
+	require.Equal(t, "#ver = :currentVer", aws.ToString(update.ConditionExpression))
+	require.Contains(t, aws.ToString(update.UpdateExpression), "#ver = :newVer")
+	require.Equal(t, "0", numericAttributeValue(t, update.ExpressionAttributeValues[":currentVer"]))
+	require.Equal(t, "1", numericAttributeValue(t, update.ExpressionAttributeValues[":newVer"]))
+}
+
+func numericAttributeValue(t *testing.T, value dynamodbTypes.AttributeValue) string {
+	t.Helper()
+	number, ok := value.(*dynamodbTypes.AttributeValueMemberN)
+	require.True(t, ok)
+	return number.Value
+}
+
 func TestTransactionUpdateLegacyBuildsSetFromManagedOnlyAssignments(t *testing.T) {
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&legacyManagedOnlyVersionedRecord{}))
@@ -202,7 +230,8 @@ func TestTransactionUpdateLegacyOverridesCallerSetUpdatedAtForImplicitRMW(t *tes
 	update := legacy.writes[0].Update
 	require.NotNil(t, update)
 	expression := aws.ToString(update.UpdateExpression)
-	require.ElementsMatch(t, []string{"value", "updatedAt"}, updateDocumentPaths(expression, update.ExpressionAttributeNames))
+	require.ElementsMatch(t, []string{"value", "version", "updatedAt"},
+		updateDocumentPaths(expression, update.ExpressionAttributeNames))
 	updatedAt, ok := update.ExpressionAttributeValues[":updTime"].(*dynamodbTypes.AttributeValueMemberS)
 	require.True(t, ok)
 	require.NotEqual(t, callerUpdatedAt.Format(time.RFC3339Nano), updatedAt.Value,
@@ -228,7 +257,8 @@ func TestTransactionUpdateLegacyIgnoresCallerSetCreatedAtForImplicitRMW(t *testi
 	update := legacy.writes[0].Update
 	require.NotNil(t, update)
 	expression := aws.ToString(update.UpdateExpression)
-	require.ElementsMatch(t, []string{"value", "updatedAt"}, updateDocumentPaths(expression, update.ExpressionAttributeNames))
+	require.ElementsMatch(t, []string{"value", "version", "updatedAt"},
+		updateDocumentPaths(expression, update.ExpressionAttributeNames))
 	require.Zero(t, updatePathOccurrences(expression, update.ExpressionAttributeNames, "createdAt"),
 		"caller-supplied created_at must be excluded so the stored lifecycle value is preserved")
 }
@@ -251,12 +281,12 @@ func TestTransactionUpdateLegacyPreservesSparseSetSemanticsAndRefreshesUpdatedAt
 	require.Contains(t, expression, "SET")
 	require.NotContains(t, expression, "REMOVE",
 		"legacy implicit updates keep zero-valued omitempty fields unselected rather than removing them")
-	require.ElementsMatch(t, []string{"value", "updatedAt"}, attributeNames(update.ExpressionAttributeNames))
-	require.Len(t, update.ExpressionAttributeValues, 2)
+	require.ElementsMatch(t, []string{"value", "version", "updatedAt"}, attributeNames(update.ExpressionAttributeNames))
+	require.Len(t, update.ExpressionAttributeValues, 4)
 	require.Zero(t, updatePathOccurrences(expression, update.ExpressionAttributeNames, "createdAt"),
 		"a zero created_at must not overwrite the stored lifecycle timestamp")
-	require.Zero(t, updatePathOccurrences(expression, update.ExpressionAttributeNames, "version"),
-		"a zero version must not be selected by the implicit update")
+	require.Equal(t, 1, updatePathOccurrences(expression, update.ExpressionAttributeNames, "version"),
+		"the persisted zero version must be incremented by the implicit update")
 	require.Equal(t, 1, updatePathOccurrences(expression, update.ExpressionAttributeNames, "updatedAt"))
 }
 

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -119,6 +120,17 @@ func (legacyCreatedAtOnlyRecord) TableName() string {
 	return "legacy_created_at_only_records"
 }
 
+type legacyUintVersionedRecord struct {
+	PK      string `theorydb:"pk,attr:PK" json:"PK"`
+	SK      string `theorydb:"sk,attr:SK" json:"SK"`
+	Value   string `theorydb:"attr:value" json:"value"`
+	Version uint64 `theorydb:"version,attr:version" json:"version"`
+}
+
+func (legacyUintVersionedRecord) TableName() string {
+	return "legacy_uint_versioned_records"
+}
+
 func TestTransactionUpdateLegacyOverlapExpressionProbe(t *testing.T) {
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&legacyTransactionalLifecycleRecord{}))
@@ -166,6 +178,55 @@ func TestTransactionUpdateLegacyLocksZeroVersion(t *testing.T) {
 	require.Contains(t, aws.ToString(update.UpdateExpression), "#ver = :newVer")
 	require.Equal(t, "0", numericAttributeValue(t, update.ExpressionAttributeValues[":currentVer"]))
 	require.Equal(t, "1", numericAttributeValue(t, update.ExpressionAttributeValues[":newVer"]))
+}
+
+func TestTransactionUpdateLegacySupportsUint64Versions(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyUintVersionedRecord{}))
+
+	for _, test := range []struct {
+		name       string
+		version    uint64
+		newVersion string
+	}{
+		{name: "zero", version: 0, newVersion: "1"},
+		{name: "non-zero", version: 7, newVersion: "8"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+			require.NoError(t, tx.Update(&legacyUintVersionedRecord{
+				PK:      "USER#legacy-uint-version",
+				SK:      "PROFILE",
+				Value:   "changed",
+				Version: test.version,
+			}))
+			require.Len(t, tx.writes, 1)
+
+			update := tx.writes[0].Update
+			require.NotNil(t, update)
+			require.Equal(t, "#ver = :currentVer", aws.ToString(update.ConditionExpression))
+			require.Equal(t, fmt.Sprint(test.version), numericAttributeValue(t, update.ExpressionAttributeValues[":currentVer"]))
+			require.Equal(t, test.newVersion, numericAttributeValue(t, update.ExpressionAttributeValues[":newVer"]))
+		})
+	}
+}
+
+func TestTransactionDeleteLegacyLocksZeroVersion(t *testing.T) {
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&legacyUintVersionedRecord{}))
+
+	tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+	require.NoError(t, tx.Delete(&legacyUintVersionedRecord{
+		PK:      "USER#legacy-delete-version-zero",
+		SK:      "PROFILE",
+		Version: 0,
+	}))
+	require.Len(t, tx.writes, 1)
+
+	deleteItem := tx.writes[0].Delete
+	require.NotNil(t, deleteItem)
+	require.Equal(t, "#ver = :ver", aws.ToString(deleteItem.ConditionExpression))
+	require.Equal(t, "0", numericAttributeValue(t, deleteItem.ExpressionAttributeValues[":ver"]))
 }
 
 func numericAttributeValue(t *testing.T, value dynamodbTypes.AttributeValue) string {

--- a/pkg/transaction/transaction_lifecycle_parity_test.go
+++ b/pkg/transaction/transaction_lifecycle_parity_test.go
@@ -211,22 +211,53 @@ func TestTransactionUpdateLegacySupportsUint64Versions(t *testing.T) {
 	}
 }
 
-func TestTransactionDeleteLegacyLocksZeroVersion(t *testing.T) {
+func TestTransactionDeleteLegacyLocksOnlyNonZeroVersions(t *testing.T) {
 	registry := model.NewRegistry()
 	require.NoError(t, registry.Register(&legacyUintVersionedRecord{}))
 
-	tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
-	require.NoError(t, tx.Delete(&legacyUintVersionedRecord{
-		PK:      "USER#legacy-delete-version-zero",
-		SK:      "PROFILE",
-		Version: 0,
-	}))
-	require.Len(t, tx.writes, 1)
+	t.Run("zero is unconditioned", func(t *testing.T) {
+		tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+		require.NoError(t, tx.Delete(&legacyUintVersionedRecord{
+			PK:      "USER#legacy-delete-version-zero",
+			SK:      "PROFILE",
+			Version: 0,
+		}))
+		require.Len(t, tx.writes, 1)
 
-	deleteItem := tx.writes[0].Delete
-	require.NotNil(t, deleteItem)
-	require.Equal(t, "#ver = :ver", aws.ToString(deleteItem.ConditionExpression))
-	require.Equal(t, "0", numericAttributeValue(t, deleteItem.ExpressionAttributeValues[":ver"]))
+		deleteItem := tx.writes[0].Delete
+		require.NotNil(t, deleteItem)
+		// Match the explicit query Delete surface: zero means a key-only,
+		// intentionally unconditioned delete rather than a version-zero lock.
+		require.Nil(t, deleteItem.ConditionExpression)
+		require.Empty(t, deleteItem.ExpressionAttributeNames)
+		require.Empty(t, deleteItem.ExpressionAttributeValues)
+	})
+
+	t.Run("non-zero is conditioned", func(t *testing.T) {
+		tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+		require.NoError(t, tx.Delete(&legacyUintVersionedRecord{
+			PK:      "USER#legacy-delete-version-non-zero",
+			SK:      "PROFILE",
+			Version: 7,
+		}))
+		require.Len(t, tx.writes, 1)
+
+		deleteItem := tx.writes[0].Delete
+		require.NotNil(t, deleteItem)
+		require.Equal(t, "#ver = :ver", aws.ToString(deleteItem.ConditionExpression))
+		require.Equal(t, "7", numericAttributeValue(t, deleteItem.ExpressionAttributeValues[":ver"]))
+	})
+
+	t.Run("overflow is rejected", func(t *testing.T) {
+		tx := NewTransaction(&session.Session{}, registry, pkgTypes.NewConverter())
+		err := tx.Delete(&legacyUintVersionedRecord{
+			PK:      "USER#legacy-delete-version-overflow",
+			SK:      "PROFILE",
+			Version: ^uint64(0),
+		})
+		require.EqualError(t, err, "failed to read current version: version value overflows int64")
+		require.Empty(t, tx.writes, "an invalid version must not queue a delete")
+	})
 }
 
 func numericAttributeValue(t *testing.T, value dynamodbTypes.AttributeValue) string {

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -333,7 +333,8 @@ func TestTransactionRollback(t *testing.T) {
 		// Operations should be cleared
 		assert.Nil(t, tx.writes)
 		assert.Nil(t, tx.reads)
-		assert.Nil(t, tx.results)
+		assert.NotNil(t, tx.results)
+		assert.Empty(t, tx.results)
 	})
 }
 

--- a/pkg/transaction/transaction_unit_test.go
+++ b/pkg/transaction/transaction_unit_test.go
@@ -192,8 +192,8 @@ func TestTransaction_UpdateErrorPoisonsCommit(t *testing.T) {
 
 func TestTransaction_CreateAndDeleteErrorsPoisonCommit(t *testing.T) {
 	tests := []struct {
-		name      string
 		operation func(*Transaction) error
+		name      string
 	}{
 		{
 			name: "create",

--- a/pkg/transaction/transaction_unit_test.go
+++ b/pkg/transaction/transaction_unit_test.go
@@ -150,7 +150,8 @@ func TestTransaction_OperationsAndCommit(t *testing.T) {
 	require.NoError(t, tx.Rollback())
 	require.Nil(t, tx.writes)
 	require.Nil(t, tx.reads)
-	require.Nil(t, tx.results)
+	require.NotNil(t, tx.results)
+	require.Empty(t, tx.results)
 }
 
 func TestTransaction_UpdateErrorPoisonsCommit(t *testing.T) {
@@ -176,12 +177,100 @@ func TestTransaction_UpdateErrorPoisonsCommit(t *testing.T) {
 	require.NoError(t, tx.Create(&unitUser{ID: "queued-before-update-error"}))
 	updateErr := tx.Update(&unitCreatedAtOnly{ID: "rejected-update"})
 	require.EqualError(t, updateErr, "no non-key fields to update")
+	queuedBeforeRetry := len(tx.writes)
+	require.Same(t, updateErr, tx.Update(&unitUser{ID: "blocked-after-update-error", Email: "blocked@example.com"}))
+	require.Len(t, tx.writes, queuedBeforeRetry, "a poisoned transaction must not queue a second operation")
 
 	require.EqualError(t, tx.Commit(), "no non-key fields to update")
 	require.Zero(t, requestCount, "a poisoned transaction must not submit earlier queued writes")
 
 	require.NoError(t, tx.Rollback())
+	require.NoError(t, tx.Update(&unitUser{ID: "accepted-after-rollback", Email: "accepted@example.com"}))
 	require.NoError(t, tx.Commit(), "rollback must clear the stored transaction error")
+	require.Equal(t, 1, requestCount, "a post-rollback update must submit normally")
+}
+
+func TestTransaction_CreateAndDeleteErrorsPoisonCommit(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation func(*Transaction) error
+	}{
+		{
+			name: "create",
+			operation: func(tx *Transaction) error {
+				return tx.Create(&struct{ ID string }{ID: "not-registered"})
+			},
+		},
+		{
+			name: "delete",
+			operation: func(tx *Transaction) error {
+				return tx.Delete(&writePolicyTransactionEvent{PK: "release#svc", SK: "event#1"})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requestCount := 0
+			httpClient := stubHTTPClient{
+				responses: map[string]string{
+					"DynamoDB_20120810.TransactWriteItems": `{}`,
+				},
+				calls: &requestCount,
+			}
+
+			stubSessionConfigLoad(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+				return minimalAWSConfig(httpClient), nil
+			})
+
+			sess, err := session.NewSession(&session.Config{Region: "us-east-1"})
+			require.NoError(t, err)
+			registry := model.NewRegistry()
+			require.NoError(t, registry.Register(&unitUser{}))
+			require.NoError(t, registry.Register(&writePolicyTransactionEvent{}))
+
+			tx := NewTransaction(sess, registry, pkgTypes.NewConverter())
+			require.NoError(t, tx.Create(&unitUser{ID: "queued-before-write-error"}))
+			operationErr := test.operation(tx)
+			require.Error(t, operationErr)
+
+			require.Same(t, operationErr, tx.Commit(), "commit must return the stored first error")
+			require.Zero(t, requestCount, "a poisoned transaction must not submit earlier queued writes")
+		})
+	}
+}
+
+func TestTransaction_RollbackThenGetCommitReusesResultsMap(t *testing.T) {
+	requestCount := 0
+	httpClient := stubHTTPClient{
+		responses: map[string]string{
+			"DynamoDB_20120810.TransactGetItems": `{"Responses":[{"Item":{"id":{"S":"user-1"}}}]}`,
+		},
+		calls: &requestCount,
+	}
+
+	stubSessionConfigLoad(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return minimalAWSConfig(httpClient), nil
+	})
+
+	sess, err := session.NewSession(&session.Config{Region: "us-east-1"})
+	require.NoError(t, err)
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&unitUser{}))
+	require.NoError(t, registry.Register(&unitCreatedAtOnly{}))
+
+	tx := NewTransaction(sess, registry, pkgTypes.NewConverter())
+	require.EqualError(t, tx.Update(&unitCreatedAtOnly{ID: "poison-before-rollback"}), "no non-key fields to update")
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, tx.Get(&unitUser{ID: "user-1"}, &unitUser{}))
+
+	var commitErr error
+	require.NotPanics(t, func() {
+		commitErr = tx.Commit()
+	})
+	require.NoError(t, commitErr)
+	require.Equal(t, 1, requestCount)
+	require.Contains(t, tx.results, "0")
 }
 
 func TestTransaction_handleTransactionError(t *testing.T) {

--- a/pkg/transaction/transaction_unit_test.go
+++ b/pkg/transaction/transaction_unit_test.go
@@ -41,9 +41,13 @@ func stubSessionConfigLoad(t *testing.T, fn func(context.Context, ...func(*confi
 
 type stubHTTPClient struct {
 	responses map[string]string
+	calls     *int
 }
 
 func (c stubHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if c.calls != nil {
+		*c.calls++
+	}
 	target := req.Header.Get("X-Amz-Target")
 	if req.Body != nil {
 		if _, err := io.Copy(io.Discard, req.Body); err != nil {
@@ -87,6 +91,15 @@ type unitUser struct {
 	ID        string    `theorydb:"pk"`
 	Email     string
 	Version   int `theorydb:"version"`
+}
+
+type unitCreatedAtOnly struct {
+	CreatedAt time.Time `theorydb:"created_at,attr:createdAt" json:"createdAt"`
+	ID        string    `theorydb:"pk,attr:id" json:"id"`
+}
+
+func (unitCreatedAtOnly) TableName() string {
+	return "created_at_only_unit"
 }
 
 func (unitUser) TableName() string {
@@ -138,6 +151,37 @@ func TestTransaction_OperationsAndCommit(t *testing.T) {
 	require.Nil(t, tx.writes)
 	require.Nil(t, tx.reads)
 	require.Nil(t, tx.results)
+}
+
+func TestTransaction_UpdateErrorPoisonsCommit(t *testing.T) {
+	requestCount := 0
+	httpClient := stubHTTPClient{
+		responses: map[string]string{
+			"DynamoDB_20120810.TransactWriteItems": `{}`,
+		},
+		calls: &requestCount,
+	}
+
+	stubSessionConfigLoad(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return minimalAWSConfig(httpClient), nil
+	})
+
+	sess, err := session.NewSession(&session.Config{Region: "us-east-1"})
+	require.NoError(t, err)
+	registry := model.NewRegistry()
+	require.NoError(t, registry.Register(&unitUser{}))
+	require.NoError(t, registry.Register(&unitCreatedAtOnly{}))
+
+	tx := NewTransaction(sess, registry, pkgTypes.NewConverter())
+	require.NoError(t, tx.Create(&unitUser{ID: "queued-before-update-error"}))
+	updateErr := tx.Update(&unitCreatedAtOnly{ID: "rejected-update"})
+	require.EqualError(t, updateErr, "no non-key fields to update")
+
+	require.EqualError(t, tx.Commit(), "no non-key fields to update")
+	require.Zero(t, requestCount, "a poisoned transaction must not submit earlier queued writes")
+
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, tx.Commit(), "rollback must clear the stored transaction error")
 }
 
 func TestTransaction_handleTransactionError(t *testing.T) {

--- a/pkg/transaction/write_policy_test.go
+++ b/pkg/transaction/write_policy_test.go
@@ -162,10 +162,12 @@ func TestWritePolicyTransaction_EnforcesPolicies(t *testing.T) {
 	err := tx.Update(event)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, theorydbErrors.ErrImmutableModelMutation))
+	require.NoError(t, tx.Rollback())
 
 	err = tx.Delete(event)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, theorydbErrors.ErrImmutableModelMutation))
+	require.NoError(t, tx.Rollback())
 
 	actual := &writePolicyTransactionActual{
 		PK:              "release#svc",

--- a/tests/integration/transaction_legacy_update_test.go
+++ b/tests/integration/transaction_legacy_update_test.go
@@ -64,9 +64,7 @@ func TestLegacyTransactionUpdateExecutesWithoutLifecycleOverlap(t *testing.T) {
 			"value":     &types.AttributeValueMemberS{Value: "original"},
 			"createdAt": &types.AttributeValueMemberS{Value: seedCreatedAt},
 			"updatedAt": &types.AttributeValueMemberS{Value: seedUpdatedAt},
-		}
-		if version > 0 {
-			item["version"] = &types.AttributeValueMemberN{Value: strconv.Itoa(version)}
+			"version":   &types.AttributeValueMemberN{Value: strconv.Itoa(version)},
 		}
 		_, err := testCtx.DynamoDBClient.PutItem(context.Background(), &dynamodb.PutItemInput{
 			TableName: aws.String((legacyTransactionLifecycleRecord{}).TableName()),


### PR DESCRIPTION
## Summary

- treat `version == 0` as a real optimistic-lock value in legacy `Transaction.Update`, adding `version = 0` and incrementing to `1`
- poison the legacy transaction when `Update` fails so `Commit` returns the stored error without submitting earlier queued writes
- clear the stored error on `Rollback` and document rejected-update atomicity

THE-2784 was split to #469 because duplicate DBName validation is a distinct registry/model-definition defect class rather than transaction semantics.

## Conclusions

### F-1 / THE-2783

Zero-version locking is normative. `docs/features/optimistic-locking.md` defines zero as the persisted post-create version and says the first update must assert `version = 0`. Go's explicit query update path always conditions/increments zero; TypeScript rejects only missing/null/empty versions and its zero-version tests lock; Python uses `expected_version is not None`, so `expected_version=0` locks and increments. The legacy `applyVersionUpdate` early return was the divergence and is removed.

### F-2 / THE-2784

Reproducible, but split to #469. Go registry parsing silently overwrote `FieldsByDBName` for direct and embedded duplicate DBName mappings, while TypeScript already rejects duplicate attributes and Python direct models also lacked the guard. #469 adds parse-time Go/Python rejection.

### F-10 / THE-2792

Choose poisoning. The explicit Go `Builder` stores its first scheduling error and `Execute` returns before any send. TypeScript and Python build all actions before their single `TransactWriteItems` call, so an update-construction error sends nothing. Legacy `Transaction.Update` now stores its first error; ignored errors cause `Commit` to return that error and make zero DynamoDB requests. `Rollback` clears the poison.

## Validation

- `go build ./... && go vet ./... && go test ./...` — exit 0
- focused verbose tests — PASS:
  - `TestTransactionUpdateLegacyLocksZeroVersion`
  - `TestTransaction_UpdateErrorPoisonsCommit`
- staging overlay, zero-version test — expected failure, exit 1: expected `#ver = :currentVer`, actual empty condition
- staging overlay, poison test — expected failure, exit 1: `An error is expected but got nil`
- `bash scripts/verify-contract-tests.sh` — `contract-tests: PASS`, exit 0
- `make rubric` — `Status: PASS (pass=36 fail=0 blocked=0)`, `rubric: PASS`, exit 0

Refs THE-2783
Refs THE-2784 (split implementation: #469)
Refs THE-2792
