### PR TITLE
fix(ci): make branch-release AGENTS.md assertions materialization-aware

### DIFF
--- a/scripts/verify-branch-release-supply-chain.sh
+++ b/scripts/verify-branch-release-supply-chain.sh
@@ -52,7 +52,6 @@ require_regex() {
 }
 
 required_files=(
-  "AGENTS.md"
   "docs/development/planning/theorydb-branch-release-policy.md"
   "docs/development/planning/theorydb-release-cycle-recovery-1.9.3.md"
   "docs/development/planning/templates/high-risk-branch-release-policy.template.md"
@@ -83,6 +82,15 @@ required_files=(
 for path in "${required_files[@]}"; do
   require_file "${path}"
 done
+
+# TACTICAL (replaced-by-wave): materialization fidelity, see factory docs/049
+# AGENTS.md is materialized content and may be untracked/gitignored, so a CI
+# checkout may legitimately not contain it. PASS when it exists on disk OR when
+# a gitignore rule covers it; FAIL only when neither holds (merge-order
+# independent with the untrack PR that introduces the .gitignore rule).
+if [[ ! -f "AGENTS.md" ]] && ! git check-ignore -q --no-index -- AGENTS.md 2>/dev/null; then
+  fail "missing AGENTS.md (materialized content absent and no gitignore rule covers it)"
+fi
 
 retired_files=(
   "scripts/prepare-stable-promotion.sh"
@@ -289,10 +297,17 @@ require_fixed "tag_name was used by an immutable release" \
 require_fixed "one-time-use" \
   "docs/development/planning/theorydb-branch-release-policy.md" \
   "branch release policy must name one-time-use immutable release versions"
-require_fixed "Do not manually recreate tags" "AGENTS.md" \
-  "AGENTS.md must prohibit manual tag recreation during release recovery"
-require_fixed "Release-As: 1.9.3-rc.1" "AGENTS.md" \
-  "AGENTS.md must document the THE-1869 1.9.3 recovery footer"
+# TACTICAL (replaced-by-wave): materialization fidelity, see factory docs/049
+# AGENTS.md may be absent in CI (materialized, untracked); gate the content
+# greps on file presence and do not count failures when it is absent.
+if [[ -f "AGENTS.md" ]]; then
+  require_fixed "Do not manually recreate tags" "AGENTS.md" \
+    "AGENTS.md must prohibit manual tag recreation during release recovery"
+  require_fixed "Release-As: 1.9.3-rc.1" "AGENTS.md" \
+    "AGENTS.md must document the THE-1869 1.9.3 recovery footer"
+else
+  echo "SKIP (replaced-by-wave): AGENTS.md materialized/absent in CI; content claims pending relocation to a tracked gov-infra surface"
+fi
 require_fixed "tag_name was used by an immutable release" \
   "docs/development/planning/templates/high-risk-branch-release-policy.template.md" \
   "high-risk branch policy template must include immutable release reuse recovery"


### PR DESCRIPTION
## Intent

Tactical, bounded COM-8 unblock. AGENTS.md is materialized content (operator policy, factory docs/049) and PR #516 untracks it, so a CI checkout legitimately lacks the file. The branch-release check in `scripts/verify-branch-release-supply-chain.sh` failed CI with `branch-release: missing AGENTS.md` plus grep errors on the two AGENTS.md content greps.

This is the narrow TACTICAL patch (`# TACTICAL (replaced-by-wave): materialization fidelity, see factory docs/049`); a GovTheory genome wave will replace these checks properly.

## Changes (`scripts/verify-branch-release-supply-chain.sh` only)

- Removed `AGENTS.md` from `required_files`. New materialization-fidelity assertion: PASS when AGENTS.md exists on disk OR a gitignore rule covers it (`git check-ignore -q --no-index`); FAIL only when neither holds. Merge-order independent with the untrack PR.
- Kept the two content greps (`Do not manually recreate tags`, `Release-As: 1.9.3-rc.1`) but gated on file presence; when absent the check prints `SKIP (replaced-by-wave): AGENTS.md materialized/absent in CI; content claims pending relocation to a tracked gov-infra surface` and counts no failure.
- No other check or assertion touched. No `gov-infra/evidence/` changes.

## Validation

`bash scripts/verify-branch-release-supply-chain.sh`:

- AGENTS.md present (current staging, tracked): `branch-release: PASS`, exit 0.
- AGENTS.md absent, no .gitignore rule: FAIL with the new single message + SKIP note (correct — neither condition holds).
- AGENTS.md absent + temporary bare `AGENTS.md` rule in .gitignore (simulated post-#516 CI): `branch-release: PASS`, exit 0, with the SKIP note. Simulation reverted; .gitignore is **not** changed by this PR.

Note: `.gitignore` on staging currently has no AGENTS.md rule — PR #516 brings it. Until then the tracked file satisfies the existence assertion, so either merge order is safe.

The two other AGENTS.md references in the script (retired-files grep target, two-release-lanes forbid grep) are fail-only greps that already tolerate an absent file and were left untouched per scope. No assertions for other materialized paths (GEMINI.md, .codex/, .agents/, .claude/) exist in this check.

## Risk

Low. Failure mode is preserved when neither file nor gitignore rule exists; content greps still enforce whenever the file is present.