### PR TITLE
fix(release): accept first release candidate titles

### DIFF
--- a/scripts/test-release-hygiene-policy.sh
+++ b/scripts/test-release-hygiene-policy.sh
@@ -748,6 +748,28 @@ expect_failure_contains \
     --title "chore(premain): release 1.9.3-beta.1" \
     --dry-run
 
+watch_rc_title_regex='^chore\(premain\): release [0-9]+\.[0-9]+\.[0-9]+-rc(?:\.[0-9]+)?$'
+if [[ "$(grep -Fc -- '-rc(?:\\.[0-9]+)?$' "${repo_root}/scripts/watch-release-cycle.sh")" -ne 2 ]]; then
+  echo "release-hygiene-policy-test: watch-release-cycle must use first-or-numbered RC title matching"
+  exit 1
+fi
+
+for title in \
+  "chore(premain): release 3.0.4-rc" \
+  "chore(premain): release 3.0.4-rc.1"; do
+  jq -ne --arg title "${title}" --arg regex "${watch_rc_title_regex}" \
+    '$title | test($regex)' >/dev/null || {
+    echo "release-hygiene-policy-test: watch-release-cycle must accept RC title ${title}"
+    exit 1
+  }
+done
+
+if jq -ne --arg title "chore(premain): release 3.0.4-beta.1" --arg regex "${watch_rc_title_regex}" \
+  '$title | test($regex)' >/dev/null; then
+  echo "release-hygiene-policy-test: watch-release-cycle must reject non-RC prerelease titles"
+  exit 1
+fi
+
 pending_fixture="$(mktemp -d)"
 tmpdirs+=("${pending_fixture}")
 mkdir -p \

--- a/scripts/watch-release-cycle.sh
+++ b/scripts/watch-release-cycle.sh
@@ -280,7 +280,7 @@ if [[ "${skip_github}" -eq 0 ]] && command -v gh >/dev/null 2>&1 && gh auth stat
       --base premain \
       --state open \
       --json number,title,headRefName,url \
-      --jq '.[] | select(.headRefName == "release-please--branches--premain") | select((.title | test("^chore\\(premain\\): release [0-9]+\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+$")) | not) | "\(.number) \(.title) \(.url)"' \
+      --jq '.[] | select(.headRefName == "release-please--branches--premain") | select((.title | test("^chore\\(premain\\): release [0-9]+\\.[0-9]+\\.[0-9]+-rc(?:\\.[0-9]+)?$")) | not) | "\(.number) \(.title) \(.url)"' \
       2>/dev/null || true
   )"
   if [[ -n "${premain_bad_release_prs}" ]]; then
@@ -295,7 +295,7 @@ if [[ "${skip_github}" -eq 0 ]] && command -v gh >/dev/null 2>&1 && gh auth stat
       --base premain \
       --state open \
       --json number,title,headRefName,url \
-      --jq '.[] | select(.headRefName == "release-please--branches--premain") | select(.title | test("^chore\\(premain\\): release [0-9]+\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+$")) | "\(.number) \(.title) \(.url)"' \
+      --jq '.[] | select(.headRefName == "release-please--branches--premain") | select(.title | test("^chore\\(premain\\): release [0-9]+\\.[0-9]+\\.[0-9]+-rc(?:\\.[0-9]+)?$")) | "\(.number) \(.title) \(.url)"' \
       2>/dev/null || true
   )"
   if [[ -n "${premain_rc_prs}" ]]; then


### PR DESCRIPTION
## Intent

Restore the release-candidate automation proof after the strict release-cycle watcher rejected release-please's valid first-RC title form.

## Root cause

release-please correctly generates the first candidate as X.Y.Z-rc, while scripts/watch-release-cycle.sh only accepted numbered candidates such as X.Y.Z-rc.1. That made the strict pre-release watch fail against the correctly generated first RC.

## Changes

- accept both X.Y.Z-rc and X.Y.Z-rc.N in the strict watcher
- pin both valid forms and reject non-RC prerelease titles in the release-hygiene policy test
- preserve the automated staging → premain push-triggered path; no workflow dispatch is part of recovery

## Verification

- make rubric — PASS (36/36)
- bash scripts/test-release-hygiene-policy.sh — PASS
- bash scripts/test-release-verifier-policy.sh — PASS
- bash scripts/verify-branch-release-supply-chain.sh — PASS

## Contract impact

None. No Go, TypeScript, Python, DMS, persisted-data, or public API behavior changes.