### PR TITLE
chore(governance): enforce materialization hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ Thumbs.db
 .codex/
 .claude/
 .agents/
+.theorymcp/
 .mcp.json
 GEMINI.md
 

--- a/gov-infra/planning/theorydb-supply-chain-allowlist.txt
+++ b/gov-infra/planning/theorydb-supply-chain-allowlist.txt
@@ -12,3 +12,6 @@
 #
 # Examples (copy exact IDs from the failing scanner output):
 # GOV-SUPPLY:GO:REPLACE:rule=REMOTE_REPLACE:from=github.com/example/upstream@v1.2.3:to=github.com/example/fork@v1.2.3
+
+# New advisory; no fixed aws-cdk release available; operator-authorized exception 2026-08-03 pending upstream fix.
+NPM-AUDIT:examples/cdk-multilang:brace-expansion:GHSA-rgw5-rvv9-x895:node_modules/aws-cdk-lib/node_modules/brace-expansion

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -552,6 +552,32 @@ check_maintainability_roadmap() {
   return 0
 }
 
+check_branch_profile_consistency() {
+  local failures=0
+
+  local materialized_surface
+  for materialized_surface in \
+    ".codex/steward.md" \
+    ".codex/theorymcp/" \
+    ".theorymcp/"; do
+    if git -C "${REPO_ROOT}" ls-files --error-unmatch -- "${materialized_surface}" >/dev/null 2>&1; then
+      echo "FAIL: TheoryCloud materialization must not be tracked: ${materialized_surface}"
+      failures=$((failures + 1))
+    fi
+    if ! git -C "${REPO_ROOT}" check-ignore -q -- "${materialized_surface}"; then
+      echo "FAIL: TheoryCloud materialization must be covered by .gitignore: ${materialized_surface}"
+      failures=$((failures + 1))
+    fi
+  done
+
+  if [[ "${failures}" -ne 0 ]]; then
+    return 1
+  fi
+
+  echo "Branch/profile consistency: PASS (TheoryCloud materialization hygiene)"
+  return 0
+}
+
 check_gov_doc_integrity() {
   # DOC-4: doc integrity for gov-infra only.
   # Checks:
@@ -664,7 +690,7 @@ CMD_TOOLCHAIN="bash scripts/verify-ci-toolchain.sh"
 CMD_PLANNING_DOCS="bash scripts/verify-planning-docs.sh"
 CMD_LINT_CONFIG="golangci-lint config verify -c .golangci-v2.yml"
 CMD_COV_THRESHOLD="bash scripts/verify-coverage.sh --check-threshold-config"
-CMD_CI_RUBRIC="bash scripts/verify-ci-rubric-enforced.sh"
+CMD_CI_RUBRIC="bash scripts/verify-ci-rubric-enforced.sh && check_branch_profile_consistency"
 CMD_DYNAMODB_PIN="bash scripts/verify-dynamodb-local-pin.sh"
 CMD_BRANCH_RELEASE="bash scripts/verify-branch-release-supply-chain.sh && bash scripts/verify-branch-version-sync.sh && bash scripts/verify-release-cycle-state.sh"
 


### PR DESCRIPTION
## Intent

Keep Theory Cloud agent materialization out of version control and add the operator-authorized exception for the new brace-expansion advisory that has no fixed aws-cdk release.

## Scope

- ignore `.theorymcp/` alongside the existing materialized-agent paths
- fail closed in COM-6 when the known materialization surfaces are tracked or unignored
- suppress exactly `GHSA-rgw5-rvv9-x895` for the affected aws-cdk-bundled `brace-expansion` instance, pending an upstream fix

## Verification

- `bash gov-infra/verifiers/gov-verify-rubric.sh`
  - `Status: PASS (pass=36 fail=0 blocked=0)`
